### PR TITLE
Fix maven gpg signing

### DIFF
--- a/libs/java/dal/db/.devcontainer/Dockerfile
+++ b/libs/java/dal/db/.devcontainer/Dockerfile
@@ -25,6 +25,3 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 COPY maven-settings.xml /home/vscode/.m2/settings.xml
 RUN mkdir -p /home/vscode/.m2/repository
 RUN sudo chmod 777 /home/vscode/.m2/repository
-
-RUN export GPG_TTY=$(tty)
-

--- a/libs/java/dal/db/.devcontainer/gpg-agent.conf
+++ b/libs/java/dal/db/.devcontainer/gpg-agent.conf
@@ -1,0 +1,1 @@
+allow-loopback-pinentry

--- a/libs/java/dal/db/.devcontainer/gpg.conf
+++ b/libs/java/dal/db/.devcontainer/gpg.conf
@@ -1,0 +1,2 @@
+use-agent 
+pinentry-mode loopback

--- a/libs/java/dal/db/Makefile
+++ b/libs/java/dal/db/Makefile
@@ -61,29 +61,29 @@ run: ## Manually run the test project.
 # Maven Central Repository Commands
 ##############################################################################
 
-setup: ## Import private key
+setup: ## Import private key (u=[sudo])
 	@echo "$(P) Import private key"
-	@./scripts/setup.sh
+	@./scripts/setup.sh $(u)
 
-deploy-staging: ## Build and deploy the package to Maven Central
+deploy-staging: ## Build and deploy the package to Maven Central (u=[sudo])
 	@echo "$(P) Build and deploy package to Maven Central"
-	@./scripts/deploy-staging.sh
+	@./scripts/deploy-staging.sh $(u)
 
-close-staging: ## Close the staging repository
+close-staging: ## Close the staging repository (u=[sudo])
 	@echo "$(P) Close the staging repository"
-	@./scripts/close-staging-repo.sh
+	@./scripts/close-staging-repo.sh $(u)
 
-release-staging: ## Release the staging repository
+release-staging: ## Release the staging repository (u=[sudo])
 	@echo "$(P) Release the staging repository"
-	@./scripts/release-staging-repo.sh
+	@./scripts/release-staging-repo.sh $(u)
 
-drop-staging: ## Drop the staging repository
+drop-staging: ## Drop the staging repository (u=[sudo])
 	@echo "$(P) Drop the staging repository"
-	@./scripts/drop-staging-repo.sh
+	@./scripts/drop-staging-repo.sh $(u)
 
-deploy-release: ## Build and deploy the package to Maven Central and release it
+deploy-release: ## Build and deploy the package to Maven Central and release it (u=[sudo])
 	@echo "$(P) Build and deploy package to Maven Central"
-	@./scripts/deploy-release.sh
+	@./scripts/deploy-release.sh $(u)
 
 ##############################################################################
 # Flyway Database Migration Commands

--- a/libs/java/dal/db/scripts/close-staging-repo.sh
+++ b/libs/java/dal/db/scripts/close-staging-repo.sh
@@ -7,5 +7,10 @@ if [ ! -z "$varStagingRepoId" ]
 then
   cd dal-db
   export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
-  sudo env PATH="$PATH" mvn nexus-staging:close -DstagingRepositoryId="cabcgovtno-$varStagingRepoId" -s /home/vscode/.m2/settings.xml
+  
+  if [ "$1" = "sudo" ]; then
+    sudo env PATH="$PATH" mvn nexus-staging:close -DstagingRepositoryId="cabcgovtno-$varStagingRepoId" -s /home/vscode/.m2/settings.xml
+  else
+    mvn nexus-staging:close -DstagingRepositoryId="cabcgovtno-$varStagingRepoId" -s /home/vscode/.m2/settings.xml
+  fi
 fi

--- a/libs/java/dal/db/scripts/deploy-release.sh
+++ b/libs/java/dal/db/scripts/deploy-release.sh
@@ -3,5 +3,10 @@
 export GPG_TTY=$(tty)
 cd dal-db
 export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
-sudo env PATH="$PATH" mvn clean deploy -P release -e -s /home/vscode/.m2/settings.xml
+
+if [ "$1" = "sudo" ]; then
+  sudo env PATH="$PATH" mvn clean deploy -P release -e -s /home/vscode/.m2/settings.xml
+else
+  mvn clean deploy -P release -e -s /home/vscode/.m2/settings.xml
+fi
 echo "Go to Nexus Repository Manager to get the Staging Repository Id - https://s01.oss.sonatype.org/"

