### PR TITLE
TNO-165 Add DB migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,12 @@ setup: ## Setup local environment for development, generate configuration files.
 	@mkdir -p ./app/editor/node_modules
 	@mkdir -p ./app/subscriber/node_modules
 
+init: ## Initialize your local environment and start the core solution.
+	@echo "$(P) Initialize your local environment and start the core solution"
+	@make setup
+	@make up
+	@make db-update
+
 ##############################################################################
 # Docker Management
 ##############################################################################
@@ -163,7 +169,7 @@ npm-refresh: ## Removes and rebuilds node app containers, images, volumes.
 
 db-update: ## Run the flyway database migration update (requires maven to be installed).
 	@echo "$(P) Run the flyway database migration update"
-	@cd libs/java/dal/db; make db-update;
+	@./tools/scripts/db-update.sh
 
 db-refresh: ## Stop and delete the database container and volume, then rebuilds and starts.
 	@echo "$(P) Stop and delete the database container and volume, then rebuilds and starts"

--- a/db/kafka/docker-compose.yml
+++ b/db/kafka/docker-compose.yml
@@ -125,7 +125,7 @@ services:
   cat:
     image: tno:kafkacat
     profiles: ["kafka", "data"]
-    restart: on-failure:1
+    restart: "no"
     hostname: cat
     container_name: tno-kafkacat
     build:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -55,30 +55,21 @@ This can be helpful if your computer's performance is unable to support developm
 | [jdk](https://docs.oracle.com/en/java/javase/11/install/installation-jdk-microsoft-windows-platforms.html#GUID-A7E27B90-A28D-4237-9383-A58B416071CA) |       11 |                                                            |
 | [maven](http://maven.apache.org/install.html)                                                                                                        |    3.8.2 |                                                            |
 
-## Configure Environment
+## Standup Local Environment
 
 In order for the various components of the solution to work they require the appropriate configuration files to be created.
 You can auto generate them with the provided scripts.
 This process will generate `.env` files in the required locations so that the solution and docker containers can run.
 
 If you have installed `make` you can use the helper method.
+If you haven't installed `make` you can use the docker-compose cli.
+Review the `Makefile` and the related scripts `./tools/scripts` to understand how to do this.
+
+When using `make` commands you can review the options by using the following command.
 
 ```bash
-make setup
+make
 ```
-
-If you haven't installed `make` you can manually run the bash script.
-
-```bash
-./tools/scripts/gen-env-files.sh
-```
-
-## Standup Local Environment
-
-You now have everything installed and ready to be run locally.
-All that remains is to turn everything on.
-The first time you do this takes a little longer as each container needs to be built and initialized.
-After the docker containers are ready it becomes much quicker.
 
 The following containers are hosted in the TNO solution.
 The exposed container ports is configurable, but the defaults are identified below.
@@ -100,36 +91,20 @@ The exposed container ports is configurable, but the defaults are identified bel
 | connect         |               50014 | Kafka connect Control Center with Schema Registry                                             |
 | ksqldb-server   |               50016 | Kafka streaming services                                                                      |
 
-If you have installed `make` you can use the helper method.
+The first time you do this takes a little longer as each container needs to be built and initialized.
+After the docker containers are ready it becomes much quicker.
+Additionally, there are a number of configuration settings (usernames, passwords, keys, etc) that are created the first time you execute this script.
 
 ```bash
-make up
+# Configure your local environment.
+# Start all of the core and kafka containers.
+# Initialize the PostgreSQL database.
+# Initialize the Kafka cluster topics.
+# Initialize the Elasticsearch indexes.
+make init
 ```
 
-If you haven't installed `make` you can use the docker-compose cli.
-The following command merges multiple compose files, builds and runs all of the containers.
-The assumption for the rest of the documentation is that you have installed `make`.
-
-```bash
-docker-compose -f docker-compose.override.yml -f docker-compose.yml -f ./db/kafka/docker-compose.yml -d up
-```
-
-Once these containers are running you can then start up the other services.
-
-```bash
-make service-up
-```
-
-| Container  |  Port | Description                                                    |
-| ---------- | ----: | -------------------------------------------------------------- |
-| kafka kowl | 50017 | Kafka UI to view cluster                                       |
-| atom       |       | Kafka Producer to ingest syndication ATOM feeds                |
-| rss        |       | Kafka Producer to ingest syndication RSS feeds                 |
-| transcribe |       | Kafka Consumer/Producer to transcribe audio/video content      |
-| nlp        |       | Kafka Consumer/Producer to perform Natural Language Processing |
-| index      |       | Kafka Consumer to index content for search                     |
-
-Once everything is up and running you can now view the application in your browser.
+You can now view the application in your browser.
 Login into Keycloak with the username and password you configured in your `.env` file.
 You can then change the passwords for the default users to anything you would like.
 Then you can login to the web application with one of those default users.
@@ -140,10 +115,28 @@ Read more [here](../test/README.md).
 
 | Container        | URI                                                      |
 | ---------------- | -------------------------------------------------------- |
-| keycloak         | [http://localhost:50000/](http://localhost:50000)        |
 | app-editor       | [http://localhost:50080/app](http://localhost:50080/app) |
 | app-subscriber   | [http://localhost:50080](http://localhost:50080)         |
-| app-api          | [http://localhost:50080/api](http://localhost:50080/api) |
-| elastic          | [http://localhost:50007](http://localhost:50007)         |
-| kafka kowl       | [http://localhost:50017](http://localhost:50017)         |
+| api-editor       | [http://localhost:50080/api](http://localhost:50080/api) |
+| keycloak         | [http://localhost:50000/](http://localhost:50000)        |
 | kafka rest-proxy | [http://localhost:50018](http://localhost:50018)         |
+| kafka kowl       | [http://localhost:50017](http://localhost:50017)         |
+| elastic          | [http://localhost:50007](http://localhost:50007)         |
+
+Once the core and Kafka containers are running you can then start up the other services.
+
+```bash
+make service-up
+```
+
+Below is a list of all the additional services and utilities.
+
+| Container  |  Port | Description                                                    |
+| ---------- | ----: | -------------------------------------------------------------- |
+| kowl       | 50017 | Kafka UI to view cluster                                       |
+| dejavu     | 50009 | Elasticsearch UI to view cluster                               |
+| atom       |       | Kafka Producer to ingest syndication ATOM feeds                |
+| rss        |       | Kafka Producer to ingest syndication RSS feeds                 |
+| transcribe |       | Kafka Consumer/Producer to transcribe audio/video content      |
+| nlp        |       | Kafka Consumer/Producer to perform Natural Language Processing |
+| search     |       | Kafka Consumer to index content for search                     |

--- a/libs/java/dal/db/dal-db-migration/.dockerignore
+++ b/libs/java/dal/db/dal-db-migration/.dockerignore
@@ -1,0 +1,5 @@
+.gitignore
+Dockerfile
+/logs
+flyway.conf
+.env

--- a/libs/java/dal/db/dal-db-migration/Dockerfile
+++ b/libs/java/dal/db/dal-db-migration/Dockerfile
@@ -1,0 +1,19 @@
+FROM maven:3.6.3-openjdk-17 AS base
+
+WORKDIR /project
+COPY . .
+RUN mvn package
+
+FROM openjdk:17.0.1-slim AS final
+
+WORKDIR /app
+COPY --from=base /project/target .
+
+RUN apt-get update && apt-get install curl -y
+
+EXPOSE 8080
+
+ENTRYPOINT ["java","-jar","DbMigration.jar"]
+
+# ENTRYPOINT ["tail"]
+# CMD ["-f","/dev/null"]

--- a/libs/java/dal/db/dal-db-migration/README.md
+++ b/libs/java/dal/db/dal-db-migration/README.md
@@ -1,0 +1,11 @@
+# Flyway Database Migration
+
+Build and run the image that will run the flyway database migration.
+This will run the database migration for the current build.
+
+```bash
+# Build
+docker build -t tno:db-migration.
+# Run
+docker run -itd --env-file=.env tno:db-migration
+```

--- a/libs/java/dal/db/dal-db-migration/pom.xml
+++ b/libs/java/dal/db/dal-db-migration/pom.xml
@@ -36,10 +36,14 @@
     <java.version>17</java.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <auto.release>${auto.release:false}</auto.release>
   </properties>
 
   <repositories>
+    <repository>
+      <id>maven-snapshots</id>
+      <name>Maven Central Repository - Snapshots</name>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+    </repository>
     <repository>
       <id>maven-releases</id>
       <name>Maven Central Repository - Releases</name>
@@ -57,11 +61,17 @@
     </repository>
   </repositories>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.5.6</version>
+  </parent>
+
   <dependencies>
     <dependency>
       <groupId>ca.bc.gov.tno</groupId>
       <artifactId>dal-db</artifactId>
-      <version>LATEST</version>
+      <version>0.0.17-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -84,47 +94,13 @@
     </dependency>
   </dependencies>
 
-  <dependencyManagement>
-    <dependencies>
-    </dependencies>
-  </dependencyManagement>
-
   <build>
     <plugins>
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>2.5.6</version>
-      </plugin>
-      <plugin>
-        <groupId>org.flywaydb</groupId>
-        <artifactId>flyway-maven-plugin</artifactId>
-        <version>8.0.2</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <version>3.1.0</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <version>3.2.0</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.8.2</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-site-plugin</artifactId>
-        <version>3.9.1</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>3.2.0</version>
       </plugin>
     </plugins>
+    <finalName>DbMigration</finalName>
   </build>
 </project>

--- a/libs/java/dal/db/dal-db-migration/src/main/java/ca/bc/gov/tno/dal/db/MigrationApp.java
+++ b/libs/java/dal/db/dal-db-migration/src/main/java/ca/bc/gov/tno/dal/db/MigrationApp.java
@@ -1,0 +1,26 @@
+package ca.bc.gov.tno.dal.db;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@EnableJpaRepositories(basePackages = { "ca.bc.gov.tno.dal.db" })
+@EntityScan(basePackages = { "ca.bc.gov.tno.dal.db" })
+@SpringBootApplication(scanBasePackages = { "ca.bc.gov.tno.dal.db" })
+public class MigrationApp implements CommandLineRunner {
+
+  public static void main(String[] args) {
+    var app = new SpringApplication(MigrationApp.class);
+    app.setWebApplicationType(WebApplicationType.NONE);
+    app.run(args);
+    System.exit(0);
+  }
+
+  @Override
+  public void run(String... args) throws Exception {
+    System.out.println("TNO Database DAL Migration Tool");
+  }
+}

--- a/libs/java/dal/db/dal-db-migration/src/main/resources/application.yml
+++ b/libs/java/dal/db/dal-db-migration/src/main/resources/application.yml
@@ -1,0 +1,37 @@
+debug: false
+
+logging:
+  level:
+    org:
+      springframework:
+        context: DEBUG
+
+spring:
+  main:
+    banner-mode: 'off'
+
+  h2:
+    console:
+      enabled: false
+      
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://database:5432/tno}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  flyway:
+    enabled: ${DB_MIGRATION_ENABLED:true}
+    validate-on-migrate: ${DB_VALIDATE_MIGRATION:true}
+    schemas: public
+    baselineOnMigrate: true
+
+  jpa:
+    show-sql: ${JPA_SHOW_SQL:true}
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQL92Dialect
+        current_session_context_class: thread
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO:none}
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ClaimService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ClaimService.java
@@ -18,8 +18,18 @@ import ca.bc.gov.tno.dal.db.services.interfaces.IClaimService;
 @Service
 public class ClaimService implements IClaimService {
 
+  private final IClaimRepository repository;
+
+  /**
+   * Creates a new instance of a ClaimService object, initializes with specified
+   * parameters.
+   * 
+   * @param repository The claim repository.
+   */
   @Autowired
-  private IClaimRepository repository;
+  public ClaimService(final IClaimRepository repository) {
+    this.repository = repository;
+  }
 
   /**
    * Find all that match the criteria.

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ContentReferenceService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ContentReferenceService.java
@@ -19,8 +19,18 @@ import ca.bc.gov.tno.dal.db.services.interfaces.IContentReferenceService;
 @Service
 public class ContentReferenceService implements IContentReferenceService {
 
+  private final IContentReferenceRepository repository;
+
+  /**
+   * Creates a new instance of a ContentReferenceService object, initializes with
+   * specified parameters.
+   * 
+   * @param repository The content reference repository.
+   */
   @Autowired
-  private IContentReferenceRepository repository;
+  public ContentReferenceService(final IContentReferenceRepository repository) {
+    this.repository = repository;
+  }
 
   /**
    * Find all that match the criteria.

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/DataSourceService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/DataSourceService.java
@@ -18,11 +18,21 @@ import ca.bc.gov.tno.dal.db.services.interfaces.IDataSourceService;
  */
 @Service
 public class DataSourceService implements IDataSourceService {
-  @Autowired
-  private SessionFactory sessionFactory;
+  private final SessionFactory sessionFactory;
+  private final IDataSourceRepository repository;
 
+  /**
+   * Creates a new instance of a DataSourceService object, initializes with
+   * specified parameters.
+   * 
+   * @param repository     The data source repository.
+   * @param sessionFactory The session factory.
+   */
   @Autowired
-  private IDataSourceRepository repository;
+  public DataSourceService(final IDataSourceRepository repository, final SessionFactory sessionFactory) {
+    this.repository = repository;
+    this.sessionFactory = sessionFactory;
+  }
 
   /**
    * Find all that match the criteria.

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/DataSourceTypeService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/DataSourceTypeService.java
@@ -18,8 +18,18 @@ import ca.bc.gov.tno.dal.db.services.interfaces.IDataSourceTypeService;
 @Service
 public class DataSourceTypeService implements IDataSourceTypeService {
 
+  private final IDataSourceTypeRepository repository;
+
+  /**
+   * Creates a new instance of a DataSourceTypeService object, initializes with
+   * specified parameters.
+   * 
+   * @param repository The data source type repository.
+   */
   @Autowired
-  private IDataSourceTypeRepository repository;
+  public DataSourceTypeService(final IDataSourceTypeRepository repository) {
+    this.repository = repository;
+  }
 
   /**
    * Find all that match the criteria.

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/LicenseService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/LicenseService.java
@@ -18,8 +18,18 @@ import ca.bc.gov.tno.dal.db.services.interfaces.ILicenseService;
 @Service
 public class LicenseService implements ILicenseService {
 
-  @Autowired
   private ILicenseRepository repository;
+
+  /**
+   * Creates a new instance of a LicenseService object, initializes with specified
+   * parameters.
+   * 
+   * @param repository The license repository.
+   */
+  @Autowired
+  public LicenseService(final ILicenseRepository repository) {
+    this.repository = repository;
+  }
 
   /**
    * Find all that match the criteria.

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/RoleService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/RoleService.java
@@ -18,8 +18,18 @@ import ca.bc.gov.tno.dal.db.services.interfaces.IRoleService;
 @Service
 public class RoleService implements IRoleService {
 
-  @Autowired
   private IRoleRepository repository;
+
+  /**
+   * Creates a new instance of a RoleService object, initializes with specified
+   * parameters.
+   * 
+   * @param repository The role repository.
+   */
+  @Autowired
+  public RoleService(final IRoleRepository repository) {
+    this.repository = repository;
+  }
 
   /**
    * Find all that match the criteria.

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ScheduleService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ScheduleService.java
@@ -18,8 +18,18 @@ import ca.bc.gov.tno.dal.db.services.interfaces.IScheduleService;
 @Service
 public class ScheduleService implements IScheduleService {
 
-  @Autowired
   private IScheduleRepository repository;
+
+  /**
+   * Creates a new instance of a ScheduleService object, initializes with
+   * specified parameters.
+   * 
+   * @param repository The schedule repository.
+   */
+  @Autowired
+  public ScheduleService(final IScheduleRepository repository) {
+    this.repository = repository;
+  }
 
   /**
    * Find all that match the criteria.

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/UserService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/UserService.java
@@ -18,8 +18,18 @@ import ca.bc.gov.tno.dal.db.services.interfaces.IUserService;
 @Service
 public class UserService implements IUserService {
 
-  @Autowired
   private IUserRepository repository;
+
+  /**
+   * Creates a new instance of a UserService object, initializes with specified
+   * parameters.
+   * 
+   * @param repository The user repository.
+   */
+  @Autowired
+  public UserService(final IUserRepository repository) {
+    this.repository = repository;
+  }
 
   /**
    * Find all that match the criteria.

--- a/libs/java/dal/db/scripts/db-update.sh
+++ b/libs/java/dal/db/scripts/db-update.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 cd dal-db-migration
+mvn clean package
 mvn clean flyway:migrate -Dflyway.configFiles=flyway.conf

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -57,7 +57,7 @@ oc get pods -n ${project:-9b301c-dev}
 oc port-forward $podName ${localPort:-22222}:${containerPort:-5432}
 ```
 
-## Network Security Policies
+## Network Policies
 
 By default security is Zero Trust.
 Which means nothing can communicate.

--- a/openshift/templates/jobs/db/build.yaml
+++ b/openshift/templates/jobs/db/build.yaml
@@ -1,22 +1,22 @@
 kind: Template
 apiVersion: v1
 metadata:
-  name: postgres-build
+  name: java-flyway-build
   annotations:
-    openshift.io/display-name: PostgreSQL Database Server
-    description: The World's Most Advanced Open Source Relational Database.
-    tags: tno,database,postgres
+    openshift.io/display-name: Java flyway migration image
+    description: Build an image containing the Java flyway migration application.
+    tags: database,postgres,flyway,java
 parameters:
   - name: APP_NAME
-    displayName: "App Name"
-    description: "The name of the application (grouped)."
+    displayName: "Application Name"
+    description: "The name of the application."
     required: true
     value: "tno"
   - name: GROUP_NAME
     displayName: "Component Group Name"
     description: "The name of the application component (e.g api, app, database)."
     required: true
-    value: "database"
+    value: "db-migration"
   - name: PROJECT_NAMESPACE
     displayName: "OpenShift Project Namespace"
     description: "The namespace of the OpenShift project containing the application."
@@ -46,7 +46,7 @@ parameters:
   - name: CONTEXT_DIR
     displayName: "Context Directory"
     description: "Set this to use a subdirectory of the source code repository"
-    value: "db/postgres/rhel8"
+    value: "libs/java/dal/db/dal-db-migration"
 
   - name: OUTPUT_IMAGE_TAG
     displayName: "Output Image Tag"
@@ -63,7 +63,7 @@ parameters:
     displayName: "Memory Limit"
     description: "Maximum amount of memory the container can use."
     required: true
-    value: 250Mi
+    value: 500Mi
 objects:
   # The final build image.
   - kind: ImageStream
@@ -72,7 +72,7 @@ objects:
       name: ${APP_NAME}-${GROUP_NAME}
       namespace: ${PROJECT_NAMESPACE}-${ENV_NAME}
       annotations:
-        description: Keeps track of changes in the postgres database image
+        description: Keeps track of changes in the image
       labels:
         app: ${APP_NAME}
         role: ${GROUP_NAME}
@@ -84,7 +84,7 @@ objects:
       name: ${APP_NAME}-${GROUP_NAME}.${INSTANCE}
       namespace: ${PROJECT_NAMESPACE}-${ENV_NAME}
       annotations:
-        description: Defines how to build the postgres database image
+        description: Defines how to build the image
       labels:
         name: ${APP_NAME}-${GROUP_NAME}.${INSTANCE}
         app: ${APP_NAME}

--- a/openshift/templates/jobs/db/deploy.yaml
+++ b/openshift/templates/jobs/db/deploy.yaml
@@ -1,0 +1,127 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: postgres-db-migration
+  annotations:
+    description: Java flyway database migration for postgreSQL database
+    iconClass: icon-postgresql
+    openshift.io/display-name: Java flyway database migration for postgreSQL database
+    openshift.io/long-description: Java flyway database migration for postgreSQL database
+    tags: postgresql,database,flyway,migration
+
+parameters:
+  - name: APP_NAME
+    displayName: "Application Name"
+    description: "The name of the application."
+    required: true
+    value: "tno"
+  - name: GROUP_NAME
+    displayName: "Component Group Name"
+    description: "The name of the application component group"
+    required: true
+    value: "db-migration"
+  - name: PROJECT_NAMESPACE
+    displayName: "OpenShift Project Namespace"
+    description: "The namespace of the OpenShift project containing the application."
+    required: true
+    value: "9b301c"
+  - name: ENV_NAME
+    displayName: "Environment name"
+    description: "The name for this environment [dev, test, prod]"
+    required: true
+    value: "dev"
+  - name: INSTANCE
+    displayName: "Unique Identifier"
+    description: "A unique identifier to allow for multiple instances (i.e. '-dev')."
+    value: ""
+
+  - name: IMAGE_TAG
+    displayName: "Image Tag"
+    description: "The image tag that identifies which image to run. (i.e. 'dev')."
+    value: "dev"
+
+  - name: DB_SERVICE_NAME
+    displayName: Database Service Name
+    description: The database service name that will be used to communicate with the database.
+    required: true
+    value: "tno-database"
+  - name: DB_URL
+    displayName: Flyway URL
+    description: Flyway URL configuration setting.
+    required: true
+    value: jdbc:postgresql://tno-database:5432/tno
+  - name: DB_SCHEMAS
+    displayName: Flyway Schemas
+    description: Flyway schemas configuration setting.
+    required: true
+    value: "public"
+
+  - name: CPU_REQUEST
+    displayName: "Requested Minimum Resources CPU Limit"
+    description: "The requested minimum resources CPU limit (in cores) for this build."
+    required: true
+    value: 100m
+  - name: CPU_LIMIT
+    displayName: "Resources CPU Limit"
+    description: "The resources CPU limit (in cores) for this build."
+    required: true
+    value: 250m
+  - name: MEMORY_REQUEST
+    displayName: "Requested Minimum Memory Limit"
+    description: "Minimum requested amount of memory the container can use."
+    required: true
+    value: 50Mi
+  - name: MEMORY_LIMIT
+    displayName: "Memory Limit"
+    description: "Maximum amount of memory the container can use."
+    required: true
+    value: 250Mi
+
+objects:
+  # Job with container
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: ${APP_NAME}-${GROUP_NAME}${INSTANCE}-${IMAGE_TAG}
+      namespace: ${PROJECT_NAMESPACE}-${ENV_NAME}
+      labels:
+        name: ${APP_NAME}-${GROUP_NAME}${INSTANCE}
+        app: ${APP_NAME}
+        group: ${GROUP_NAME}
+    spec:
+      backoffLimit: 5
+      activeDeadlineSeconds: 100
+      template:
+        metadata:
+          name: ${APP_NAME}-${GROUP_NAME}${INSTANCE}
+          labels:
+            name: ${APP_NAME}-${GROUP_NAME}${INSTANCE}
+            app: ${APP_NAME}
+            role: ${GROUP_NAME}
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: ${APP_NAME}-${GROUP_NAME}
+              image: image-registry.openshift-image-registry.svc:5000/${PROJECT_NAMESPACE}-tools/${APP_NAME}-${GROUP_NAME}:${IMAGE_TAG}
+              env:
+                - name: DB_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${DB_SERVICE_NAME}
+                      key: PATRONI_SUPERUSER_USERNAME
+                - name: DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${DB_SERVICE_NAME}
+                      key: PATRONI_SUPERUSER_PASSWORD
+                - name: DB_URL
+                  value: ${DB_URL}
+                - name: DB_SCHEMAS
+                  value: ${DB_SCHEMAS}
+              resources:
+                limits:
+                  cpu: ${CPU_LIMIT}
+                  memory: ${MEMORY_LIMIT}
+                requests:
+                  cpu: ${CPU_REQUEST}
+                  memory: "${MEMORY_REQUEST}"

--- a/openshift/templates/postgres/singleton/03-deploy.yaml
+++ b/openshift/templates/postgres/singleton/03-deploy.yaml
@@ -87,7 +87,6 @@ objects:
         name: ${APP_NAME}-${GROUP_NAME}${INSTANCE}
         app: ${APP_NAME}
         role: ${GROUP_NAME}
-        env: ${ENV_NAME}
     spec:
       ports:
         - name: ${POSTGRESQL_PORT}-tcp
@@ -111,7 +110,6 @@ objects:
         name: ${APP_NAME}-${GROUP_NAME}${INSTANCE}
         app: ${APP_NAME}
         role: ${GROUP_NAME}
-        env: ${ENV_NAME}
     spec:
       strategy:
         type: Recreate
@@ -140,7 +138,6 @@ objects:
             name: ${APP_NAME}-${GROUP_NAME}${INSTANCE}
             app: ${APP_NAME}
             role: ${GROUP_NAME}
-            env: ${ENV_NAME}
         spec:
           volumes:
             - name: db-data

--- a/tools/scripts/db-update.sh
+++ b/tools/scripts/db-update.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd libs/java/dal/db
+docker build -t tno:db-migration dal-db-migration
+docker run -it --env-file=.env --name tno-db-migration tno:db-migration
+docker rm tno-db-migration

--- a/tools/scripts/gen-env-files.sh
+++ b/tools/scripts/gen-env-files.sh
@@ -14,7 +14,7 @@ else
     echo "Your keycloak username: $varKeycloak"
 fi
 
-varDbUser=$(grep -Po 'POSTGRES_USER=\K.*$' ./db/postgres/.env)
+varDbUser=$(grep -Po 'POSTGRES_USER=\K.*$' ./db/postgres/docker/.env)
 if [ -z "$varDbUser" ]
 then
     echo 'Enter a username for the database.'
@@ -32,7 +32,7 @@ else
     echo "Your Elasticsearch username: $varElastic"
 fi
 
-varAzureCognitiveServiceKey=$(grep -Po 'COGNITIVE_SERVICES_SPEECH_SUBSCRIPTION_KEY=\K.*$' ./api/editor/api-editor/src/main/resources/.env)
+varAzureCognitiveServiceKey=$(grep -Po 'COGNITIVE_SERVICES_SPEECH_SUBSCRIPTION_KEY=\K.*$' ./api/editor/.env)
 if [ -z "$varAzureCognitiveServiceKey" ]
 then
     echo 'Enter your Azure Cognitive Service subscription key.'
@@ -41,7 +41,7 @@ else
     echo "Your Azure Cognitive Service subscription key: $varAzureCognitiveServiceKey"
 fi
 
-varAzureCognitiveServiceRegion=$(grep -Po 'COGNITIVE_SERVICES_SPEECH_REGION=\K.*$' ./api/editor/api-editor/src/main/resources/.env)
+varAzureCognitiveServiceRegion=$(grep -Po 'COGNITIVE_SERVICES_SPEECH_REGION=\K.*$' ./api/editor/.env)
 if [ -z "$varAzureCognitiveServiceRegion" ]
 then
     echo 'Enter your Azure Cognitive Service region (i.e. canadacentral).'
@@ -50,7 +50,7 @@ else
     echo "Your Azure Cognitive Service region: $varAzureCognitiveServiceRegion"
 fi
 
-varAzureVideoAnalyzerKey=$(grep -Po 'AZURE_VIDEO_ANALYZER_SUBSCRIPTION_KEY=\K.*$' ./api/editor/api-editor/src/main/resources/.env)
+varAzureVideoAnalyzerKey=$(grep -Po 'AZURE_VIDEO_ANALYZER_SUBSCRIPTION_KEY=\K.*$' ./api/editor/.env)
 if [ -z "$varAzureVideoAnalyzerKey" ]
 then
     echo 'Enter your Azure Video Analyzer subscription key.'
@@ -59,7 +59,7 @@ else
     echo "Your Azure Video Analyzer subscription key: $varAzureVideoAnalyzerKey"
 fi
 
-varAzureVideoAccountId=$(grep -Po 'AZURE_VIDEO_ANALYZER_ACCOUNT_ID=\K.*$' ./api/editor/api-editor/src/main/resources/.env)
+varAzureVideoAccountId=$(grep -Po 'AZURE_VIDEO_ANALYZER_ACCOUNT_ID=\K.*$' ./api/editor/.env)
 if [ -z "$varAzureVideoAccountId" ]
 then
     echo 'Enter your Azure Video Analyzer account ID.'
@@ -68,7 +68,7 @@ else
     echo "Your Azure Video Analyzer account ID: $varAzureVideoAccountId"
 fi
 
-varAzureVideoLocation=$(grep -Po 'AZURE_VIDEO_ANALYZER_LOCATION=\K.*$' ./api/editor/api-editor/src/main/resources/.env)
+varAzureVideoLocation=$(grep -Po 'AZURE_VIDEO_ANALYZER_LOCATION=\K.*$' ./api/editor/.env)
 if [ -z "$varAzureVideoLocation" ]
 then
     echo 'Enter your Azure Video Analyzer location (i.e. trial).'
@@ -110,16 +110,30 @@ echo \
     echo "./.env created"
 fi
 
-# Database - PostgreSQL
-if test -f "./db/postgres/.env"; then
-    echo "./db/postgres/.env exists"
+# Database - PostgreSQL DockerHub Image
+if test -f "./db/postgres/docker/.env"; then
+    echo "./db/postgres/docker/.env exists"
 else
 echo \
 "POSTGRES_USER=$varDbUser
 POSTGRES_PASSWORD=$varPassword
 POSTGRES_DB=$varDbName
-KEYCLOAK_DB=keycloak" >> ./db/postgres/.env
-    echo "./db/postgres/.env created"
+KEYCLOAK_DB=keycloak" >> ./db/postgres/docker/.env
+    echo "./db/postgres/docker/.env created"
+fi
+
+# Database - PostgreSQL Redhat Image
+if test -f "./db/postgres/rhel8/.env"; then
+    echo "./db/postgres/rhel8/.env exists"
+else
+echo \
+"POSTGRESQL_USER=$varDbUser
+POSTGRESQL_PASSWORD=$varPassword
+POSTGRESQL_DATABASE=$varDbName
+KEYCLOAK_DATABASE=keycloak
+
+POSTGRESQL_ADMIN_PASSWORD=$varPassword" >> ./db/postgres/rhel8/.env
+    echo "./db/postgres/rhel8/.env created"
 fi
 
 # Database - DAL


### PR DESCRIPTION
To improve developer local environment setup, scripts have been updated and a `make db-update` command has been added.  Developers can now initialize their TNO database and run future migrations.

DevOps process isn't complete, but the same process can be applied within Openshift through building the `dal-db-migration` image and running it as a Job.  I will look into other CI/CD options to perform this.

There is a new `make init` command that will now perform initializing a new environment.

## Warning

A number of updates were made to `.env` file locations.  The `make setup` script will generate them, however it would be best to reset your environment entirely by deleting all of your containers and images and existing `.env` files.  This makes me think I may need to start providing migration scripts for this, but I really don't want to spend extra time on it presently.