### PR TITLE
nuke.sh updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/sh.exe.stackdump
 bash.exe.stackdump
 *.env
+*.bak
 .vs
 *.orig
 *.param

--- a/libs/npm/core/.prettierrc.bak
+++ b/libs/npm/core/.prettierrc.bak
@@ -1,8 +1,0 @@
-module.exports = {
-  semi: true,
-  trailingComma: 'all',
-  singleQuote: true,
-  printWidth: 100,
-  tabWidth: 2,
-  endOfLine: 'lf',
-};

--- a/tools/scripts/nuke.sh
+++ b/tools/scripts/nuke.sh
@@ -6,23 +6,45 @@ echo "Nuking local TNO environment and configuration"
 echo "*****************************************************"
 echo ""
 
-echo 'This operation will delete your configuration files!'
-echo 'It will first make backup copies by renaming them (i.e. backup.env)'
-read -p 'Enter "y" to continue: ' varContinue
+# Get a list of all files into an array. Make sure all name patterns are specified in "find" command.
+configFiles=()
+while IFS= read -r -d $'\0'; do
+    configFiles+=("$REPLY")
+done < <(find . -type f \( -name "*.env" -o -name "flyway.conf" -o -name "maven-settings.xml" \) -print0)
 
-if [ "$varContinue" == "y" ]; then
-  echo "Deleting backup configurations"
-  find . -type f -name '*backup.env' -exec rm {} +
-  find . -type f -name 'flyway.backup.conf' -exec rm {} +
-  find . -type f -name 'maven-settings.backup.xml' -exec rm {} +
+# Proceed only if there are files found matching the pattern, else do nothing.
+numFiles=${#configFiles[@]}
+if [[ $numFiles > 0 ]]; then
+  echo -e "$numFiles environment files found.\n"
 
-  echo "Creating backup configurations"
-  find . -type f -name ".env" -exec sh -c 'cp {} `dirname {}`/` {} .env`backup.env' \;
-  find . -type f -name "flyway.conf" -exec sh -c 'cp {} `dirname {}`/`basename {} .conf`.backup.conf' \;
-  find . -type f -name "maven-settings.xml" -exec sh -c 'cp {} `dirname {}`/`basename {} .xml`.backup.xml' \;
+  echo "This operation will delete your current configuration files!"
+  echo "It will first make backup copies by renaming them (i.e. .env.yyymmdd-HHMMSS.bak)"
+  read -p "Enter 'y' to continue: " varContinue
 
-  echo "Deleting original configurations"
-  find . -type f -name '.env' -exec rm {} +
-  find . -type f -name 'flyway.conf' -exec rm {} +
-  find . -type f -name 'maven-settings.xml' -exec rm {} +
+  if [ "$varContinue" == "y" ]; then
+    currentDT=$(date +"%y%m%d-%H%M%S")
+    
+    #Ask user if they want to delete all existing backups before moving current config files
+    echo -e "\nWould you like to delete any existing backup files before backing up the existing configuration?"
+    read -p "Enter 'd' to delete existing backups first. Any other key to keep them: " varDelete
+    if [ "$varDelete" == "d" ]; then
+      echo "Deleting all old configuration backups."
+      find . -type f -name "*.bak" -delete
+    else
+      echo "Keeping old configuration backups."
+    fi
+    echo ""
+    # For every configuration file found, move (rename) the file
+    for file in "${configFiles[@]}"; do
+      echo "Moving '$file' to '$file.$currentDT.bak'"
+      mv "$file" "$file.$currentDT.bak"
+    done  
+    echo -e "\nConfiguration files moved and are ready to be regenerated."
+  else
+    # User chose not move configuration files.
+    echo -e "\nExiting with no action."
+  fi
+else
+  # No configuration files found to move. There is nothing to do.
+  echo "No environment files found. Exiting."
 fi


### PR DESCRIPTION
- Added "*.bak" to .gitignore. All other changes in nuke.sh
- Only proceed to nuke if there are 1 or more existing environment/config files
- Ask user if they want to delete existing backups
- Move all environment/config files using pattern \<oldname\>.\<timestamp\>.bak