--- a/libs/java/dal/db/scripts/deploy-staging.sh
+++ b/libs/java/dal/db/scripts/deploy-staging.sh
@@ -3,5 +3,10 @@
 export GPG_TTY=$(tty)
 cd dal-db
 export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
-sudo env PATH="$PATH" mvn clean deploy -P staging -e -s /home/vscode/.m2/settings.xml
+
+if [ "$1" = "sudo" ]; then
+  sudo env PATH="$PATH" mvn clean deploy -P staging -e -s /home/vscode/.m2/settings.xml
+else
+  mvn clean deploy -P staging -e -s /home/vscode/.m2/settings.xml
+fi
 echo "Go to Nexus Repository Manager to get the Staging Repository Id - https://s01.oss.sonatype.org/"

--- a/libs/java/dal/db/scripts/drop-staging-repo.sh
+++ b/libs/java/dal/db/scripts/drop-staging-repo.sh
@@ -7,5 +7,10 @@ if [ ! -z "$varStagingRepoId" ]
 then
   cd dal-db
   export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
-  sudo env PATH="$PATH" mvn nexus-staging:drop -P staging -DstagingRepositoryId="cabcgovtno-$varStagingRepoId" -s /home/vscode/.m2/settings.xml
+  
+  if [ "$1" = "sudo" ]; then
+    sudo env PATH="$PATH" mvn nexus-staging:drop -P staging -DstagingRepositoryId="cabcgovtno-$varStagingRepoId" -s /home/vscode/.m2/settings.xml
+  else
+    mvn nexus-staging:drop -P staging -DstagingRepositoryId="cabcgovtno-$varStagingRepoId" -s /home/vscode/.m2/settings.xml
+  fi
 fi

--- a/libs/java/dal/db/scripts/release-staging-repo.sh
+++ b/libs/java/dal/db/scripts/release-staging-repo.sh
@@ -7,5 +7,10 @@ if [ ! -z "$varStagingRepoId" ]
 then
   cd dal-db
   export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
-  sudo env PATH="$PATH" mvn nexus-staging:release -P staging -DstagingRepositoryId="cabcgovtno-$varStagingRepoId" -s /home/vscode/.m2/settings.xml
+  
+  if [ "$1" = "sudo" ]; then
+    sudo env PATH="$PATH" mvn nexus-staging:release -P staging -DstagingRepositoryId="cabcgovtno-$varStagingRepoId" -s /home/vscode/.m2/settings.xml
+  else
+    mvn nexus-staging:release -P staging -DstagingRepositoryId="cabcgovtno-$varStagingRepoId" -s /home/vscode/.m2/settings.xml
+  fi
 fi

--- a/libs/java/dal/db/scripts/setup.sh
+++ b/libs/java/dal/db/scripts/setup.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
 
-# This fixes a bug with GPG when signing the package.
-# export GPG_TTY=$(tty)
-# export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
-
 # Import the private.key that is in the root folder.
 # This is required to sign and verify packages.
-# sudo env "PATH=$PATH" gpg --import private.key
-sudo gpg --import private.key
+# sudo env "PATH=$PATH" gpg --import private.key]
+FILE=private.key
+if [ -f "$FILE" ]; then
+  if [ "$1" = "sudo" ]; then
+    sudo gpg --import "$FILE"
+    sudo cp .devcontainer/gpg.conf ~/.gnupg/gpg.conf
+    sudo cp .devcontainer/gpg-agent.conf ~/.gnupg/gpg-agent.conf
+  else
+    gpg --import "$FILE"
+    cp .devcontainer/gpg.conf ~/.gnupg/gpg.conf
+    cp .devcontainer/gpg-agent.conf ~/.gnupg/gpg-agent.conf
+  fi
+fi
+
+echo RELOADAGENT | gpg-connect-agent
+
+# sudo echo 'default-key:0:"xxxxxx' | gpgconf —change-options gpg


### PR DESCRIPTION
The fix to run with `sudo` won't work with containers in Windows VM.  The default behaviour is now for Windows VM, but there is now an override that can be used through parameters.

`make setup u=sudo`
`make deploy-release u=sudo`