### PR TITLE
TNO-208 Fix content actions

### DIFF
--- a/api/editor/api-editor/src/main/java/ca/bc/gov/tno/areas/editor/models/ContentModel.java
+++ b/api/editor/api-editor/src/main/java/ca/bc/gov/tno/areas/editor/models/ContentModel.java
@@ -8,6 +8,7 @@ import javax.persistence.Persistence;
 
 import ca.bc.gov.tno.dal.db.ContentStatus;
 import ca.bc.gov.tno.dal.db.entities.Content;
+import ca.bc.gov.tno.dal.db.entities.ContentAction;
 import ca.bc.gov.tno.dal.db.entities.ContentCategory;
 import ca.bc.gov.tno.dal.db.entities.ContentTag;
 import ca.bc.gov.tno.dal.db.entities.ContentTone;
@@ -147,6 +148,10 @@ public class ContentModel extends AuditColumnModel {
         .addAll(this.fileReferences.stream()
             .map((file) -> new FileReference(file.getId(), content, file.getPath(), file.getMimeType(), file.getSize(),
                 file.getRunningTime()))
+            .toList());
+    content.getContentActions()
+        .addAll(this.actions.stream()
+            .map((action) -> new ContentAction(content, action.getId(), action.getValue()))
             .toList());
     content.getContentTags()
         .addAll(this.tags.stream()

--- a/libs/java/dal/db/dal-db-test/src/main/java/ca/bc/gov/tno/dal/db/ContentTest.java
+++ b/libs/java/dal/db/dal-db-test/src/main/java/ca/bc/gov/tno/dal/db/ContentTest.java
@@ -71,7 +71,7 @@ public class ContentTest {
 
     var content = new Content(contentType, mediaType, license, null, "SOURCE", user, ContentStatus.Published,
         "headline");
-    content.getContentActions().add(new ContentAction(content, 1, "test"));
+    content.getContentActions().add(new ContentAction(content, 1, "true"));
     content.getContentTags().add(new ContentTag(content, "TBD"));
     content.getContentTonePools().add(new ContentTone(content, 1, 3));
     content.getContentCategories().add(new ContentCategory(content, 1, 67));
@@ -169,7 +169,7 @@ public class ContentTest {
 
     var c4 = new Content(contentType, mediaType, license, null, "Action", user, ContentStatus.Published,
         "action content");
-    c4.getContentActions().add(new ContentAction(c4, action));
+    c4.getContentActions().add(new ContentAction(c4, action, "true"));
     c4 = contentService.add(c4);
 
     var user2 = userService.findById(2).get(); // Editor

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/ContentAction.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/ContentAction.java
@@ -93,26 +93,6 @@ public class ContentAction extends AuditColumns {
    * Creates a new instance of a ContentAction object, initializes with specified
    * parameters.
    * 
-   * @param content Content object
-   * @param action  Action object
-   */
-  public ContentAction(Content content, Action action) {
-    if (content == null)
-      throw new NullPointerException("Parameter 'content' cannot be null.");
-    if (action == null)
-      throw new NullPointerException("Parameter 'action' cannot be null.");
-
-    this.content = content;
-    this.contentId = content.getId();
-    this.action = action;
-    this.actionId = action.getId();
-    this.value = "";
-  }
-
-  /**
-   * Creates a new instance of a ContentAction object, initializes with specified
-   * parameters.
-   * 
    * @param content  Content object
    * @param actionId Foreign key to Action object
    * @param value    Action value
@@ -133,17 +113,17 @@ public class ContentAction extends AuditColumns {
    * Creates a new instance of a ContentAction object, initializes with specified
    * parameters.
    * 
-   * @param content  Content object
-   * @param actionId Foreign key to Action object
+   * @param contentId Foreign key to Content object
+   * @param actionId  Foreign key to Action object
+   * @param value     Action value
    */
-  public ContentAction(Content content, int actionId) {
-    if (content == null)
-      throw new NullPointerException("Parameter 'content' cannot be null.");
+  public ContentAction(int contentId, int actionId, String value) {
+    if (value == null)
+      throw new NullPointerException("Parameter 'value' cannot be null.");
 
-    this.content = content;
-    this.contentId = content.getId();
+    this.contentId = contentId;
     this.actionId = actionId;
-    this.value = "";
+    this.value = value;
   }
 
   /**

--- a/test/TNO.postman_collection.json
+++ b/test/TNO.postman_collection.json
@@ -1,4658 +1,5992 @@
 {
-  "info": {
-    "_postman_id": "561164e7-8ec2-4d90-a35b-f823a9cc68da",
-    "name": "TNO",
-    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
-  },
-  "item": [
-    {
-      "name": "auth",
-      "item": [
-        {
-          "name": "token: service-account",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "var jsonData = JSON.parse(responseBody);\r",
-                  "postman.setEnvironmentVariable(\"access-token\", jsonData.access_token);"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "auth": {
-              "type": "noauth"
-            },
-            "method": "POST",
-            "header": [],
-            "body": {
-              "mode": "urlencoded",
-              "urlencoded": [
-                {
-                  "key": "client_id",
-                  "value": "tno-service-account",
-                  "type": "text"
-                },
-                {
-                  "key": "grant_type",
-                  "value": "client_credentials",
-                  "type": "text"
-                },
-                {
-                  "key": "audience",
-                  "value": "tno-service-account",
-                  "type": "text"
-                },
-                {
-                  "key": "client_secret",
-                  "value": "{{service-account-secret}}",
-                  "type": "text"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{keycloak-scheme}}://{{keycloak-host}}:{{keycloak-port}}/auth/realms/{{realm}}/protocol/openid-connect/token",
-              "protocol": "{{keycloak-scheme}}",
-              "host": ["{{keycloak-host}}"],
-              "port": "{{keycloak-port}}",
-              "path": ["auth", "realms", "{{realm}}", "protocol", "openid-connect", "token"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "token: test user",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "var jsonData = JSON.parse(responseBody);",
-                  "postman.setEnvironmentVariable(\"access-token\", jsonData.access_token);"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "auth": {
-              "type": "noauth"
-            },
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "name": "Content-Type",
-                "type": "text",
-                "value": "application/x-www-form-urlencoded"
-              }
-            ],
-            "body": {
-              "mode": "urlencoded",
-              "urlencoded": [
-                {
-                  "key": "client_id",
-                  "value": "tno-test",
-                  "type": "text"
-                },
-                {
-                  "key": "grant_type",
-                  "value": "password",
-                  "type": "text"
-                },
-                {
-                  "key": "username",
-                  "value": "{{test-username}}",
-                  "type": "text"
-                },
-                {
-                  "key": "password",
-                  "value": "{{test-password}}",
-                  "type": "text"
-                },
-                {
-                  "key": "client_secret",
-                  "value": "{{test-secret}}",
-                  "type": "text"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{keycloak-scheme}}://{{keycloak-host}}:{{keycloak-port}}/auth/realms/{{realm}}/protocol/openid-connect/token",
-              "protocol": "{{keycloak-scheme}}",
-              "host": ["{{keycloak-host}}"],
-              "port": "{{keycloak-port}}",
-              "path": ["auth", "realms", "{{realm}}", "protocol", "openid-connect", "token"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "userinfo",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{keycloak-scheme}}://{{keycloak-host}}:{{keycloak-port}}/auth/realms/{{realm}}/protocol/openid-connect/userinfo",
-              "protocol": "{{keycloak-scheme}}",
-              "host": ["{{keycloak-host}}"],
-              "port": "{{keycloak-port}}",
-              "path": ["auth", "realms", "{{realm}}", "protocol", "openid-connect", "userinfo"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "open id connect endpoints Copy",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{keycloak-scheme}}://{{keycloak-host}}:{{keycloak-port}}/auth/realms/{{realm}}/.well-known/openid-configuration",
-              "protocol": "{{keycloak-scheme}}",
-              "host": ["{{keycloak-host}}"],
-              "port": "{{keycloak-port}}",
-              "path": ["auth", "realms", "{{realm}}", ".well-known", "openid-configuration"]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "azure",
-      "item": [
-        {
-          "name": "video-analyzer",
-          "item": [
-            {
-              "name": "videos",
-              "item": [
-                {
-                  "name": "list",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [""],
-                        "type": "text/javascript"
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Ocp-Apim-Subscription-Key",
-                        "value": "{{azure-video-subscription-key}}",
-                        "type": "text"
-                      },
-                      {
-                        "key": "x-ms-client-request-id",
-                        "value": "",
-                        "description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
-                        "type": "text",
-                        "disabled": true
-                      }
-                    ],
-                    "url": {
-                      "raw": "https://api.videoindexer.ai/{{azure-video-location}}/accounts/{{azure-video-account-id}}/videos?pageSize=25&skip=0",
-                      "protocol": "https",
-                      "host": ["api", "videoindexer", "ai"],
-                      "path": [
-                        "{{azure-video-location}}",
-                        "accounts",
-                        "{{azure-video-account-id}}",
-                        "videos"
-                      ],
-                      "query": [
-                        {
-                          "key": "createdAfter",
-                          "value": "",
-                          "disabled": true
-                        },
-                        {
-                          "key": "createdBefore",
-                          "value": "",
-                          "disabled": true
-                        },
-                        {
-                          "key": "pageSize",
-                          "value": "25"
-                        },
-                        {
-                          "key": "skip",
-                          "value": "0"
-                        },
-                        {
-                          "key": "accessToken",
-                          "value": "{{azure-video-access-token}}",
-                          "disabled": true
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "thumbnail",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [""],
-                        "type": "text/javascript"
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Ocp-Apim-Subscription-Key",
-                        "value": "{{azure-video-subscription-key}}",
-                        "type": "text"
-                      },
-                      {
-                        "key": "x-ms-client-request-id",
-                        "value": "",
-                        "description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
-                        "type": "text",
-                        "disabled": true
-                      }
-                    ],
-                    "url": {
-                      "raw": "https://api.videoindexer.ai/{{azure-video-location}}/accounts/{{azure-video-account-id}}/videos/:videoId/Thumnails/:thumbnailId",
-                      "protocol": "https",
-                      "host": ["api", "videoindexer", "ai"],
-                      "path": [
-                        "{{azure-video-location}}",
-                        "accounts",
-                        "{{azure-video-account-id}}",
-                        "videos",
-                        ":videoId",
-                        "Thumnails",
-                        ":thumbnailId"
-                      ],
-                      "query": [
-                        {
-                          "key": "accessToken",
-                          "value": "{{azure-video-access-token}}",
-                          "disabled": true
-                        }
-                      ],
-                      "variable": [
-                        {
-                          "key": "videoId",
-                          "value": "e2228a52d9"
-                        },
-                        {
-                          "key": "thumbnailId",
-                          "value": "00000000-0000-0000-0000-000000000000"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "captions",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [""],
-                        "type": "text/javascript"
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Ocp-Apim-Subscription-Key",
-                        "value": "{{azure-video-subscription-key}}",
-                        "type": "text"
-                      },
-                      {
-                        "key": "x-ms-client-request-id",
-                        "value": "",
-                        "description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
-                        "type": "text",
-                        "disabled": true
-                      }
-                    ],
-                    "url": {
-                      "raw": "https://api.videoindexer.ai/{{azure-video-location}}/accounts/{{azure-video-account-id}}/videos/:videoId/Captions?format=Txt&language=en-US&includeAudioEffects=false",
-                      "protocol": "https",
-                      "host": ["api", "videoindexer", "ai"],
-                      "path": [
-                        "{{azure-video-location}}",
-                        "accounts",
-                        "{{azure-video-account-id}}",
-                        "videos",
-                        ":videoId",
-                        "Captions"
-                      ],
-                      "query": [
-                        {
-                          "key": "accessToken",
-                          "value": "{{azure-video-access-token}}",
-                          "disabled": true
-                        },
-                        {
-                          "key": "indexId",
-                          "value": "",
-                          "description": "The video id",
-                          "disabled": true
-                        },
-                        {
-                          "key": "format",
-                          "value": "Txt",
-                          "description": "The captions format. Allowed values: Vtt / Ttml / Srt / Txt / Csv"
-                        },
-                        {
-                          "key": "language",
-                          "value": "en-US",
-                          "description": "The language of the captions. Supported languages: Serbian (Cyrillic): sr-Cyrl-RS, Serbian (Latin): sr-Latn-RS, Bosnian: bs-Latn, Chinese (Simplified): zh-Hans, Chinese (Traditional): zh-Hant, Filipino: fil-PH, English United Kingdom: en-GB, Fijian: en-FJ, English Australia: en-AU, Samoan: en-WS, English United States: en-US, Greek: el-GR, Spanish: es-ES, Spanish (Mexico): es-MX, Estonian: et-EE, Persian: fa-IR, Finnish: fi-FI, French (Canada): fr-CA, French: fr-FR, Haitian: fr-HT, Afrikaans: af-ZA, Arabic (Saudi Arabia): ar-SA, Arabic Syrian Arab Republic: ar-SY, Arabic (Palestinian Authority): ar-PS, Arabic (Qatar): ar-QA, Arabic Egypt: ar-EG, Arabic Modern Standard (Bahrain): ar-BH, Arabic (Oman): ar-OM, Arabic (Lebanon): ar-LB, Arabic (United Arab Emirates): ar-AE, Arabic (Kuwait): ar-KW, Arabic (Jordan): ar-JO, Arabic (Iraq): ar-IQ, Arabic (Israel): ar-IL, Danish: da-DK, German: de-DE, Bulgarian: bg-BG, Bangla: bn-BD, Malagasy: mg-MG, Malay: ms-MY, Maltese: mt-MT, Catalan: ca-ES, Czech: cs-CZ, Dutch: nl-NL, Norwegian: nb-NO, Indonesian: id-ID, Italian: it-IT, Lithuanian: lt-LT, Latvian: lv-LV, Japanese: ja-JP, Urdu: ur-PK, Ukrainian: uk-UA, Hindi: hi-IN, Hebrew: he-IL, Hungarian: hu-HU, Croatian: hr-HR, Korean: ko-KR, Vietnamese: vi-VN, Turkish: tr-TR, Tamil: ta-IN, Thai: th-TH, Tongan: to-TO, Russian: ru-RU, Romanian: ro-RO, Portuguese: pt-BR, Polish: pl-PL, Swedish: sv-SE, Kiswahili: sw-KE, Slovenian: sl-SI, Slovak: sk-SK, Chinese (Cantonese, Traditional): zh-HK."
-                        },
-                        {
-                          "key": "includeAudioEffects",
-                          "value": "false",
-                          "description": "Include audio effects"
-                        }
-                      ],
-                      "variable": [
-                        {
-                          "key": "videoId",
-                          "value": "e2228a52d9"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "player-widget",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [""],
-                        "type": "text/javascript"
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Ocp-Apim-Subscription-Key",
-                        "value": "{{azure-video-subscription-key}}",
-                        "type": "text"
-                      },
-                      {
-                        "key": "x-ms-client-request-id",
-                        "value": "",
-                        "description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
-                        "type": "text",
-                        "disabled": true
-                      }
-                    ],
-                    "url": {
-                      "raw": "https://api.videoindexer.ai/{{azure-video-location}}/accounts/{{azure-video-account-id}}/videos/:videoId/PlayerWidget",
-                      "protocol": "https",
-                      "host": ["api", "videoindexer", "ai"],
-                      "path": [
-                        "{{azure-video-location}}",
-                        "accounts",
-                        "{{azure-video-account-id}}",
-                        "videos",
-                        ":videoId",
-                        "PlayerWidget"
-                      ],
-                      "query": [
-                        {
-                          "key": "accessToken",
-                          "value": "{{azure-video-access-token}}",
-                          "disabled": true
-                        }
-                      ],
-                      "variable": [
-                        {
-                          "key": "videoId",
-                          "value": "e2228a52d9"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "stream-url",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [""],
-                        "type": "text/javascript"
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "GET",
-                    "header": [
-                      {
-                        "key": "Ocp-Apim-Subscription-Key",
-                        "value": "{{azure-video-subscription-key}}",
-                        "type": "text"
-                      },
-                      {
-                        "key": "x-ms-client-request-id",
-                        "value": "",
-                        "description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
-                        "type": "text",
-                        "disabled": true
-                      }
-                    ],
-                    "url": {
-                      "raw": "https://api.videoindexer.ai/{{azure-video-location}}/accounts/{{azure-video-account-id}}/videos/:videoId/streaming-url",
-                      "protocol": "https",
-                      "host": ["api", "videoindexer", "ai"],
-                      "path": [
-                        "{{azure-video-location}}",
-                        "accounts",
-                        "{{azure-video-account-id}}",
-                        "videos",
-                        ":videoId",
-                        "streaming-url"
-                      ],
-                      "query": [
-                        {
-                          "key": "accessToken",
-                          "value": "{{azure-video-access-token}}",
-                          "disabled": true
-                        },
-                        {
-                          "key": "useProxy",
-                          "value": "",
-                          "description": "\nWrap the streaming endpoint with proxy. Required for delivering content to Safari browsers. <a href=https://azure.microsoft.com/en-us/blog/how-to-make-token-authorized-aes-encrypted-hls-stream-working-in-safari/ /a>",
-                          "disabled": true
-                        },
-                        {
-                          "key": "urlFormat",
-                          "value": "SMOOTH_STREAMING_FORMAT",
-                          "description": "Streaming URL format.. Allowed values: SMOOTH_STREAMING_FORMAT / MPEG_DASH / HLS_V4 / HLS_V3",
-                          "disabled": true
-                        },
-                        {
-                          "key": "tokenLifetimeInMinutes",
-                          "value": "",
-                          "description": "Format - int32. Streaming URL token lifetime in minutes. Value must be positive. Default is 60 minutes",
-                          "disabled": true
-                        }
-                      ],
-                      "variable": [
-                        {
-                          "key": "videoId",
-                          "value": "e2228a52d9"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "upload",
-                  "event": [
-                    {
-                      "listen": "test",
-                      "script": {
-                        "exec": [""],
-                        "type": "text/javascript"
-                      }
-                    }
-                  ],
-                  "request": {
-                    "method": "POST",
-                    "header": [
-                      {
-                        "key": "Ocp-Apim-Subscription-Key",
-                        "value": "{{azure-video-subscription-key}}",
-                        "type": "text"
-                      },
-                      {
-                        "key": "x-ms-client-request-id",
-                        "value": "",
-                        "description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
-                        "type": "text",
-                        "disabled": true
-                      }
-                    ],
-                    "body": {
-                      "mode": "formdata",
-                      "formdata": [
-                        {
-                          "key": "",
-                          "type": "file",
-                          "src": "/C:/Users/jfoster/Downloads/Recording.m4a"
-                        }
-                      ]
-                    },
-                    "url": {
-                      "raw": "https://api.videoindexer.ai/{{azure-video-location}}/accounts/{{azure-video-account-id}}/videos?name=test&privacy=Private&description=test&language=en-US&streamingPreset=Default&sendSuccessEmail=true&fileName",
-                      "protocol": "https",
-                      "host": ["api", "videoindexer", "ai"],
-                      "path": [
-                        "{{azure-video-location}}",
-                        "accounts",
-                        "{{azure-video-account-id}}",
-                        "videos"
-                      ],
-                      "query": [
-                        {
-                          "key": "accessToken",
-                          "value": "{{azure-video-access-token}}",
-                          "disabled": true
-                        },
-                        {
-                          "key": "name",
-                          "value": "test",
-                          "description": "The video name"
-                        },
-                        {
-                          "key": "privacy",
-                          "value": "Private",
-                          "description": "The video privacy mode. Allowed values: Private / Public"
-                        },
-                        {
-                          "key": "priority",
-                          "value": "High",
-                          "description": "Index priority, can be used in paid regions only. Allowed values: Low / Normal / High",
-                          "disabled": true
-                        },
-                        {
-                          "key": "description",
-                          "value": "test",
-                          "description": "The video description."
-                        },
-                        {
-                          "key": "partition",
-                          "value": "",
-                          "description": "A partition to partition videos by (used for searching a specific partition)",
-                          "disabled": true
-                        },
-                        {
-                          "key": "externalId",
-                          "value": "",
-                          "description": "An external id to associate with the video (can be searched for later).",
-                          "disabled": true
-                        },
-                        {
-                          "key": "externalUrl",
-                          "value": "",
-                          "description": "Format - uri. An external URL to associate with the video (can be retrieved later)",
-                          "disabled": true
-                        },
-                        {
-                          "key": "callbackUrl",
-                          "value": "",
-                          "description": "Format - uri. A url to send notifications to (POST). These are the supported notifications:\n\nVideo indexing completed: 2 additional query string parameters will be added to the url: id and state.\n\nFor example, if the callback url is 'https://test.com/notifyme?projectName=MyProject', the notification will be sent to 'https://test.com/notifyme?projectName=MyProject&id=12345abcde&state=Processed'.\n\nA face was identified (after the face was trained in another video): 4 additional query string parameters will be added to the url: id, faceId, knownPersonId and personName.\n\nFor example, if the callback url is 'https://test.com/notifyme?projectName=MyProject', the notification will be sent to 'https://test.com/notifyme?projectName=MyProject&id=12345abcde&faceId=1234&knownPersonId=B689EC08-FAB6-497A-A727-DA7285DBD436&personName=JohnSmith'.",
-                          "disabled": true
-                        },
-                        {
-                          "key": "metadata",
-                          "value": "",
-                          "description": "Metadata to associate with the video (will be returned in queries).",
-                          "disabled": true
-                        },
-                        {
-                          "key": "language",
-                          "value": "en-US",
-                          "description": "The language of the video, to be used when generating the transcript: Auto-detect single language - 'auto', Auto-detect multi language (preview) - 'multi'.. Supported languages: Chinese (Simplified): zh-Hans, English United Kingdom: en-GB, English Australia: en-AU, English United States: en-US, Spanish: es-ES, Spanish (Mexico): es-MX, Finnish: fi-FI, French (Canada): fr-CA, French: fr-FR, Arabic (Saudi Arabia): ar-SA, Arabic Syrian Arab Republic: ar-SY, Arabic (Palestinian Authority): ar-PS, Arabic (Qatar): ar-QA, Arabic Egypt: ar-EG, Arabic Modern Standard (Bahrain): ar-BH, Arabic (Oman): ar-OM, Arabic (Lebanon): ar-LB, Arabic (United Arab Emirates): ar-AE, Arabic (Kuwait): ar-KW, Arabic (Jordan): ar-JO, Arabic (Iraq): ar-IQ, Arabic (Israel): ar-IL, Danish: da-DK, German: de-DE, Czech: cs-CZ, Dutch: nl-NL, Norwegian: nb-NO, Italian: it-IT, Japanese: ja-JP, Hindi: hi-IN, Korean: ko-KR, Turkish: tr-TR, Thai: th-TH, Russian: ru-RU, Portuguese: pt-BR, Polish: pl-PL, Swedish: sv-SE, Chinese (Cantonese, Traditional): zh-HK."
-                        },
-                        {
-                          "key": "videoUrl",
-                          "value": "",
-                          "description": "Format - uri. A public url of the video/audio file (url encoded). It is recommended to use readonly urls (e.g. when using Azure Storage SAS urls). If not specified, the file should be passed as a multipart/form body content.",
-                          "disabled": true
-                        },
-                        {
-                          "key": "indexingPreset",
-                          "value": "",
-                          "description": "The indexing preset to use. Allowed values: Default / AudioOnly / VideoOnly / BasicAudio / Advanced / AdvancedAudio / AdvancedVideo",
-                          "disabled": true
-                        },
-                        {
-                          "key": "streamingPreset",
-                          "value": "Default",
-                          "description": "The streaming preset to use. Allowed values: NoStreaming / Default / SingleBitrate / AdaptiveBitrate"
-                        },
-                        {
-                          "key": "linguisticModelId",
-                          "value": "",
-                          "description": "Linguistic model id as received by 'create linguistic model' call",
-                          "disabled": true
-                        },
-                        {
-                          "key": "personModelId",
-                          "value": "",
-                          "description": "Faces will be identified against the provided person model.",
-                          "disabled": true
-                        },
-                        {
-                          "key": "animationModelId",
-                          "value": "",
-                          "description": "Animations will be identified against the provided animation model.",
-                          "disabled": true
-                        },
-                        {
-                          "key": "sendSuccessEmail",
-                          "value": "true",
-                          "description": "Indicates whether to send a success mail once video was succesfully indexed"
-                        },
-                        {
-                          "key": "assetId",
-                          "value": "",
-                          "description": "Azure media services asset id. Used to index from existing assets in your connected Azure media services account. (Paid only)",
-                          "disabled": true
-                        },
-                        {
-                          "key": "brandsCategories",
-                          "value": "",
-                          "description": "List of brands categories delimited by comma. Azure Video Analyzer for Media will only take these categories in to account when indexing. If not specified all brands will be used.",
-                          "disabled": true
-                        },
-                        {
-                          "key": "fileName",
-                          "value": null
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "access-token",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "postman.setEnvironmentVariable(\"azure-video-access-token\", responseBody.replaceAll('\"', \"\"));"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Ocp-Apim-Subscription-Key",
-                    "value": "{{azure-video-subscription-key}}",
-                    "type": "text"
-                  },
-                  {
-                    "key": "x-ms-client-request-id",
-                    "value": "",
-                    "description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "https://api.videoindexer.ai/auth/{{azure-video-location}}/accounts/{{azure-video-account-id}}/accessToken?allowEdit=true",
-                  "protocol": "https",
-                  "host": ["api", "videoindexer", "ai"],
-                  "path": [
-                    "auth",
-                    "{{azure-video-location}}",
-                    "accounts",
-                    "{{azure-video-account-id}}",
-                    "accessToken"
-                  ],
-                  "query": [
-                    {
-                      "key": "allowEdit",
-                      "value": "true"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "access-token-user",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "postman.setEnvironmentVariable(\"azure-video-access-token\", responseBody.replaceAll('\"', \"\"));"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Ocp-Apim-Subscription-Key",
-                    "value": "{{azure-video-subscription-key}}",
-                    "type": "text"
-                  },
-                  {
-                    "key": "x-ms-client-request-id",
-                    "value": "",
-                    "description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
-                    "type": "text",
-                    "disabled": true
-                  }
-                ],
-                "url": {
-                  "raw": "https://api.videoindexer.ai/auth/{{azure-video-location}}/users/me/accessToken?allowEdit=true",
-                  "protocol": "https",
-                  "host": ["api", "videoindexer", "ai"],
-                  "path": ["auth", "{{azure-video-location}}", "users", "me", "accessToken"],
-                  "query": [
-                    {
-                      "key": "allowEdit",
-                      "value": "true"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "access-token-with-permission",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "postman.setEnvironmentVariable(\"azure-video-access-token\", responseBody.replaceAll('\"', \"\"));"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Ocp-Apim-Subscription-Key",
-                    "value": "{{azure-video-subscription-key}}",
-                    "type": "text"
-                  },
-                  {
-                    "key": "x-ms-client-request-id",
-                    "value": "",
-                    "description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
-                    "type": "text",
-                    "disabled": true
-                  }
-                ],
-                "url": {
-                  "raw": "https://api.videoindexer.ai/auth/{{azure-video-location}}/accounts/{{azure-video-account-id}}/accessTokenWithPermission?permission=Contributor",
-                  "protocol": "https",
-                  "host": ["api", "videoindexer", "ai"],
-                  "path": [
-                    "auth",
-                    "{{azure-video-location}}",
-                    "accounts",
-                    "{{azure-video-account-id}}",
-                    "accessTokenWithPermission"
-                  ],
-                  "query": [
-                    {
-                      "key": "permission",
-                      "value": "Contributor",
-                      "description": "The requested permission. Allowed values: Reader (allows reading content) / Contributor (allows modifying content) / MyAccessAdministrator (allows managing the acting user's permission) / Owner (allows managing permissions and modifying content)"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ],
-          "auth": {
-            "type": "bearer",
-            "bearer": [
-              {
-                "key": "token",
-                "value": "{{azure-video-access-token}}",
-                "type": "string"
-              }
-            ]
-          },
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [""]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [""]
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "api-editor",
-      "item": [
-        {
-          "name": "health",
-          "item": [
-            {
-              "name": "health",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/health",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{port}}{{root-path}}",
-                  "path": ["health"]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "admin",
-          "item": [
-            {
-              "name": "actions",
-              "item": [
-                {
-                  "name": "actions",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/actions",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "actions"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "actions/:id",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/actions/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "actions", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "actions",
-                  "request": {
-                    "method": "POST",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/actions",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "actions"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "actions/:id",
-                  "request": {
-                    "method": "PUT",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/actions/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "actions", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "actions/:id",
-                  "request": {
-                    "method": "DELETE",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/actions/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "actions", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "categories",
-              "item": [
-                {
-                  "name": "categories",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/categories",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "categories"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "categories/:id",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/categories/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "categories", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "categories",
-                  "request": {
-                    "method": "POST",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/categories",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "categories"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "categories/:id",
-                  "request": {
-                    "method": "PUT",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/categories/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "categories", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "categories/:id",
-                  "request": {
-                    "method": "DELETE",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/categories/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "categories", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "claims",
-              "item": [
-                {
-                  "name": "claims",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/claims",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "claims"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "claims/:id",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/claims/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "claims", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "claims",
-                  "request": {
-                    "method": "POST",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/claims",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "claims"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "claims/:id",
-                  "request": {
-                    "method": "PUT",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/claims/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "claims", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "claims/:id",
-                  "request": {
-                    "method": "DELETE",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/claims/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "claims", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "content references",
-              "item": [
-                {
-                  "name": "content/references",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/references",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "content", "references"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "content/references/:source/:uid",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/references/:source/:uid",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "content", "references", ":source", ":uid"],
-                      "variable": [
-                        {
-                          "key": "source",
-                          "value": null
-                        },
-                        {
-                          "key": "uid",
-                          "value": null
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "content/references",
-                  "request": {
-                    "method": "POST",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"source\": \"CJN\",\r\n    \"uid\": \"01\",\r\n    \"topic\": \"test\",\r\n    \"offset\": 0,\r\n    \"status\": 0\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/references",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "content", "references"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "content/references/:source/:uid",
-                  "request": {
-                    "method": "PUT",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"source\": \"CJN\",\r\n    \"uid\": \"01\",\r\n    \"topic\": \"test\",\r\n    \"offset\": 0,\r\n    \"status\": 0\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/references/:source/:uid",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "content", "references", ":source", ":uid"],
-                      "variable": [
-                        {
-                          "key": "source",
-                          "value": null
-                        },
-                        {
-                          "key": "uid",
-                          "value": null
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "content/references/:source/:uid",
-                  "request": {
-                    "method": "DELETE",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"source\": \"CJN\",\r\n    \"uid\": \"01\",\r\n    \"topic\": \"test\",\r\n    \"offset\": 0,\r\n    \"status\": 0\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/references/:source/:uid",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "content", "references", ":source", ":uid"],
-                      "variable": [
-                        {
-                          "key": "source",
-                          "value": null
-                        },
-                        {
-                          "key": "uid",
-                          "value": null
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "content types",
-              "item": [
-                {
-                  "name": "content/types",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/types",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "content", "types"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "content/types/:id",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/types/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "content", "types", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "content/types",
-                  "request": {
-                    "method": "POST",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"name\": \"dst\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/types",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "content", "types"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "content/types/:id",
-                  "request": {
-                    "method": "PUT",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"name\": \"dst\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/types/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "content", "types", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "content/types/:id",
-                  "request": {
-                    "method": "DELETE",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"name\": \"dst\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/types/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "content", "types", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": null
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "data sources",
-              "item": [
-                {
-                  "name": "data/sources",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/data/sources",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "data", "sources"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "data/sources/:id",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/data/sources/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "data", "sources", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "data/sources",
-                  "request": {
-                    "method": "POST",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"name\": \"The Canadian Jewish News\",\r\n    \"abbr\": \"CJN\",\r\n    \"description\": \"Daily breaking news, podcasts, newsletters and events that matter to the Canadian Jewish community.\",\r\n    \"isEnabled\": true,\r\n    \"typeId\": 1,\r\n    \"licenseId\": 1,\r\n    \"scheduleId\": 1,\r\n    \"topic\": \"test\",\r\n    \"connection\": {\r\n        \"url\": \"https://thecjn.ca/feed/\"\r\n    }\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/data/sources",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "data", "sources"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "data/sources/:id",
-                  "request": {
-                    "method": "PUT",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"name\": \"The Canadian Jewish News\",\r\n    \"abbr\": \"CJN\",\r\n    \"description\": \"Daily breaking news, podcasts, newsletters and events that matter to the Canadian Jewish community.\",\r\n    \"isEnabled\": true,\r\n    \"typeId\": 1,\r\n    \"licenseId\": 1,\r\n    \"scheduleId\": 1,\r\n    \"topic\": \"test\",\r\n    \"connection\": {\r\n        \"url\": \"https://thecjn.ca/feed/\"\r\n    }\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/data/sources/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "data", "sources", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "data/sources/:id",
-                  "request": {
-                    "method": "DELETE",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"name\": \"The Canadian Jewish News\",\r\n    \"abbr\": \"CJN\",\r\n    \"description\": \"Daily breaking news, podcasts, newsletters and events that matter to the Canadian Jewish community.\",\r\n    \"isEnabled\": true,\r\n    \"typeId\": 1,\r\n    \"licenseId\": 1,\r\n    \"scheduleId\": 1,\r\n    \"topic\": \"test\",\r\n    \"connection\": {\r\n        \"url\": \"https://thecjn.ca/feed/\"\r\n    }\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/data/sources/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "data", "sources", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "media types",
-              "item": [
-                {
-                  "name": "media/types",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/media/types",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "media", "types"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "media/types/:id",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/media/types/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "media", "types", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "media/types",
-                  "request": {
-                    "method": "POST",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"name\": \"dst\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/media/types",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "media", "types"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "media/types/:id",
-                  "request": {
-                    "method": "PUT",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"name\": \"dst\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/media/types/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "media", "types", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "media/types/:id",
-                  "request": {
-                    "method": "DELETE",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"name\": \"dst\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/media/types/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "media", "types", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": null
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "licenses",
-              "item": [
-                {
-                  "name": "licenses",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/licenses",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "licenses"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "data/sources/:id",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/licenses/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "licenses", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "licenses",
-                  "request": {
-                    "method": "POST",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"name\": \"license\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/licenses",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "licenses"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "licenses/:id",
-                  "request": {
-                    "method": "PUT",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"name\": \"license\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/licenses/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "licenses", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "data/sources/:id",
-                  "request": {
-                    "method": "DELETE",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"name\": \"license\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/licenses/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "licenses", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "roles",
-              "item": [
-                {
-                  "name": "roles",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/roles",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "roles"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "roles/:id",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/roles/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "roles", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "roles",
-                  "request": {
-                    "method": "POST",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/roles",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "roles"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "roles/:id",
-                  "request": {
-                    "method": "PUT",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/roles/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "roles", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "roles/:id",
-                  "request": {
-                    "method": "DELETE",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/roles/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "roles", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "schedules",
-              "item": [
-                {
-                  "name": "schedules",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/schedules",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "schedules"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "schedules/:id",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/schedules/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "schedules", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "schedules",
-                  "request": {
-                    "method": "POST",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"name\": \"schedule\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/schedules",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "schedules"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "schedules/:id",
-                  "request": {
-                    "method": "PUT",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"name\": \"schedule\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/schedules/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "schedules", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "schedules/:id",
-                  "request": {
-                    "method": "DELETE",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"name\": \"schedule\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/schedules/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "schedules", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "tags",
-              "item": [
-                {
-                  "name": "tags",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tags",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "tags"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "tags/:id",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tags/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "tags", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "tags",
-                  "request": {
-                    "method": "POST",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tags",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "tags"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "tags/:id",
-                  "request": {
-                    "method": "PUT",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tags/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "tags", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "tags/:id",
-                  "request": {
-                    "method": "DELETE",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tags/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "tags", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "tone pools",
-              "item": [
-                {
-                  "name": "tone/pools",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tone/pools",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "tone", "pools"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "tone/pools/:id",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tone/pools/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "tone", "pools", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "tone/pools",
-                  "request": {
-                    "method": "POST",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tone/pools",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "tone", "pools"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "tone/pools/:id",
-                  "request": {
-                    "method": "PUT",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tone/pools/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "tone", "pools", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "tone/pools/:id",
-                  "request": {
-                    "method": "DELETE",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tone/pools/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "tone", "pools", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "users",
-              "item": [
-                {
-                  "name": "users",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/users",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "users"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "users/:id",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/users/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "users", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "users",
-                  "request": {
-                    "method": "POST",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/users",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "users"]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "users/:id",
-                  "request": {
-                    "method": "PUT",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/users/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "users", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "users/:id",
-                  "request": {
-                    "method": "DELETE",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"username\": \"admin\"\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/users/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["admin", "users", ":id"],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "editor",
-          "item": [
-            {
-              "name": "contents",
-              "item": [
-                {
-                  "name": "find",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/contents",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["editor", "contents"],
-                      "query": [
-                        {
-                          "key": "page",
-                          "value": "1",
-                          "disabled": true
-                        },
-                        {
-                          "key": "quantity",
-                          "value": "10",
-                          "disabled": true
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "find/:id",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/contents/:id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["editor", "contents", ":id"],
-                      "query": [
-                        {
-                          "key": "page",
-                          "value": "1",
-                          "disabled": true
-                        },
-                        {
-                          "key": "quantity",
-                          "value": "10",
-                          "disabled": true
-                        }
-                      ],
-                      "variable": [
-                        {
-                          "key": "id",
-                          "value": "30"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "add",
-                  "protocolProfileBehavior": {
-                    "disabledSystemHeaders": {}
-                  },
-                  "request": {
-                    "method": "POST",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"status\": 0,\r\n    \"contentTypeId\": 1,\r\n    \"headline\": \"Story headline\",\r\n    \"source\": \"source\",\r\n    \"licenseId\": 1,\r\n    \"mediaTypeId\": 1,\r\n    \"page\": \"page\",\r\n    \"section\": \"section\",\r\n    \"summary\": \"summary\",\r\n    \"ownerId\": 1\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/contents",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["editor", "contents"]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "actions",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/actions",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{port}}{{root-path}}",
-                  "path": ["editor", "actions"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "content/types",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/content/types",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{port}}{{root-path}}",
-                  "path": ["editor", "content", "types"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "categories",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/categories",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{port}}{{root-path}}",
-                  "path": ["editor", "categories"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "media/types",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/media/types",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{port}}{{root-path}}",
-                  "path": ["editor", "media", "types"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "tags",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/tags",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{port}}{{root-path}}",
-                  "path": ["editor", "tags"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "tone/pools",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/tone/pools",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{port}}{{root-path}}",
-                  "path": ["editor", "tone", "pools"]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "elastic",
-          "item": [
-            {
-              "name": "info",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/elastic",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{port}}{{root-path}}",
-                  "path": ["elastic"]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "azure-storage",
-          "item": [
-            {
-              "name": "upload",
-              "request": {
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "formdata",
-                  "formdata": [
-                    {
-                      "key": "key1",
-                      "value": "value1",
-                      "type": "text"
-                    },
-                    {
-                      "key": "key2",
-                      "value": "value2",
-                      "type": "text"
-                    },
-                    {
-                      "key": "file",
-                      "type": "file",
-                      "src": "/C:/Users/jfoster/Downloads/test.txt"
-                    }
-                  ]
-                },
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/azure/storage/upload",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{port}}{{root-path}}",
-                  "path": ["azure", "storage", "upload"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "containers/:name",
-              "request": {
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "formdata",
-                  "formdata": [
-                    {
-                      "key": "key1",
-                      "value": "value1",
-                      "type": "text"
-                    },
-                    {
-                      "key": "key2",
-                      "value": "value2",
-                      "type": "text"
-                    },
-                    {
-                      "key": "file",
-                      "type": "file",
-                      "src": "/C:/Users/jfoster/Downloads/test.txt"
-                    }
-                  ]
-                },
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/azure/storage/containers/:name",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{port}}{{root-path}}",
-                  "path": ["azure", "storage", "containers", ":name"],
-                  "variable": [
-                    {
-                      "key": "name",
-                      "value": "test-container3"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "download",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/azure/storage/download?file=test.txt",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{port}}{{root-path}}",
-                  "path": ["azure", "storage", "download"],
-                  "query": [
-                    {
-                      "key": "file",
-                      "value": "test.txt"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "cognitive-services",
-          "item": [
-            {
-              "name": "transcribe",
-              "request": {
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "formdata",
-                  "formdata": [
-                    {
-                      "key": "key1",
-                      "value": "value1",
-                      "type": "text"
-                    },
-                    {
-                      "key": "key2",
-                      "value": "value2",
-                      "type": "text"
-                    },
-                    {
-                      "key": "file",
-                      "type": "file",
-                      "src": "/C:/Users/jfoster/Downloads/Recording.wav"
-                    }
-                  ]
-                },
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/azure/cognitive/services/transcribe",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{port}}{{root-path}}",
-                  "path": ["azure", "cognitive", "services", "transcribe"]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "video-analyzer",
-          "item": [
-            {
-              "name": "videos",
-              "item": [
-                {
-                  "name": "list",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/azure/video/analyzer/videos",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{port}}{{root-path}}",
-                      "path": ["azure", "video", "analyzer", "videos"]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "access-token",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/azure/video/analyzer/access-token",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{port}}{{root-path}}",
-                  "path": ["azure", "video", "analyzer", "access-token"]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "kafka",
-          "item": [
-            {
-              "name": "topics",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/kafka/topics",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{port}}{{root-path}}",
-                  "path": ["kafka", "topics"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "topics",
-              "request": {
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"value\": \"test3\"\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/kafka/topics/test/1",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{port}}{{root-path}}",
-                  "path": ["kafka", "topics", "test", "1"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "topics/:topic",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/kafka/topics/:topic",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{port}}{{root-path}}",
-                  "path": ["kafka", "topics", ":topic"],
-                  "variable": [
-                    {
-                      "key": "topic",
-                      "value": "test"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "userinfo",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/userinfo",
-              "protocol": "{{scheme}}",
-              "host": ["{{host}}"],
-              "port": "{{port}}{{root-path}}",
-              "path": ["userinfo"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "root",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/",
-              "protocol": "{{scheme}}",
-              "host": ["{{host}}"],
-              "port": "{{port}}{{root-path}}",
-              "path": [""]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "app-editor",
-      "item": []
-    },
-    {
-      "name": "temp",
-      "item": []
-    },
-    {
-      "name": "kafka",
-      "item": [
-        {
-          "name": "topics",
-          "item": [
-            {
-              "name": "topics",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/topics",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["topics"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "topic/:topic",
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content",
-                    "value": "application/json",
-                    "type": "text"
-                  },
-                  {
-                    "key": "Content-Type",
-                    "value": "application/vnd.kafka.json.v2+json",
-                    "type": "text"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"records\": [\r\n        {\r\n            \"key\": \"uid-01\",\r\n            \"value\": {\r\n                \"source\": \"NTLP\",\r\n                \"uid\": \"uid-01\",\r\n                \"link\": \"https://some.com/place\",\r\n                \"language\": null,\r\n                \"author\": \"John Doe\",\r\n                \"title\": \"A Test Story\",\r\n                \"summary\": \"A test story summary\",\r\n                \"body\": \"Gunmen opened fire at a Cancun beach resort on Thursday, killing two people in what Mexican state officials called a confrontation between rival drug dealers that witnesses said forced tourists and hotel staff to hide for several hours. \\nThe shooting occurred on the beach near the Hyatt Ziva Cancun, an all-inclusive resort in Puerto Morelos that is popular with American tourists. \\n\\\"The @FGEQuintanaRoo reports that there was a confrontation between members of antagonistic groups of drug dealers on a beach in Bahía Petempich, Puerto Morelos,\\\" the attorney general for Quintana Roo state said via Twitter on Thursday. \\\"Two of them lost their lives at the scene. There are no serious injuries.\\\" \\nThe Secretariat of Public Security of Quintana Roo later tweeted that no tourists were seriously injured or kidnapped. The news site Notacaribe reported one person was injured at the scene after being hit with the handle of a weapon. \\nMike Sington, a Twitter user and former executive at NBC Universal, told Reuters by direct message that he was hiding with other guests of the resort in a dark area of the hotel and that staff had not explained what was happening. Other guests told him they heard gunshots and that a gunman had been on the beach, he said.\\nA senior state official said a group of gunmen arrived by boat in pursuit of the men who were slain, in what another Mexican official said appeared to have been a targeted \\\"execution.\\\"\\nMike Sington, a Twitter user and former executive at NBC Universal, told Reuters by direct message that he was hiding with other guests of the resort in a dark area of the hotel and that staff had not explained what was happening. Other guests told him they heard gunshots and that a gunman had been on the beach, he said.\\nHotel staff later sent text messages saying the gunman had been apprehended and that staff would escort guests to their rooms where they were ordered to shelter in place, Sington said.\\n\\\"I've never been so scared, literally shaking,\\\" he tweeted.\\nHe later added that guests were taken out of hiding and brought to the lobby, where they cried and hugged each other.\\nIn a statement released Thursday evening, Global Affairs Canada said it is not aware of any Canadian citizens affected by the shooting but continues to monitor the situation closely. \\nCanadian citizens requiring emergency consular assistance should contact the Consular Agency of Canada in Cancun, Mexico at 52 (55) 5724-9795 or cncun@international.gc.ca or call the department's 24/7 Emergency Watch and Response Centre at 1-800-387-3124 (toll-free), +1 613-996-8885 or by sending an email to sos@international.gc.ca.\\nMexican security forces were sent in to reinforce Tulum — another popular resort about 130 kilometres from Cancun — after two foreign tourists were killed and others wounded last month during a shootout between suspected gang members.\",\r\n                \"publishedOn\": \"2021-10-04T01:00:00\",\r\n                \"tags\": [\r\n                    {\r\n                        \"key\": \"category\",\r\n                        \"value\": \"test\"\r\n                    }\r\n                ]\r\n            }\r\n        }\r\n    ]\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/topics/:topic",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["topics", ":topic"],
-                  "variable": [
-                    {
-                      "key": "topic",
-                      "value": "test"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "topics/:topic/partitions",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/topics/:topic/partitions",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["topics", ":topic", "partitions"],
-                  "variable": [
-                    {
-                      "key": "topic",
-                      "value": "test"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "topics/:topic/partitions/:id",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/topics/:topic/partitions/:id",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["topics", ":topic", "partitions", ":id"],
-                  "variable": [
-                    {
-                      "key": "topic",
-                      "value": "test"
-                    },
-                    {
-                      "key": "id",
-                      "value": "0"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "consumers",
-          "item": [
-            {
-              "name": "group",
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/vnd.kafka.jsonschema.v2+json",
-                    "type": "text"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n  \"name\": \"my_consumer\",\r\n  \"format\": \"jsonschema\",\r\n  \"auto.offset.reset\": \"earliest\",\r\n  \"auto.commit.enable\": \"false\"\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["consumers", ":group_name"],
-                  "query": [
-                    {
-                      "key": "auto.offset.reset",
-                      "value": "earliest",
-                      "disabled": true
-                    },
-                    {
-                      "key": "auto.commit.enable",
-                      "value": "false",
-                      "disabled": true
-                    },
-                    {
-                      "key": "name",
-                      "value": "test-consumer",
-                      "disabled": true
-                    },
-                    {
-                      "key": "format",
-                      "value": "jsonschema",
-                      "disabled": true
-                    }
-                  ],
-                  "variable": [
-                    {
-                      "key": "group_name",
-                      "value": "test"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "instance",
-              "request": {
-                "method": "DELETE",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/vnd.kafka.jsonschema.v2+json",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["consumers", ":group_name", "instances", ":consumer_id"],
-                  "variable": [
-                    {
-                      "key": "group_name",
-                      "value": "nlp-01"
-                    },
-                    {
-                      "key": "consumer_id",
-                      "value": null
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "offsets",
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/vnd.kafka.jsonschema.v2+json",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/offsets",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["consumers", ":group_name", "instances", ":consumer_id", "offsets"],
-                  "variable": [
-                    {
-                      "key": "group_name",
-                      "value": null
-                    },
-                    {
-                      "key": "consumer_id",
-                      "value": null
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "offsets",
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/vnd.kafka.jsonschema.v2+json",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/offsets",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["consumers", ":group_name", "instances", ":consumer_id", "offsets"],
-                  "variable": [
-                    {
-                      "key": "group_name",
-                      "value": null
-                    },
-                    {
-                      "key": "consumer_id",
-                      "value": null
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "subscription",
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/vnd.kafka.jsonschema.v2+json",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/subscription",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["consumers", ":group_name", "instances", ":consumer_id", "subscription"],
-                  "variable": [
-                    {
-                      "key": "group_name",
-                      "value": null
-                    },
-                    {
-                      "key": "consumer_id",
-                      "value": null
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "subscription",
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/vnd.kafka.jsonschema.v2+json",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/subscription",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["consumers", ":group_name", "instances", ":consumer_id", "subscription"],
-                  "variable": [
-                    {
-                      "key": "group_name",
-                      "value": "syndication-01"
-                    },
-                    {
-                      "key": "consumer_id",
-                      "value": null
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "subscription",
-              "request": {
-                "method": "DELETE",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/vnd.kafka.jsonschema.v2+json",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/subscription",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["consumers", ":group_name", "instances", ":consumer_id", "subscription"],
-                  "variable": [
-                    {
-                      "key": "group_name",
-                      "value": null
-                    },
-                    {
-                      "key": "consumer_id",
-                      "value": null
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "assignments",
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/vnd.kafka.jsonschema.v2+json",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/assignments",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["consumers", ":group_name", "instances", ":consumer_id", "assignments"],
-                  "variable": [
-                    {
-                      "key": "group_name",
-                      "value": null
-                    },
-                    {
-                      "key": "consumer_id",
-                      "value": null
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "assignments",
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/vnd.kafka.jsonschema.v2+json",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/assignments",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["consumers", ":group_name", "instances", ":consumer_id", "assignments"],
-                  "variable": [
-                    {
-                      "key": "group_name",
-                      "value": null
-                    },
-                    {
-                      "key": "consumer_id",
-                      "value": null
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "positions",
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/vnd.kafka.jsonschema.v2+json",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/positions",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["consumers", ":group_name", "instances", ":consumer_id", "positions"],
-                  "variable": [
-                    {
-                      "key": "group_name",
-                      "value": null
-                    },
-                    {
-                      "key": "consumer_id",
-                      "value": null
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "positions/beginning",
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/vnd.kafka.jsonschema.v2+json",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/positions/beginning",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": [
-                    "consumers",
-                    ":group_name",
-                    "instances",
-                    ":consumer_id",
-                    "positions",
-                    "beginning"
-                  ],
-                  "variable": [
-                    {
-                      "key": "group_name",
-                      "value": null
-                    },
-                    {
-                      "key": "consumer_id",
-                      "value": null
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "positions/end",
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/vnd.kafka.jsonschema.v2+json",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/positions/end",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": [
-                    "consumers",
-                    ":group_name",
-                    "instances",
-                    ":consumer_id",
-                    "positions",
-                    "end"
-                  ],
-                  "variable": [
-                    {
-                      "key": "group_name",
-                      "value": null
-                    },
-                    {
-                      "key": "consumer_id",
-                      "value": null
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "records",
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/vnd.kafka.jsonschema.v2+json",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/records",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["consumers", ":group_name", "instances", ":consumer_id", "records"],
-                  "variable": [
-                    {
-                      "key": "group_name",
-                      "value": null
-                    },
-                    {
-                      "key": "consumer_id",
-                      "value": null
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "brokers",
-          "item": [
-            {
-              "name": "brokers",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/brokers",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["brokers"]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "clusters",
-          "item": [
-            {
-              "name": "consumer-groups",
-              "item": [
-                {
-                  "name": "consumers",
-                  "item": [
-                    {
-                      "name": "one",
-                      "request": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                          "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:culster_id/consumer-groups/:group_id/consumers/:consumer_id",
-                          "protocol": "{{scheme}}",
-                          "host": ["{{host}}"],
-                          "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                          "path": [
-                            "v3",
-                            "clusters",
-                            ":culster_id",
-                            "consumer-groups",
-                            ":group_id",
-                            "consumers",
-                            ":consumer_id"
-                          ],
-                          "variable": [
-                            {
-                              "key": "culster_id",
-                              "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                            },
-                            {
-                              "key": "group_id",
-                              "value": "nlp-01"
-                            },
-                            {
-                              "key": "consumer_id",
-                              "value": null
-                            }
-                          ]
-                        }
-                      },
-                      "response": []
-                    },
-                    {
-                      "name": "assignments",
-                      "request": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                          "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:culster_id/consumer-groups/:group_id/consumers/:consumer_id/assignments",
-                          "protocol": "{{scheme}}",
-                          "host": ["{{host}}"],
-                          "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                          "path": [
-                            "v3",
-                            "clusters",
-                            ":culster_id",
-                            "consumer-groups",
-                            ":group_id",
-                            "consumers",
-                            ":consumer_id",
-                            "assignments"
-                          ],
-                          "variable": [
-                            {
-                              "key": "culster_id",
-                              "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                            },
-                            {
-                              "key": "group_id",
-                              "value": "nlp-01"
-                            },
-                            {
-                              "key": "consumer_id",
-                              "value": null
-                            }
-                          ]
-                        }
-                      },
-                      "response": []
-                    },
-                    {
-                      "name": "assignment",
-                      "request": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                          "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:culster_id/consumer-groups/:group_id/consumers/:consumer_id/assignments/:topic_name/partitions/:partition_id",
-                          "protocol": "{{scheme}}",
-                          "host": ["{{host}}"],
-                          "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                          "path": [
-                            "v3",
-                            "clusters",
-                            ":culster_id",
-                            "consumer-groups",
-                            ":group_id",
-                            "consumers",
-                            ":consumer_id",
-                            "assignments",
-                            ":topic_name",
-                            "partitions",
-                            ":partition_id"
-                          ],
-                          "variable": [
-                            {
-                              "key": "culster_id",
-                              "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                            },
-                            {
-                              "key": "group_id",
-                              "value": "nlp-01"
-                            },
-                            {
-                              "key": "consumer_id",
-                              "value": null
-                            },
-                            {
-                              "key": "topic_name",
-                              "value": null
-                            },
-                            {
-                              "key": "partition_id",
-                              "value": null
-                            }
-                          ]
-                        }
-                      },
-                      "response": []
-                    }
-                  ]
-                },
-                {
-                  "name": "all",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/consumer-groups",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                      "path": ["v3", "clusters", ":cluster_id", "consumer-groups"],
-                      "variable": [
-                        {
-                          "key": "cluster_id",
-                          "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "one",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:culster_id/consumer-groups/:group_id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                      "path": ["v3", "clusters", ":culster_id", "consumer-groups", ":group_id"],
-                      "variable": [
-                        {
-                          "key": "culster_id",
-                          "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                        },
-                        {
-                          "key": "group_id",
-                          "value": "nlp-01"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "consumers",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:culster_id/consumer-groups/:group_id/consumers",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                      "path": [
-                        "v3",
-                        "clusters",
-                        ":culster_id",
-                        "consumer-groups",
-                        ":group_id",
-                        "consumers"
-                      ],
-                      "variable": [
-                        {
-                          "key": "culster_id",
-                          "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                        },
-                        {
-                          "key": "group_id",
-                          "value": "nlp-01"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "lag-summary",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:culster_id/consumer-groups/:group_id/lag-summary",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                      "path": [
-                        "v3",
-                        "clusters",
-                        ":culster_id",
-                        "consumer-groups",
-                        ":group_id",
-                        "lag-summary"
-                      ],
-                      "variable": [
-                        {
-                          "key": "culster_id",
-                          "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                        },
-                        {
-                          "key": "group_id",
-                          "value": "nlp-01"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "lags",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:culster_id/consumer-groups/:group_id/lags",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                      "path": [
-                        "v3",
-                        "clusters",
-                        ":culster_id",
-                        "consumer-groups",
-                        ":group_id",
-                        "lags"
-                      ],
-                      "variable": [
-                        {
-                          "key": "culster_id",
-                          "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                        },
-                        {
-                          "key": "group_id",
-                          "value": "nlp-01"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "lags/:topic_name",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:culster_id/consumer-groups/:group_id/lags/:topic_name/partitions/:partition_id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                      "path": [
-                        "v3",
-                        "clusters",
-                        ":culster_id",
-                        "consumer-groups",
-                        ":group_id",
-                        "lags",
-                        ":topic_name",
-                        "partitions",
-                        ":partition_id"
-                      ],
-                      "variable": [
-                        {
-                          "key": "culster_id",
-                          "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                        },
-                        {
-                          "key": "group_id",
-                          "value": "nlp-01"
-                        },
-                        {
-                          "key": "topic_name",
-                          "value": null
-                        },
-                        {
-                          "key": "partition_id",
-                          "value": null
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "topics",
-              "item": [
-                {
-                  "name": "all",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                      "path": ["v3", "clusters", ":cluster_id", "topics"],
-                      "variable": [
-                        {
-                          "key": "cluster_id",
-                          "value": "wGfL7FzuT-6n5YpvPvHoow"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "one",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics/:topic_name",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                      "path": ["v3", "clusters", ":cluster_id", "topics", ":topic_name"],
-                      "variable": [
-                        {
-                          "key": "cluster_id",
-                          "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                        },
-                        {
-                          "key": "topic_name",
-                          "value": "test"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "add",
-                  "request": {
-                    "method": "POST",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "{\r\n    \"topic_name\": \"elastic-logs\",\r\n    \"partitions_count\": 3,\r\n    \"replication_factor\": 1,\r\n    \"configs\": [\r\n        {\r\n            \"name\": \"cleanup.policy\",\r\n            \"value\": \"compact\"\r\n        },\r\n        {\r\n            \"name\": \"compression.type\",\r\n            \"value\": \"gzip\"\r\n        }\r\n    ]\r\n}",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                      "path": ["v3", "clusters", ":cluster_id", "topics"],
-                      "variable": [
-                        {
-                          "key": "cluster_id",
-                          "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "delete",
-                  "request": {
-                    "method": "DELETE",
-                    "header": [],
-                    "body": {
-                      "mode": "raw",
-                      "raw": "",
-                      "options": {
-                        "raw": {
-                          "language": "json"
-                        }
-                      }
-                    },
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics/:topic_name",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                      "path": ["v3", "clusters", ":cluster_id", "topics", ":topic_name"],
-                      "variable": [
-                        {
-                          "key": "cluster_id",
-                          "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                        },
-                        {
-                          "key": "topic_name",
-                          "value": "test"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "partitions",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics/:topic_name/partitions",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                      "path": [
-                        "v3",
-                        "clusters",
-                        ":cluster_id",
-                        "topics",
-                        ":topic_name",
-                        "partitions"
-                      ],
-                      "variable": [
-                        {
-                          "key": "cluster_id",
-                          "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                        },
-                        {
-                          "key": "topic_name",
-                          "value": "test"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "partitions/:id",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics/:topic_name/partitions/:partition_id",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                      "path": [
-                        "v3",
-                        "clusters",
-                        ":cluster_id",
-                        "topics",
-                        ":topic_name",
-                        "partitions",
-                        ":partition_id"
-                      ],
-                      "variable": [
-                        {
-                          "key": "cluster_id",
-                          "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                        },
-                        {
-                          "key": "topic_name",
-                          "value": "test"
-                        },
-                        {
-                          "key": "partition_id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": "reassignment",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics/-/partitions/-/reassignment",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                      "path": [
-                        "v3",
-                        "clusters",
-                        ":cluster_id",
-                        "topics",
-                        "-",
-                        "partitions",
-                        "-",
-                        "reassignment"
-                      ],
-                      "variable": [
-                        {
-                          "key": "cluster_id",
-                          "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": ":id/reassignment",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics/:topic_name/partitions/-/reassignment",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                      "path": [
-                        "v3",
-                        "clusters",
-                        ":cluster_id",
-                        "topics",
-                        ":topic_name",
-                        "partitions",
-                        "-",
-                        "reassignment"
-                      ],
-                      "variable": [
-                        {
-                          "key": "cluster_id",
-                          "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                        },
-                        {
-                          "key": "topic_name",
-                          "value": "nlp"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                },
-                {
-                  "name": ":id/reassignment",
-                  "request": {
-                    "method": "GET",
-                    "header": [],
-                    "url": {
-                      "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics/:topic_name/partitions/:partition_id/reassignment",
-                      "protocol": "{{scheme}}",
-                      "host": ["{{host}}"],
-                      "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                      "path": [
-                        "v3",
-                        "clusters",
-                        ":cluster_id",
-                        "topics",
-                        ":topic_name",
-                        "partitions",
-                        ":partition_id",
-                        "reassignment"
-                      ],
-                      "variable": [
-                        {
-                          "key": "cluster_id",
-                          "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                        },
-                        {
-                          "key": "topic_name",
-                          "value": "nlp"
-                        },
-                        {
-                          "key": "partition_id",
-                          "value": "1"
-                        }
-                      ]
-                    }
-                  },
-                  "response": []
-                }
-              ]
-            },
-            {
-              "name": "clusters",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["v3", "clusters"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "clusters/:id",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:id",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{host}}"],
-                  "port": "{{kafka-rest-port}}{{kafka-rest-path}}",
-                  "path": ["v3", "clusters", ":id"],
-                  "variable": [
-                    {
-                      "key": "id",
-                      "value": "Dja5AfDJTH-rMtXW1we-Ag"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "nlp",
-      "item": [
-        {
-          "name": "health",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{scheme}}://{{host}}:{{nlp-port}}/health",
-              "protocol": "{{scheme}}",
-              "host": ["{{host}}"],
-              "port": "{{nlp-port}}",
-              "path": ["health"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "pause",
-          "request": {
-            "method": "PUT",
-            "header": [],
-            "url": {
-              "raw": "{{scheme}}://{{host}}:{{nlp-port}}/pause",
-              "protocol": "{{scheme}}",
-              "host": ["{{host}}"],
-              "port": "{{nlp-port}}",
-              "path": ["pause"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "resume",
-          "request": {
-            "method": "PUT",
-            "header": [],
-            "url": {
-              "raw": "{{scheme}}://{{host}}:{{nlp-port}}/resume",
-              "protocol": "{{scheme}}",
-              "host": ["{{host}}"],
-              "port": "{{nlp-port}}",
-              "path": ["resume"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "stop",
-          "request": {
-            "method": "PUT",
-            "header": [],
-            "url": {
-              "raw": "{{scheme}}://{{host}}:{{nlp-port}}/stop",
-              "protocol": "{{scheme}}",
-              "host": ["{{host}}"],
-              "port": "{{nlp-port}}",
-              "path": ["stop"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "start",
-          "request": {
-            "method": "PUT",
-            "header": [],
-            "url": {
-              "raw": "{{scheme}}://{{host}}:{{nlp-port}}/start",
-              "protocol": "{{scheme}}",
-              "host": ["{{host}}"],
-              "port": "{{nlp-port}}",
-              "path": ["start"]
-            }
-          },
-          "response": []
-        }
-      ],
-      "auth": {
-        "type": "noauth"
-      },
-      "event": [
-        {
-          "listen": "prerequest",
-          "script": {
-            "type": "text/javascript",
-            "exec": [""]
-          }
-        },
-        {
-          "listen": "test",
-          "script": {
-            "type": "text/javascript",
-            "exec": [""]
-          }
-        }
-      ]
-    },
-    {
-      "name": "elasticsearch",
-      "item": [
-        {
-          "name": "indices",
-          "item": [
-            {
-              "name": "indices",
-              "request": {
-                "auth": {
-                  "type": "basic",
-                  "basic": [
-                    {
-                      "key": "password",
-                      "value": "{{elastic-password}}",
-                      "type": "string"
-                    },
-                    {
-                      "key": "username",
-                      "value": "{{elastic-username}}",
-                      "type": "string"
-                    }
-                  ]
-                },
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{elastic-host}}:{{elastic-port}}{{elastic-path}}/_cat/indices/*?v&s=index",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{elastic-host}}"],
-                  "port": "{{elastic-port}}{{elastic-path}}",
-                  "path": ["_cat", "indices", "*"],
-                  "query": [
-                    {
-                      "key": "v",
-                      "value": null
-                    },
-                    {
-                      "key": "s",
-                      "value": "index"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "indexes",
-          "item": [
-            {
-              "name": ":id",
-              "request": {
-                "auth": {
-                  "type": "basic",
-                  "basic": [
-                    {
-                      "key": "password",
-                      "value": "{{elastic-password}}",
-                      "type": "string"
-                    },
-                    {
-                      "key": "username",
-                      "value": "{{elastic-username}}",
-                      "type": "string"
-                    }
-                  ]
-                },
-                "method": "PUT",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"settings\":{\r\n        \"index\":{\r\n            \"number_of_shards\": 1,\r\n            \"number_of_replicas\": 1\r\n        }\r\n    },\r\n    \"mappings\": {\r\n        \"properties\": {\r\n            \"type\": { \"type\": \"keyword\" },\r\n            \"language\": { \"type\": \"keyword\" },\r\n            \"title\": { \"type\": \"text\" },\r\n            \"copyright\":{ \"type\": \"text\", \"index\": false },\r\n            \"author\": { \"type\": \"text\" },\r\n            \"summary\": { \"type\": \"text\" },\r\n            \"publishedOn\": { \"type\": \"date\" },\r\n            \"updatedOn\": { \"type\": \"date\" },\r\n            \"kafka\": {\r\n                \"type\": \"object\",\r\n                \"properties\": {\r\n                    \"topic\": { \"type\": \"keyword\", \"index\": false },\r\n                    \"offset\": { \"type\": \"long\", \"index\": false },\r\n                    \"partition\": { \"type\": \"integer\", \"index\": false }\r\n                }\r\n            },\r\n            \"source\": {\r\n                \"type\": \"object\",\r\n                \"properties\": {\r\n                    \"name\": { \"type\": \"keyword\" },\r\n                    \"uid\": { \"type\": \"keyword\", \"index\": false },\r\n                    \"link\": { \"type\": \"keyword\", \"index\": false },\r\n                    \"filePath\": { \"type\": \"keyword\", \"index\": false },\r\n                    \"streamUrl\": { \"type\": \"keyword\", \"index\": false }\r\n                }\r\n            },\r\n            \"tags\": {\r\n                \"type\": \"nested\",\r\n                \"properties\": {\r\n                    \"key\": { \"type\": \"keyword\" },\r\n                    \"value\": { \"type\": \"text\" }\r\n                }\r\n            }\r\n        }\r\n    }\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{scheme}}://{{elastic-host}}:{{elastic-port}}{{elastic-path}}/:id",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{elastic-host}}"],
-                  "port": "{{elastic-port}}{{elastic-path}}",
-                  "path": [":id"],
-                  "variable": [
-                    {
-                      "key": "id",
-                      "value": "test"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": ":id",
-              "request": {
-                "auth": {
-                  "type": "basic",
-                  "basic": [
-                    {
-                      "key": "password",
-                      "value": "{{elastic-password}}",
-                      "type": "string"
-                    },
-                    {
-                      "key": "username",
-                      "value": "{{elastic-username}}",
-                      "type": "string"
-                    }
-                  ]
-                },
-                "method": "DELETE",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{elastic-host}}:{{elastic-port}}{{elastic-path}}/:id",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{elastic-host}}"],
-                  "port": "{{elastic-port}}{{elastic-path}}",
-                  "path": [":id"],
-                  "variable": [
-                    {
-                      "key": "id",
-                      "value": "story"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "home",
-          "request": {
-            "auth": {
-              "type": "basic",
-              "basic": [
-                {
-                  "key": "password",
-                  "value": "{{elastic-password}}",
-                  "type": "string"
-                },
-                {
-                  "key": "username",
-                  "value": "{{elastic-username}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{scheme}}://{{elastic-host}}:{{elastic-port}}{{elastic-path}}",
-              "protocol": "{{scheme}}",
-              "host": ["{{elastic-host}}"],
-              "port": "{{elastic-port}}{{elastic-path}}"
-            }
-          },
-          "response": [
-            {
-              "name": "home",
-              "originalRequest": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{scheme}}://{{elastic-host}}:{{elastic-port}}{{elastic-path}}",
-                  "protocol": "{{scheme}}",
-                  "host": ["{{elastic-host}}"],
-                  "port": "{{elastic-port}}{{elastic-path}}"
-                }
-              },
-              "status": "OK",
-              "code": 200,
-              "_postman_previewlanguage": "json",
-              "header": [
-                {
-                  "key": "X-elastic-product",
-                  "value": "Elasticsearch"
-                },
-                {
-                  "key": "content-type",
-                  "value": "application/json; charset=UTF-8"
-                },
-                {
-                  "key": "content-encoding",
-                  "value": "gzip"
-                },
-                {
-                  "key": "content-length",
-                  "value": "326"
-                }
-              ],
-              "cookie": [],
-              "body": "{\n    \"name\": \"tno\",\n    \"cluster_name\": \"tno-es-cluster\",\n    \"cluster_uuid\": \"0WYCrEAZSg-aDYboOS2FDA\",\n    \"version\": {\n        \"number\": \"7.15.0\",\n        \"build_flavor\": \"default\",\n        \"build_type\": \"docker\",\n        \"build_hash\": \"79d65f6e357953a5b3cbcc5e2c7c21073d89aa29\",\n        \"build_date\": \"2021-09-16T03:05:29.143308416Z\",\n        \"build_snapshot\": false,\n        \"lucene_version\": \"8.9.0\",\n        \"minimum_wire_compatibility_version\": \"6.8.0\",\n        \"minimum_index_compatibility_version\": \"6.0.0-beta1\"\n    },\n    \"tagline\": \"You Know, for Search\"\n}"
-            }
-          ]
-        },
-        {
-          "name": "health",
-          "request": {
-            "auth": {
-              "type": "basic",
-              "basic": [
-                {
-                  "key": "password",
-                  "value": "{{elastic-password}}",
-                  "type": "string"
-                },
-                {
-                  "key": "username",
-                  "value": "{{elastic-username}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{scheme}}://{{elastic-host}}:{{elastic-port}}{{elastic-path}}/_cat/health",
-              "protocol": "{{scheme}}",
-              "host": ["{{elastic-host}}"],
-              "port": "{{elastic-port}}{{elastic-path}}",
-              "path": ["_cat", "health"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "cat",
-          "request": {
-            "auth": {
-              "type": "basic",
-              "basic": [
-                {
-                  "key": "password",
-                  "value": "{{elastic-password}}",
-                  "type": "string"
-                },
-                {
-                  "key": "username",
-                  "value": "{{elastic-username}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{scheme}}://{{elastic-host}}:{{elastic-port}}{{elastic-path}}/_cat",
-              "protocol": "{{scheme}}",
-              "host": ["{{elastic-host}}"],
-              "port": "{{elastic-port}}{{elastic-path}}",
-              "path": ["_cat"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "nodes",
-          "request": {
-            "auth": {
-              "type": "basic",
-              "basic": [
-                {
-                  "key": "password",
-                  "value": "{{elastic-password}}",
-                  "type": "string"
-                },
-                {
-                  "key": "username",
-                  "value": "{{elastic-username}}",
-                  "type": "string"
-                }
-              ]
-            },
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{scheme}}://{{elastic-host}}:{{elastic-port}}{{elastic-path}}/_cat/nodes",
-              "protocol": "{{scheme}}",
-              "host": ["{{elastic-host}}"],
-              "port": "{{elastic-port}}{{elastic-path}}",
-              "path": ["_cat", "nodes"]
-            }
-          },
-          "response": []
-        }
-      ]
-    }
-  ],
-  "auth": {
-    "type": "bearer",
-    "bearer": [
-      {
-        "key": "token",
-        "value": "{{access-token}}",
-        "type": "string"
-      }
-    ]
-  },
-  "event": [
-    {
-      "listen": "prerequest",
-      "script": {
-        "type": "text/javascript",
-        "exec": [""]
-      }
-    },
-    {
-      "listen": "test",
-      "script": {
-        "type": "text/javascript",
-        "exec": [""]
-      }
-    }
-  ]
+	"info": {
+		"_postman_id": "561164e7-8ec2-4d90-a35b-f823a9cc68da",
+		"name": "TNO",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "auth",
+			"item": [
+				{
+					"name": "token: service-account",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);\r",
+									"postman.setEnvironmentVariable(\"access-token\", jsonData.access_token);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "client_id",
+									"value": "tno-service-account",
+									"type": "text"
+								},
+								{
+									"key": "grant_type",
+									"value": "client_credentials",
+									"type": "text"
+								},
+								{
+									"key": "audience",
+									"value": "tno-service-account",
+									"type": "text"
+								},
+								{
+									"key": "client_secret",
+									"value": "{{service-account-secret}}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{keycloak-scheme}}://{{keycloak-host}}:{{keycloak-port}}/auth/realms/{{realm}}/protocol/openid-connect/token",
+							"protocol": "{{keycloak-scheme}}",
+							"host": [
+								"{{keycloak-host}}"
+							],
+							"port": "{{keycloak-port}}",
+							"path": [
+								"auth",
+								"realms",
+								"{{realm}}",
+								"protocol",
+								"openid-connect",
+								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "token: test user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setEnvironmentVariable(\"access-token\", jsonData.access_token);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "client_id",
+									"value": "tno-test",
+									"type": "text"
+								},
+								{
+									"key": "grant_type",
+									"value": "password",
+									"type": "text"
+								},
+								{
+									"key": "username",
+									"value": "{{test-username}}",
+									"type": "text"
+								},
+								{
+									"key": "password",
+									"value": "{{test-password}}",
+									"type": "text"
+								},
+								{
+									"key": "client_secret",
+									"value": "{{test-secret}}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{keycloak-scheme}}://{{keycloak-host}}:{{keycloak-port}}/auth/realms/{{realm}}/protocol/openid-connect/token",
+							"protocol": "{{keycloak-scheme}}",
+							"host": [
+								"{{keycloak-host}}"
+							],
+							"port": "{{keycloak-port}}",
+							"path": [
+								"auth",
+								"realms",
+								"{{realm}}",
+								"protocol",
+								"openid-connect",
+								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "userinfo",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{keycloak-scheme}}://{{keycloak-host}}:{{keycloak-port}}/auth/realms/{{realm}}/protocol/openid-connect/userinfo",
+							"protocol": "{{keycloak-scheme}}",
+							"host": [
+								"{{keycloak-host}}"
+							],
+							"port": "{{keycloak-port}}",
+							"path": [
+								"auth",
+								"realms",
+								"{{realm}}",
+								"protocol",
+								"openid-connect",
+								"userinfo"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "open id connect endpoints Copy",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{keycloak-scheme}}://{{keycloak-host}}:{{keycloak-port}}/auth/realms/{{realm}}/.well-known/openid-configuration",
+							"protocol": "{{keycloak-scheme}}",
+							"host": [
+								"{{keycloak-host}}"
+							],
+							"port": "{{keycloak-port}}",
+							"path": [
+								"auth",
+								"realms",
+								"{{realm}}",
+								".well-known",
+								"openid-configuration"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "azure",
+			"item": [
+				{
+					"name": "video-analyzer",
+					"item": [
+						{
+							"name": "videos",
+							"item": [
+								{
+									"name": "list",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Ocp-Apim-Subscription-Key",
+												"value": "{{azure-video-subscription-key}}",
+												"type": "text"
+											},
+											{
+												"key": "x-ms-client-request-id",
+												"value": "",
+												"description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
+												"type": "text",
+												"disabled": true
+											}
+										],
+										"url": {
+											"raw": "https://api.videoindexer.ai/{{azure-video-location}}/accounts/{{azure-video-account-id}}/videos?pageSize=25&skip=0",
+											"protocol": "https",
+											"host": [
+												"api",
+												"videoindexer",
+												"ai"
+											],
+											"path": [
+												"{{azure-video-location}}",
+												"accounts",
+												"{{azure-video-account-id}}",
+												"videos"
+											],
+											"query": [
+												{
+													"key": "createdAfter",
+													"value": "",
+													"disabled": true
+												},
+												{
+													"key": "createdBefore",
+													"value": "",
+													"disabled": true
+												},
+												{
+													"key": "pageSize",
+													"value": "25"
+												},
+												{
+													"key": "skip",
+													"value": "0"
+												},
+												{
+													"key": "accessToken",
+													"value": "{{azure-video-access-token}}",
+													"disabled": true
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "thumbnail",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Ocp-Apim-Subscription-Key",
+												"value": "{{azure-video-subscription-key}}",
+												"type": "text"
+											},
+											{
+												"key": "x-ms-client-request-id",
+												"value": "",
+												"description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
+												"type": "text",
+												"disabled": true
+											}
+										],
+										"url": {
+											"raw": "https://api.videoindexer.ai/{{azure-video-location}}/accounts/{{azure-video-account-id}}/videos/:videoId/Thumnails/:thumbnailId",
+											"protocol": "https",
+											"host": [
+												"api",
+												"videoindexer",
+												"ai"
+											],
+											"path": [
+												"{{azure-video-location}}",
+												"accounts",
+												"{{azure-video-account-id}}",
+												"videos",
+												":videoId",
+												"Thumnails",
+												":thumbnailId"
+											],
+											"query": [
+												{
+													"key": "accessToken",
+													"value": "{{azure-video-access-token}}",
+													"disabled": true
+												}
+											],
+											"variable": [
+												{
+													"key": "videoId",
+													"value": "e2228a52d9"
+												},
+												{
+													"key": "thumbnailId",
+													"value": "00000000-0000-0000-0000-000000000000"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "captions",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Ocp-Apim-Subscription-Key",
+												"value": "{{azure-video-subscription-key}}",
+												"type": "text"
+											},
+											{
+												"key": "x-ms-client-request-id",
+												"value": "",
+												"description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
+												"type": "text",
+												"disabled": true
+											}
+										],
+										"url": {
+											"raw": "https://api.videoindexer.ai/{{azure-video-location}}/accounts/{{azure-video-account-id}}/videos/:videoId/Captions?format=Txt&language=en-US&includeAudioEffects=false",
+											"protocol": "https",
+											"host": [
+												"api",
+												"videoindexer",
+												"ai"
+											],
+											"path": [
+												"{{azure-video-location}}",
+												"accounts",
+												"{{azure-video-account-id}}",
+												"videos",
+												":videoId",
+												"Captions"
+											],
+											"query": [
+												{
+													"key": "accessToken",
+													"value": "{{azure-video-access-token}}",
+													"disabled": true
+												},
+												{
+													"key": "indexId",
+													"value": "",
+													"description": "The video id",
+													"disabled": true
+												},
+												{
+													"key": "format",
+													"value": "Txt",
+													"description": "The captions format. Allowed values: Vtt / Ttml / Srt / Txt / Csv"
+												},
+												{
+													"key": "language",
+													"value": "en-US",
+													"description": "The language of the captions. Supported languages: Serbian (Cyrillic): sr-Cyrl-RS, Serbian (Latin): sr-Latn-RS, Bosnian: bs-Latn, Chinese (Simplified): zh-Hans, Chinese (Traditional): zh-Hant, Filipino: fil-PH, English United Kingdom: en-GB, Fijian: en-FJ, English Australia: en-AU, Samoan: en-WS, English United States: en-US, Greek: el-GR, Spanish: es-ES, Spanish (Mexico): es-MX, Estonian: et-EE, Persian: fa-IR, Finnish: fi-FI, French (Canada): fr-CA, French: fr-FR, Haitian: fr-HT, Afrikaans: af-ZA, Arabic (Saudi Arabia): ar-SA, Arabic Syrian Arab Republic: ar-SY, Arabic (Palestinian Authority): ar-PS, Arabic (Qatar): ar-QA, Arabic Egypt: ar-EG, Arabic Modern Standard (Bahrain): ar-BH, Arabic (Oman): ar-OM, Arabic (Lebanon): ar-LB, Arabic (United Arab Emirates): ar-AE, Arabic (Kuwait): ar-KW, Arabic (Jordan): ar-JO, Arabic (Iraq): ar-IQ, Arabic (Israel): ar-IL, Danish: da-DK, German: de-DE, Bulgarian: bg-BG, Bangla: bn-BD, Malagasy: mg-MG, Malay: ms-MY, Maltese: mt-MT, Catalan: ca-ES, Czech: cs-CZ, Dutch: nl-NL, Norwegian: nb-NO, Indonesian: id-ID, Italian: it-IT, Lithuanian: lt-LT, Latvian: lv-LV, Japanese: ja-JP, Urdu: ur-PK, Ukrainian: uk-UA, Hindi: hi-IN, Hebrew: he-IL, Hungarian: hu-HU, Croatian: hr-HR, Korean: ko-KR, Vietnamese: vi-VN, Turkish: tr-TR, Tamil: ta-IN, Thai: th-TH, Tongan: to-TO, Russian: ru-RU, Romanian: ro-RO, Portuguese: pt-BR, Polish: pl-PL, Swedish: sv-SE, Kiswahili: sw-KE, Slovenian: sl-SI, Slovak: sk-SK, Chinese (Cantonese, Traditional): zh-HK."
+												},
+												{
+													"key": "includeAudioEffects",
+													"value": "false",
+													"description": "Include audio effects"
+												}
+											],
+											"variable": [
+												{
+													"key": "videoId",
+													"value": "e2228a52d9"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "player-widget",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Ocp-Apim-Subscription-Key",
+												"value": "{{azure-video-subscription-key}}",
+												"type": "text"
+											},
+											{
+												"key": "x-ms-client-request-id",
+												"value": "",
+												"description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
+												"type": "text",
+												"disabled": true
+											}
+										],
+										"url": {
+											"raw": "https://api.videoindexer.ai/{{azure-video-location}}/accounts/{{azure-video-account-id}}/videos/:videoId/PlayerWidget",
+											"protocol": "https",
+											"host": [
+												"api",
+												"videoindexer",
+												"ai"
+											],
+											"path": [
+												"{{azure-video-location}}",
+												"accounts",
+												"{{azure-video-account-id}}",
+												"videos",
+												":videoId",
+												"PlayerWidget"
+											],
+											"query": [
+												{
+													"key": "accessToken",
+													"value": "{{azure-video-access-token}}",
+													"disabled": true
+												}
+											],
+											"variable": [
+												{
+													"key": "videoId",
+													"value": "e2228a52d9"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "stream-url",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Ocp-Apim-Subscription-Key",
+												"value": "{{azure-video-subscription-key}}",
+												"type": "text"
+											},
+											{
+												"key": "x-ms-client-request-id",
+												"value": "",
+												"description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
+												"type": "text",
+												"disabled": true
+											}
+										],
+										"url": {
+											"raw": "https://api.videoindexer.ai/{{azure-video-location}}/accounts/{{azure-video-account-id}}/videos/:videoId/streaming-url",
+											"protocol": "https",
+											"host": [
+												"api",
+												"videoindexer",
+												"ai"
+											],
+											"path": [
+												"{{azure-video-location}}",
+												"accounts",
+												"{{azure-video-account-id}}",
+												"videos",
+												":videoId",
+												"streaming-url"
+											],
+											"query": [
+												{
+													"key": "accessToken",
+													"value": "{{azure-video-access-token}}",
+													"disabled": true
+												},
+												{
+													"key": "useProxy",
+													"value": "",
+													"description": "\nWrap the streaming endpoint with proxy. Required for delivering content to Safari browsers. <a href=https://azure.microsoft.com/en-us/blog/how-to-make-token-authorized-aes-encrypted-hls-stream-working-in-safari/ /a>",
+													"disabled": true
+												},
+												{
+													"key": "urlFormat",
+													"value": "SMOOTH_STREAMING_FORMAT",
+													"description": "Streaming URL format.. Allowed values: SMOOTH_STREAMING_FORMAT / MPEG_DASH / HLS_V4 / HLS_V3",
+													"disabled": true
+												},
+												{
+													"key": "tokenLifetimeInMinutes",
+													"value": "",
+													"description": "Format - int32. Streaming URL token lifetime in minutes. Value must be positive. Default is 60 minutes",
+													"disabled": true
+												}
+											],
+											"variable": [
+												{
+													"key": "videoId",
+													"value": "e2228a52d9"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "upload",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Ocp-Apim-Subscription-Key",
+												"value": "{{azure-video-subscription-key}}",
+												"type": "text"
+											},
+											{
+												"key": "x-ms-client-request-id",
+												"value": "",
+												"description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
+												"type": "text",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "formdata",
+											"formdata": [
+												{
+													"key": "",
+													"type": "file",
+													"src": "/C:/Users/jfoster/Downloads/Recording.m4a"
+												}
+											]
+										},
+										"url": {
+											"raw": "https://api.videoindexer.ai/{{azure-video-location}}/accounts/{{azure-video-account-id}}/videos?name=test&privacy=Private&description=test&language=en-US&streamingPreset=Default&sendSuccessEmail=true&fileName",
+											"protocol": "https",
+											"host": [
+												"api",
+												"videoindexer",
+												"ai"
+											],
+											"path": [
+												"{{azure-video-location}}",
+												"accounts",
+												"{{azure-video-account-id}}",
+												"videos"
+											],
+											"query": [
+												{
+													"key": "accessToken",
+													"value": "{{azure-video-access-token}}",
+													"disabled": true
+												},
+												{
+													"key": "name",
+													"value": "test",
+													"description": "The video name"
+												},
+												{
+													"key": "privacy",
+													"value": "Private",
+													"description": "The video privacy mode. Allowed values: Private / Public"
+												},
+												{
+													"key": "priority",
+													"value": "High",
+													"description": "Index priority, can be used in paid regions only. Allowed values: Low / Normal / High",
+													"disabled": true
+												},
+												{
+													"key": "description",
+													"value": "test",
+													"description": "The video description."
+												},
+												{
+													"key": "partition",
+													"value": "",
+													"description": "A partition to partition videos by (used for searching a specific partition)",
+													"disabled": true
+												},
+												{
+													"key": "externalId",
+													"value": "",
+													"description": "An external id to associate with the video (can be searched for later).",
+													"disabled": true
+												},
+												{
+													"key": "externalUrl",
+													"value": "",
+													"description": "Format - uri. An external URL to associate with the video (can be retrieved later)",
+													"disabled": true
+												},
+												{
+													"key": "callbackUrl",
+													"value": "",
+													"description": "Format - uri. A url to send notifications to (POST). These are the supported notifications:\n\nVideo indexing completed: 2 additional query string parameters will be added to the url: id and state.\n\nFor example, if the callback url is 'https://test.com/notifyme?projectName=MyProject', the notification will be sent to 'https://test.com/notifyme?projectName=MyProject&id=12345abcde&state=Processed'.\n\nA face was identified (after the face was trained in another video): 4 additional query string parameters will be added to the url: id, faceId, knownPersonId and personName.\n\nFor example, if the callback url is 'https://test.com/notifyme?projectName=MyProject', the notification will be sent to 'https://test.com/notifyme?projectName=MyProject&id=12345abcde&faceId=1234&knownPersonId=B689EC08-FAB6-497A-A727-DA7285DBD436&personName=JohnSmith'.",
+													"disabled": true
+												},
+												{
+													"key": "metadata",
+													"value": "",
+													"description": "Metadata to associate with the video (will be returned in queries).",
+													"disabled": true
+												},
+												{
+													"key": "language",
+													"value": "en-US",
+													"description": "The language of the video, to be used when generating the transcript: Auto-detect single language - 'auto', Auto-detect multi language (preview) - 'multi'.. Supported languages: Chinese (Simplified): zh-Hans, English United Kingdom: en-GB, English Australia: en-AU, English United States: en-US, Spanish: es-ES, Spanish (Mexico): es-MX, Finnish: fi-FI, French (Canada): fr-CA, French: fr-FR, Arabic (Saudi Arabia): ar-SA, Arabic Syrian Arab Republic: ar-SY, Arabic (Palestinian Authority): ar-PS, Arabic (Qatar): ar-QA, Arabic Egypt: ar-EG, Arabic Modern Standard (Bahrain): ar-BH, Arabic (Oman): ar-OM, Arabic (Lebanon): ar-LB, Arabic (United Arab Emirates): ar-AE, Arabic (Kuwait): ar-KW, Arabic (Jordan): ar-JO, Arabic (Iraq): ar-IQ, Arabic (Israel): ar-IL, Danish: da-DK, German: de-DE, Czech: cs-CZ, Dutch: nl-NL, Norwegian: nb-NO, Italian: it-IT, Japanese: ja-JP, Hindi: hi-IN, Korean: ko-KR, Turkish: tr-TR, Thai: th-TH, Russian: ru-RU, Portuguese: pt-BR, Polish: pl-PL, Swedish: sv-SE, Chinese (Cantonese, Traditional): zh-HK."
+												},
+												{
+													"key": "videoUrl",
+													"value": "",
+													"description": "Format - uri. A public url of the video/audio file (url encoded). It is recommended to use readonly urls (e.g. when using Azure Storage SAS urls). If not specified, the file should be passed as a multipart/form body content.",
+													"disabled": true
+												},
+												{
+													"key": "indexingPreset",
+													"value": "",
+													"description": "The indexing preset to use. Allowed values: Default / AudioOnly / VideoOnly / BasicAudio / Advanced / AdvancedAudio / AdvancedVideo",
+													"disabled": true
+												},
+												{
+													"key": "streamingPreset",
+													"value": "Default",
+													"description": "The streaming preset to use. Allowed values: NoStreaming / Default / SingleBitrate / AdaptiveBitrate"
+												},
+												{
+													"key": "linguisticModelId",
+													"value": "",
+													"description": "Linguistic model id as received by 'create linguistic model' call",
+													"disabled": true
+												},
+												{
+													"key": "personModelId",
+													"value": "",
+													"description": "Faces will be identified against the provided person model.",
+													"disabled": true
+												},
+												{
+													"key": "animationModelId",
+													"value": "",
+													"description": "Animations will be identified against the provided animation model.",
+													"disabled": true
+												},
+												{
+													"key": "sendSuccessEmail",
+													"value": "true",
+													"description": "Indicates whether to send a success mail once video was succesfully indexed"
+												},
+												{
+													"key": "assetId",
+													"value": "",
+													"description": "Azure media services asset id. Used to index from existing assets in your connected Azure media services account. (Paid only)",
+													"disabled": true
+												},
+												{
+													"key": "brandsCategories",
+													"value": "",
+													"description": "List of brands categories delimited by comma. Azure Video Analyzer for Media will only take these categories in to account when indexing. If not specified all brands will be used.",
+													"disabled": true
+												},
+												{
+													"key": "fileName",
+													"value": null
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "access-token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"postman.setEnvironmentVariable(\"azure-video-access-token\", responseBody.replaceAll('\"', \"\"));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Ocp-Apim-Subscription-Key",
+										"value": "{{azure-video-subscription-key}}",
+										"type": "text"
+									},
+									{
+										"key": "x-ms-client-request-id",
+										"value": "",
+										"description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "https://api.videoindexer.ai/auth/{{azure-video-location}}/accounts/{{azure-video-account-id}}/accessToken?allowEdit=true",
+									"protocol": "https",
+									"host": [
+										"api",
+										"videoindexer",
+										"ai"
+									],
+									"path": [
+										"auth",
+										"{{azure-video-location}}",
+										"accounts",
+										"{{azure-video-account-id}}",
+										"accessToken"
+									],
+									"query": [
+										{
+											"key": "allowEdit",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "access-token-user",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"postman.setEnvironmentVariable(\"azure-video-access-token\", responseBody.replaceAll('\"', \"\"));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Ocp-Apim-Subscription-Key",
+										"value": "{{azure-video-subscription-key}}",
+										"type": "text"
+									},
+									{
+										"key": "x-ms-client-request-id",
+										"value": "",
+										"description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
+										"type": "text",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "https://api.videoindexer.ai/auth/{{azure-video-location}}/users/me/accessToken?allowEdit=true",
+									"protocol": "https",
+									"host": [
+										"api",
+										"videoindexer",
+										"ai"
+									],
+									"path": [
+										"auth",
+										"{{azure-video-location}}",
+										"users",
+										"me",
+										"accessToken"
+									],
+									"query": [
+										{
+											"key": "allowEdit",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "access-token-with-permission",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"postman.setEnvironmentVariable(\"azure-video-access-token\", responseBody.replaceAll('\"', \"\"));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Ocp-Apim-Subscription-Key",
+										"value": "{{azure-video-subscription-key}}",
+										"type": "text"
+									},
+									{
+										"key": "x-ms-client-request-id",
+										"value": "",
+										"description": "\nFormat - uuid. A globally unique identifier (GUID) for the request which can be sent by client for instrumentation purposes. The server makes sure all logs associated with handling the request can be linked to the client request id so a client can provide this request id in support tickets so support engineers could find the logs linked to this particular request, so avoid using the same request id for different requests, including in retry scenarios.",
+										"type": "text",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "https://api.videoindexer.ai/auth/{{azure-video-location}}/accounts/{{azure-video-account-id}}/accessTokenWithPermission?permission=Contributor",
+									"protocol": "https",
+									"host": [
+										"api",
+										"videoindexer",
+										"ai"
+									],
+									"path": [
+										"auth",
+										"{{azure-video-location}}",
+										"accounts",
+										"{{azure-video-account-id}}",
+										"accessTokenWithPermission"
+									],
+									"query": [
+										{
+											"key": "permission",
+											"value": "Contributor",
+											"description": "The requested permission. Allowed values: Reader (allows reading content) / Contributor (allows modifying content) / MyAccessAdministrator (allows managing the acting user's permission) / Owner (allows managing permissions and modifying content)"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"auth": {
+						"type": "bearer",
+						"bearer": [
+							{
+								"key": "token",
+								"value": "{{azure-video-access-token}}",
+								"type": "string"
+							}
+						]
+					},
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "api-editor",
+			"item": [
+				{
+					"name": "health",
+					"item": [
+						{
+							"name": "health",
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/health",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}{{root-path}}",
+									"path": [
+										"health"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "admin",
+					"item": [
+						{
+							"name": "actions",
+							"item": [
+								{
+									"name": "actions",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/actions",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"actions"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "actions/:id",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/actions/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"actions",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "actions",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/actions",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"actions"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "actions/:id",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/actions/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"actions",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "actions/:id",
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/actions/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"actions",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "categories",
+							"item": [
+								{
+									"name": "categories",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/categories",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"categories"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "categories/:id",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/categories/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"categories",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "categories",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/categories",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"categories"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "categories/:id",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/categories/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"categories",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "categories/:id",
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/categories/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"categories",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "claims",
+							"item": [
+								{
+									"name": "claims",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/claims",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"claims"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "claims/:id",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/claims/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"claims",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "claims",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/claims",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"claims"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "claims/:id",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/claims/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"claims",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "claims/:id",
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/claims/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"claims",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "content references",
+							"item": [
+								{
+									"name": "content/references",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/references",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"content",
+												"references"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "content/references/:source/:uid",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/references/:source/:uid",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"content",
+												"references",
+												":source",
+												":uid"
+											],
+											"variable": [
+												{
+													"key": "source",
+													"value": null
+												},
+												{
+													"key": "uid",
+													"value": null
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "content/references",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"source\": \"CJN\",\r\n    \"uid\": \"01\",\r\n    \"topic\": \"test\",\r\n    \"offset\": 0,\r\n    \"status\": 0\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/references",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"content",
+												"references"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "content/references/:source/:uid",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"source\": \"CJN\",\r\n    \"uid\": \"01\",\r\n    \"topic\": \"test\",\r\n    \"offset\": 0,\r\n    \"status\": 0\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/references/:source/:uid",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"content",
+												"references",
+												":source",
+												":uid"
+											],
+											"variable": [
+												{
+													"key": "source",
+													"value": null
+												},
+												{
+													"key": "uid",
+													"value": null
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "content/references/:source/:uid",
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"source\": \"CJN\",\r\n    \"uid\": \"01\",\r\n    \"topic\": \"test\",\r\n    \"offset\": 0,\r\n    \"status\": 0\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/references/:source/:uid",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"content",
+												"references",
+												":source",
+												":uid"
+											],
+											"variable": [
+												{
+													"key": "source",
+													"value": null
+												},
+												{
+													"key": "uid",
+													"value": null
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "content types",
+							"item": [
+								{
+									"name": "content/types",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/types",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"content",
+												"types"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "content/types/:id",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/types/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"content",
+												"types",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "content/types",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"name\": \"dst\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/types",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"content",
+												"types"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "content/types/:id",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"name\": \"dst\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/types/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"content",
+												"types",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "content/types/:id",
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"name\": \"dst\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/content/types/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"content",
+												"types",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": null
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "data sources",
+							"item": [
+								{
+									"name": "data/sources",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/data/sources",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"data",
+												"sources"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "data/sources/:id",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/data/sources/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"data",
+												"sources",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "data/sources",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"createdById\": \"616beebf-ce6c-4b28-bd5f-a32ceded524b\",\r\n    \"createdBy\": \"service-account-tno-service-account\",\r\n    \"createdOn\": \"2022-02-16T18:43:10.931+0000\",\r\n    \"updatedById\": \"00000000-0000-0000-0000-000000000000\",\r\n    \"updatedBy\": \"\",\r\n    \"updatedOn\": \"2022-02-16T18:43:10.931+0000\",\r\n    \"name\": \"The Canadian Jewish News\",\r\n    \"code\": \"CJN\",\r\n    \"description\": \"Daily breaking news, podcasts, newsletters and events that matter to the Canadian Jewish community.\",\r\n    \"enabled\": true,\r\n    \"mediaTypeId\": 1,\r\n    \"licenseId\": 1,\r\n    \"topic\": \"test\",\r\n    \"connection\": {\r\n        \"url\": \"https://thecjn.ca/feed/\"\r\n    },\r\n    \"parentId\": null,\r\n    \"dataSourceSchedules\": [\r\n    ]\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/data/sources",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"data",
+												"sources"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "data/sources/:id",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"createdById\": \"6531ca81-60a9-4c8d-8770-94fa41a70478\",\r\n    \"createdBy\": \"service-account-tno-service-account\",\r\n    \"createdOn\": \"2022-02-16T21:35:24.642+0000\",\r\n    \"updatedById\": \"6531ca81-60a9-4c8d-8770-94fa41a70478\",\r\n    \"updatedBy\": \"service-account-tno-service-account\",\r\n    \"updatedOn\": \"2022-02-16T21:35:24.642+0000\",\r\n    \"version\": 0,\r\n    \"id\": 1,\r\n    \"name\": \"The Canadian Jewish News\",\r\n    \"code\": \"CJN\",\r\n    \"description\": \"Daily breaking news, podcasts, newsletters and events that matter to the Canadian Jewish community.\",\r\n    \"enabled\": true,\r\n    \"mediaTypeId\": 1,\r\n    \"licenseId\": 1,\r\n    \"topic\": \"test\",\r\n    \"lastRanOn\": null,\r\n    \"connection\": {\r\n        \"url\": \"https://thecjn.ca/feed/\"\r\n    },\r\n    \"parentId\": null,\r\n    \"dataSourceSchedules\": [\r\n        {\r\n            \"createdById\": \"616beebf-ce6c-4b28-bd5f-a32ceded524b\",\r\n            \"createdBy\": \"service-account-tno-service-account\",\r\n            \"createdOn\": \"2022-02-16T19:54:56.119+0000\",\r\n            \"updatedById\": \"616beebf-ce6c-4b28-bd5f-a32ceded524b\",\r\n            \"updatedBy\": \"service-account-tno-service-account\",\r\n            \"updatedOn\": \"2022-02-16T19:54:56.119+0000\",\r\n            \"dataSourceId\": 1,\r\n            \"scheduleId\": 1\r\n        }\r\n    ]\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/data/sources/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"data",
+												"sources",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "data/sources/:id",
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"name\": \"The Canadian Jewish News\",\r\n    \"abbr\": \"CJN\",\r\n    \"description\": \"Daily breaking news, podcasts, newsletters and events that matter to the Canadian Jewish community.\",\r\n    \"isEnabled\": true,\r\n    \"typeId\": 1,\r\n    \"licenseId\": 1,\r\n    \"scheduleId\": 1,\r\n    \"topic\": \"test\",\r\n    \"connection\": {\r\n        \"url\": \"https://thecjn.ca/feed/\"\r\n    }\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/data/sources/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"data",
+												"sources",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "media types",
+							"item": [
+								{
+									"name": "media/types",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/media/types",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"media",
+												"types"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "media/types/:id",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/media/types/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"media",
+												"types",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "media/types",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"name\": \"dst\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/media/types",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"media",
+												"types"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "media/types/:id",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"name\": \"dst\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/media/types/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"media",
+												"types",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "media/types/:id",
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"name\": \"dst\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/media/types/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"media",
+												"types",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": null
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "licenses",
+							"item": [
+								{
+									"name": "licenses",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/licenses",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"licenses"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "data/sources/:id",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/licenses/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"licenses",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "licenses",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"name\": \"license\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/licenses",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"licenses"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "licenses/:id",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"name\": \"license\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/licenses/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"licenses",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "data/sources/:id",
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"name\": \"license\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/licenses/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"licenses",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "roles",
+							"item": [
+								{
+									"name": "roles",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/roles",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"roles"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "roles/:id",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/roles/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"roles",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "roles",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/roles",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"roles"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "roles/:id",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/roles/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"roles",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "roles/:id",
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/roles/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"roles",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "schedules",
+							"item": [
+								{
+									"name": "schedules",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/schedules",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"schedules"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "schedules/:id",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/schedules/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"schedules",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "schedules",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"name\": \"every 30 seconds\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true,\r\n    \"scheduleType\": 0,\r\n    \"delayMS\": 30000,\r\n    \"runOn\": null,\r\n    \"startAt\": null,\r\n    \"stopAt\": null,\r\n    \"repeat\": 0,\r\n    \"runOnWeekDays\": [0],\r\n    \"runOnMonths\": [0],\r\n    \"dayOfMonth\": 0\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/schedules",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"schedules"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "schedules/:id",
+									"protocolProfileBehavior": {
+										"disabledSystemHeaders": {}
+									},
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"createdById\": \"00000000-0000-0000-0000-000000000000\",\r\n    \"createdBy\": \"\",\r\n    \"createdOn\": \"2022-02-16T17:40:59.527+0000\",\r\n    \"updatedById\": \"616beebf-ce6c-4b28-bd5f-a32ceded524b\",\r\n    \"updatedBy\": \"service-account-tno-service-account\",\r\n    \"updatedOn\": \"2022-02-16T18:43:10.931+0000\",\r\n    \"version\": 2,\r\n    \"id\": 1,\r\n    \"name\": \"Continous - 60s\",\r\n    \"description\": \"test\",\r\n    \"enabled\": true,\r\n    \"scheduleType\": 0,\r\n    \"delayMS\": 60000,\r\n    \"runOn\": null,\r\n    \"startAt\": null,\r\n    \"stopAt\": null,\r\n    \"repeat\": 0,\r\n    \"runOnWeekDays\": [\r\n        0\r\n    ],\r\n    \"runOnMonths\": [\r\n        0\r\n    ],\r\n    \"dayOfMonth\": 0\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/schedules/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"schedules",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "schedules/:id",
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"name\": \"schedule\",\r\n    \"description\": \"\",\r\n    \"isEnabled\": true\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/schedules/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"schedules",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "series",
+							"item": [
+								{
+									"name": "series",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/series",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"series"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "series/:id",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/series/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"series",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "series",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"name\": \"Series 1\",\r\n    \"description\": \"description\",\r\n    \"isEnabled\": true,\r\n    \"sortOrder\": 0\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/series",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"series"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "series/:id",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/series/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"series",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "series/:id",
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/series/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"series",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "tags",
+							"item": [
+								{
+									"name": "tags",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tags",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"tags"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "tags/:id",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tags/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"tags",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "tags",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tags",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"tags"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "tags/:id",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tags/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"tags",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "tags/:id",
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tags/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"tags",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "tone pools",
+							"item": [
+								{
+									"name": "tone/pools",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tone/pools",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"tone",
+												"pools"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "tone/pools/:id",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tone/pools/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"tone",
+												"pools",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "tone/pools",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tone/pools",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"tone",
+												"pools"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "tone/pools/:id",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tone/pools/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"tone",
+												"pools",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "tone/pools/:id",
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/tone/pools/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"tone",
+												"pools",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "users",
+							"item": [
+								{
+									"name": "users",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/users",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"users"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "users/:id",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/users/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"users",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "users",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/users",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"users"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "users/:id",
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/users/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"users",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "users/:id",
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"username\": \"admin\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/admin/users/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"admin",
+												"users",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "editor",
+					"item": [
+						{
+							"name": "contents",
+							"item": [
+								{
+									"name": "find",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/contents?page=1&quantity=100&sort=mediaTypeId asc",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"editor",
+												"contents"
+											],
+											"query": [
+												{
+													"key": "page",
+													"value": "1"
+												},
+												{
+													"key": "quantity",
+													"value": "100"
+												},
+												{
+													"key": "mediaTypeId",
+													"value": "3",
+													"disabled": true
+												},
+												{
+													"key": "logicalOperator",
+													"value": "Equals",
+													"disabled": true
+												},
+												{
+													"key": "headline",
+													"value": "a",
+													"disabled": true
+												},
+												{
+													"key": "ownerId",
+													"value": "1",
+													"disabled": true
+												},
+												{
+													"key": "sort",
+													"value": "mediaTypeId asc"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "find/:id",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/contents/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"editor",
+												"contents",
+												":id"
+											],
+											"query": [
+												{
+													"key": "page",
+													"value": "1",
+													"disabled": true
+												},
+												{
+													"key": "quantity",
+													"value": "10",
+													"disabled": true
+												}
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "26"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "add",
+									"protocolProfileBehavior": {
+										"disabledSystemHeaders": {}
+									},
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"status\": 0,\r\n    \"contentTypeId\": 2,\r\n    \"headline\": \"test X\",\r\n    \"source\": \"source A\",\r\n    \"licenseId\": 2,\r\n    \"mediaTypeId\": 3,\r\n    \"page\": \"P1\",\r\n    \"section\": \"\",\r\n    \"summary\": \"summary\",\r\n    \"ownerId\": 1,\r\n    \"tags\": [\r\n        {\r\n            \"id\": \"TBD\"\r\n        }\r\n    ]\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/contents",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"editor",
+												"contents"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "add - with series",
+									"protocolProfileBehavior": {
+										"disabledSystemHeaders": {}
+									},
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"status\": 0,\r\n    \"contentTypeId\": 2,\r\n    \"headline\": \"test X\",\r\n    \"source\": \"source A\",\r\n    \"licenseId\": 2,\r\n    \"mediaTypeId\": 3,\r\n    \"page\": \"P1\",\r\n    \"section\": \"\",\r\n    \"summary\": \"summary\",\r\n    \"ownerId\": 1,\r\n    \"seriesId\": 1,\r\n    \"tags\": [\r\n        {\r\n            \"id\": \"TBD\"\r\n        }\r\n    ]\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/contents",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"editor",
+												"contents"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "add - with File",
+									"protocolProfileBehavior": {
+										"disabledSystemHeaders": {}
+									},
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"status\": 0,\r\n    \"contentTypeId\": 2,\r\n    \"headline\": \"test X\",\r\n    \"source\": \"source A\",\r\n    \"licenseId\": 2,\r\n    \"mediaTypeId\": 3,\r\n    \"page\": \"P1\",\r\n    \"section\": \"\",\r\n    \"summary\": \"summary\",\r\n    \"ownerId\": 1,\r\n    \"seriesId\": 1,\r\n    \"fileReferences\": [\r\n        {\r\n            \"mimeType\": \"audio\",\r\n            \"path\": \"some/path/file.mpg\",\r\n            \"size\": 4000,\r\n            \"runningTime\": 780000\r\n        }\r\n    ],\r\n    \"actions\": [\r\n        {\r\n            \"id\": 5,\r\n            \"value\": \"true\"\r\n        }, {\r\n            \"id\": 6,\r\n            \"value\": \"true\"\r\n        }\r\n    ],\r\n    \"tags\": [\r\n        {\r\n            \"id\": \"TBD\"\r\n        }\r\n    ]\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/contents",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"editor",
+												"contents"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "update",
+									"protocolProfileBehavior": {
+										"disabledSystemHeaders": {}
+									},
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"createdById\": \"616beebf-ce6c-4b28-bd5f-a32ceded524b\",\r\n    \"createdBy\": \"service-account-tno-service-account\",\r\n    \"createdOn\": \"2022-02-23T19:34:49.403+0000\",\r\n    \"updatedById\": \"616beebf-ce6c-4b28-bd5f-a32ceded524b\",\r\n    \"updatedBy\": \"service-account-tno-service-account\",\r\n    \"updatedOn\": \"2022-02-23T19:34:49.403+0000\",\r\n    \"version\": 0,\r\n    \"id\": 1,\r\n    \"status\": 0,\r\n    \"workflowStatus\": 0,\r\n    \"contentTypeId\": 2,\r\n    \"printContent\": null,\r\n    \"headline\": \"test X\",\r\n    \"dataSourceId\": null,\r\n    \"source\": \"source A\",\r\n    \"uid\": \"\",\r\n    \"licenseId\": 2,\r\n    \"mediaTypeId\": 2,\r\n    \"seriesId\": null,\r\n    \"page\": \"P1\",\r\n    \"publishedOn\": null,\r\n    \"summary\": \"summary\",\r\n    \"transcription\": \"\",\r\n    \"sourceURL\": \"\",\r\n    \"ownerId\": 2,\r\n    \"contentActions\": [],\r\n    \"contentCategories\": [],\r\n    \"contentTags\": [\r\n        {\r\n            \"createdById\": \"616beebf-ce6c-4b28-bd5f-a32ceded524b\",\r\n            \"createdBy\": \"service-account-tno-service-account\",\r\n            \"createdOn\": null,\r\n            \"updatedById\": \"616beebf-ce6c-4b28-bd5f-a32ceded524b\",\r\n            \"updatedBy\": \"service-account-tno-service-account\",\r\n            \"updatedOn\": null,\r\n            \"version\": 0,\r\n            \"contentId\": 1,\r\n            \"tagId\": \"TBD\"\r\n        }\r\n    ],\r\n    \"contentTones\": [],\r\n    \"timeTrackings\": [],\r\n    \"links\": [],\r\n    \"contentTonePools\": []\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/contents/:id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"editor",
+												"contents",
+												":id"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "actions",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/actions",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}{{root-path}}",
+									"path": [
+										"editor",
+										"actions"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "content/types",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/content/types",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}{{root-path}}",
+									"path": [
+										"editor",
+										"content",
+										"types"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "categories",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/categories",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}{{root-path}}",
+									"path": [
+										"editor",
+										"categories"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "media/types",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/media/types",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}{{root-path}}",
+									"path": [
+										"editor",
+										"media",
+										"types"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "series",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/series",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}{{root-path}}",
+									"path": [
+										"editor",
+										"series"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "tags",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/tags",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}{{root-path}}",
+									"path": [
+										"editor",
+										"tags"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "tone/pools",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/editor/tone/pools",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}{{root-path}}",
+									"path": [
+										"editor",
+										"tone",
+										"pools"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "reports",
+					"item": [
+						{
+							"name": "cbra",
+							"item": [
+								{
+									"name": "generate",
+									"protocolProfileBehavior": {
+										"disabledSystemHeaders": {}
+									},
+									"request": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/reports/cbra?from=2021-01-01T00:00:00",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"reports",
+												"cbra"
+											],
+											"query": [
+												{
+													"key": "to",
+													"value": null,
+													"disabled": true
+												},
+												{
+													"key": "from",
+													"value": "2021-01-01T00:00:00"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "elastic",
+					"item": [
+						{
+							"name": "info",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/elastic",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}{{root-path}}",
+									"path": [
+										"elastic"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "azure-storage",
+					"item": [
+						{
+							"name": "upload",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "key1",
+											"value": "value1",
+											"type": "text"
+										},
+										{
+											"key": "key2",
+											"value": "value2",
+											"type": "text"
+										},
+										{
+											"key": "file",
+											"type": "file",
+											"src": "/C:/Users/jfoster/Downloads/test.txt"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/azure/storage/upload",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}{{root-path}}",
+									"path": [
+										"azure",
+										"storage",
+										"upload"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "containers/:name",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "key1",
+											"value": "value1",
+											"type": "text"
+										},
+										{
+											"key": "key2",
+											"value": "value2",
+											"type": "text"
+										},
+										{
+											"key": "file",
+											"type": "file",
+											"src": "/C:/Users/jfoster/Downloads/test.txt"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/azure/storage/containers/:name",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}{{root-path}}",
+									"path": [
+										"azure",
+										"storage",
+										"containers",
+										":name"
+									],
+									"variable": [
+										{
+											"key": "name",
+											"value": "test-container3"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "download",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/azure/storage/download?file=test.txt",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}{{root-path}}",
+									"path": [
+										"azure",
+										"storage",
+										"download"
+									],
+									"query": [
+										{
+											"key": "file",
+											"value": "test.txt"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "cognitive-services",
+					"item": [
+						{
+							"name": "transcribe",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "key1",
+											"value": "value1",
+											"type": "text"
+										},
+										{
+											"key": "key2",
+											"value": "value2",
+											"type": "text"
+										},
+										{
+											"key": "file",
+											"type": "file",
+											"src": "/C:/Users/jfoster/Downloads/Recording.wav"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/azure/cognitive/services/transcribe",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}{{root-path}}",
+									"path": [
+										"azure",
+										"cognitive",
+										"services",
+										"transcribe"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "video-analyzer",
+					"item": [
+						{
+							"name": "videos",
+							"item": [
+								{
+									"name": "list",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/azure/video/analyzer/videos",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}{{root-path}}",
+											"path": [
+												"azure",
+												"video",
+												"analyzer",
+												"videos"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "access-token",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/azure/video/analyzer/access-token",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}{{root-path}}",
+									"path": [
+										"azure",
+										"video",
+										"analyzer",
+										"access-token"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "kafka",
+					"item": [
+						{
+							"name": "topics",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/kafka/topics",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}{{root-path}}",
+									"path": [
+										"kafka",
+										"topics"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "topics",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"value\": \"test3\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/kafka/topics/test/1",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}{{root-path}}",
+									"path": [
+										"kafka",
+										"topics",
+										"test",
+										"1"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "topics/:topic",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/kafka/topics/:topic",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}{{root-path}}",
+									"path": [
+										"kafka",
+										"topics",
+										":topic"
+									],
+									"variable": [
+										{
+											"key": "topic",
+											"value": "test"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "userinfo",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/userinfo",
+							"protocol": "{{scheme}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}{{root-path}}",
+							"path": [
+								"userinfo"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "root",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{scheme}}://{{host}}:{{port}}{{root-path}}/",
+							"protocol": "{{scheme}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}{{root-path}}",
+							"path": [
+								""
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "app-editor",
+			"item": []
+		},
+		{
+			"name": "kafka",
+			"item": [
+				{
+					"name": "topics",
+					"item": [
+						{
+							"name": "topics",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/topics",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"topics"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "topic/:topic",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.kafka.json.v2+json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"records\": [\r\n        {\r\n            \"key\": \"uid-01\",\r\n            \"value\": {\r\n                \"source\": \"NTLP\",\r\n                \"uid\": \"uid-01\",\r\n                \"link\": \"https://some.com/place\",\r\n                \"language\": null,\r\n                \"author\": \"John Doe\",\r\n                \"title\": \"A Test Story\",\r\n                \"summary\": \"A test story summary\",\r\n                \"body\": \"Gunmen opened fire at a Cancun beach resort on Thursday, killing two people in what Mexican state officials called a confrontation between rival drug dealers that witnesses said forced tourists and hotel staff to hide for several hours. \\nThe shooting occurred on the beach near the Hyatt Ziva Cancun, an all-inclusive resort in Puerto Morelos that is popular with American tourists. \\n\\\"The @FGEQuintanaRoo reports that there was a confrontation between members of antagonistic groups of drug dealers on a beach in Bahía Petempich, Puerto Morelos,\\\" the attorney general for Quintana Roo state said via Twitter on Thursday. \\\"Two of them lost their lives at the scene. There are no serious injuries.\\\" \\nThe Secretariat of Public Security of Quintana Roo later tweeted that no tourists were seriously injured or kidnapped. The news site Notacaribe reported one person was injured at the scene after being hit with the handle of a weapon. \\nMike Sington, a Twitter user and former executive at NBC Universal, told Reuters by direct message that he was hiding with other guests of the resort in a dark area of the hotel and that staff had not explained what was happening. Other guests told him they heard gunshots and that a gunman had been on the beach, he said.\\nA senior state official said a group of gunmen arrived by boat in pursuit of the men who were slain, in what another Mexican official said appeared to have been a targeted \\\"execution.\\\"\\nMike Sington, a Twitter user and former executive at NBC Universal, told Reuters by direct message that he was hiding with other guests of the resort in a dark area of the hotel and that staff had not explained what was happening. Other guests told him they heard gunshots and that a gunman had been on the beach, he said.\\nHotel staff later sent text messages saying the gunman had been apprehended and that staff would escort guests to their rooms where they were ordered to shelter in place, Sington said.\\n\\\"I've never been so scared, literally shaking,\\\" he tweeted.\\nHe later added that guests were taken out of hiding and brought to the lobby, where they cried and hugged each other.\\nIn a statement released Thursday evening, Global Affairs Canada said it is not aware of any Canadian citizens affected by the shooting but continues to monitor the situation closely. \\nCanadian citizens requiring emergency consular assistance should contact the Consular Agency of Canada in Cancun, Mexico at 52 (55) 5724-9795 or cncun@international.gc.ca or call the department's 24/7 Emergency Watch and Response Centre at 1-800-387-3124 (toll-free), +1 613-996-8885 or by sending an email to sos@international.gc.ca.\\nMexican security forces were sent in to reinforce Tulum — another popular resort about 130 kilometres from Cancun — after two foreign tourists were killed and others wounded last month during a shootout between suspected gang members.\",\r\n                \"publishedOn\": \"2021-10-04T01:00:00\",\r\n                \"tags\": [\r\n                    {\r\n                        \"key\": \"category\",\r\n                        \"value\": \"test\"\r\n                    }\r\n                ]\r\n            }\r\n        }\r\n    ]\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/topics/:topic",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"topics",
+										":topic"
+									],
+									"variable": [
+										{
+											"key": "topic",
+											"value": "test"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "topics/:topic/partitions",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/topics/:topic/partitions",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"topics",
+										":topic",
+										"partitions"
+									],
+									"variable": [
+										{
+											"key": "topic",
+											"value": "test"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "topics/:topic/partitions/:id",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/topics/:topic/partitions/:id",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"topics",
+										":topic",
+										"partitions",
+										":id"
+									],
+									"variable": [
+										{
+											"key": "topic",
+											"value": "test"
+										},
+										{
+											"key": "id",
+											"value": "0"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "consumers",
+					"item": [
+						{
+							"name": "group",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.kafka.jsonschema.v2+json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n  \"name\": \"my_consumer\",\r\n  \"format\": \"jsonschema\",\r\n  \"auto.offset.reset\": \"earliest\",\r\n  \"auto.commit.enable\": \"false\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"consumers",
+										":group_name"
+									],
+									"query": [
+										{
+											"key": "auto.offset.reset",
+											"value": "earliest",
+											"disabled": true
+										},
+										{
+											"key": "auto.commit.enable",
+											"value": "false",
+											"disabled": true
+										},
+										{
+											"key": "name",
+											"value": "test-consumer",
+											"disabled": true
+										},
+										{
+											"key": "format",
+											"value": "jsonschema",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "group_name",
+											"value": "test"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "instance",
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.kafka.jsonschema.v2+json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"consumers",
+										":group_name",
+										"instances",
+										":consumer_id"
+									],
+									"variable": [
+										{
+											"key": "group_name",
+											"value": "nlp-01"
+										},
+										{
+											"key": "consumer_id",
+											"value": null
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "offsets",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.kafka.jsonschema.v2+json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/offsets",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"consumers",
+										":group_name",
+										"instances",
+										":consumer_id",
+										"offsets"
+									],
+									"variable": [
+										{
+											"key": "group_name",
+											"value": null
+										},
+										{
+											"key": "consumer_id",
+											"value": null
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "offsets",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.kafka.jsonschema.v2+json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/offsets",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"consumers",
+										":group_name",
+										"instances",
+										":consumer_id",
+										"offsets"
+									],
+									"variable": [
+										{
+											"key": "group_name",
+											"value": null
+										},
+										{
+											"key": "consumer_id",
+											"value": null
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "subscription",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.kafka.jsonschema.v2+json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/subscription",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"consumers",
+										":group_name",
+										"instances",
+										":consumer_id",
+										"subscription"
+									],
+									"variable": [
+										{
+											"key": "group_name",
+											"value": null
+										},
+										{
+											"key": "consumer_id",
+											"value": null
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "subscription",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.kafka.jsonschema.v2+json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/subscription",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"consumers",
+										":group_name",
+										"instances",
+										":consumer_id",
+										"subscription"
+									],
+									"variable": [
+										{
+											"key": "group_name",
+											"value": "atom-01"
+										},
+										{
+											"key": "consumer_id",
+											"value": null
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "subscription",
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.kafka.jsonschema.v2+json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/subscription",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"consumers",
+										":group_name",
+										"instances",
+										":consumer_id",
+										"subscription"
+									],
+									"variable": [
+										{
+											"key": "group_name",
+											"value": null
+										},
+										{
+											"key": "consumer_id",
+											"value": null
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "assignments",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.kafka.jsonschema.v2+json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/assignments",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"consumers",
+										":group_name",
+										"instances",
+										":consumer_id",
+										"assignments"
+									],
+									"variable": [
+										{
+											"key": "group_name",
+											"value": null
+										},
+										{
+											"key": "consumer_id",
+											"value": null
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "assignments",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.kafka.jsonschema.v2+json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/assignments",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"consumers",
+										":group_name",
+										"instances",
+										":consumer_id",
+										"assignments"
+									],
+									"variable": [
+										{
+											"key": "group_name",
+											"value": null
+										},
+										{
+											"key": "consumer_id",
+											"value": null
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "positions",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.kafka.jsonschema.v2+json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/positions",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"consumers",
+										":group_name",
+										"instances",
+										":consumer_id",
+										"positions"
+									],
+									"variable": [
+										{
+											"key": "group_name",
+											"value": null
+										},
+										{
+											"key": "consumer_id",
+											"value": null
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "positions/beginning",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.kafka.jsonschema.v2+json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/positions/beginning",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"consumers",
+										":group_name",
+										"instances",
+										":consumer_id",
+										"positions",
+										"beginning"
+									],
+									"variable": [
+										{
+											"key": "group_name",
+											"value": null
+										},
+										{
+											"key": "consumer_id",
+											"value": null
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "positions/end",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.kafka.jsonschema.v2+json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/positions/end",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"consumers",
+										":group_name",
+										"instances",
+										":consumer_id",
+										"positions",
+										"end"
+									],
+									"variable": [
+										{
+											"key": "group_name",
+											"value": null
+										},
+										{
+											"key": "consumer_id",
+											"value": null
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "records",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/vnd.kafka.jsonschema.v2+json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/consumers/:group_name/instances/:consumer_id/records",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"consumers",
+										":group_name",
+										"instances",
+										":consumer_id",
+										"records"
+									],
+									"variable": [
+										{
+											"key": "group_name",
+											"value": null
+										},
+										{
+											"key": "consumer_id",
+											"value": null
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "brokers",
+					"item": [
+						{
+							"name": "brokers",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/brokers",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"brokers"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "clusters",
+					"item": [
+						{
+							"name": "consumer-groups",
+							"item": [
+								{
+									"name": "consumers",
+									"item": [
+										{
+											"name": "one",
+											"request": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:culster_id/consumer-groups/:group_id/consumers/:consumer_id",
+													"protocol": "{{scheme}}",
+													"host": [
+														"{{host}}"
+													],
+													"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+													"path": [
+														"v3",
+														"clusters",
+														":culster_id",
+														"consumer-groups",
+														":group_id",
+														"consumers",
+														":consumer_id"
+													],
+													"variable": [
+														{
+															"key": "culster_id",
+															"value": "Dja5AfDJTH-rMtXW1we-Ag"
+														},
+														{
+															"key": "group_id",
+															"value": "nlp-01"
+														},
+														{
+															"key": "consumer_id",
+															"value": null
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "assignments",
+											"request": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:culster_id/consumer-groups/:group_id/consumers/:consumer_id/assignments",
+													"protocol": "{{scheme}}",
+													"host": [
+														"{{host}}"
+													],
+													"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+													"path": [
+														"v3",
+														"clusters",
+														":culster_id",
+														"consumer-groups",
+														":group_id",
+														"consumers",
+														":consumer_id",
+														"assignments"
+													],
+													"variable": [
+														{
+															"key": "culster_id",
+															"value": "Dja5AfDJTH-rMtXW1we-Ag"
+														},
+														{
+															"key": "group_id",
+															"value": "nlp-01"
+														},
+														{
+															"key": "consumer_id",
+															"value": null
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "assignment",
+											"request": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:culster_id/consumer-groups/:group_id/consumers/:consumer_id/assignments/:topic_name/partitions/:partition_id",
+													"protocol": "{{scheme}}",
+													"host": [
+														"{{host}}"
+													],
+													"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+													"path": [
+														"v3",
+														"clusters",
+														":culster_id",
+														"consumer-groups",
+														":group_id",
+														"consumers",
+														":consumer_id",
+														"assignments",
+														":topic_name",
+														"partitions",
+														":partition_id"
+													],
+													"variable": [
+														{
+															"key": "culster_id",
+															"value": "Dja5AfDJTH-rMtXW1we-Ag"
+														},
+														{
+															"key": "group_id",
+															"value": "nlp-01"
+														},
+														{
+															"key": "consumer_id",
+															"value": null
+														},
+														{
+															"key": "topic_name",
+															"value": null
+														},
+														{
+															"key": "partition_id",
+															"value": null
+														}
+													]
+												}
+											},
+											"response": []
+										}
+									]
+								},
+								{
+									"name": "all",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/consumer-groups",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+											"path": [
+												"v3",
+												"clusters",
+												":cluster_id",
+												"consumer-groups"
+											],
+											"variable": [
+												{
+													"key": "cluster_id",
+													"value": "Dja5AfDJTH-rMtXW1we-Ag"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "one",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:culster_id/consumer-groups/:group_id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+											"path": [
+												"v3",
+												"clusters",
+												":culster_id",
+												"consumer-groups",
+												":group_id"
+											],
+											"variable": [
+												{
+													"key": "culster_id",
+													"value": "Dja5AfDJTH-rMtXW1we-Ag"
+												},
+												{
+													"key": "group_id",
+													"value": "nlp-01"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "consumers",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:culster_id/consumer-groups/:group_id/consumers",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+											"path": [
+												"v3",
+												"clusters",
+												":culster_id",
+												"consumer-groups",
+												":group_id",
+												"consumers"
+											],
+											"variable": [
+												{
+													"key": "culster_id",
+													"value": "Dja5AfDJTH-rMtXW1we-Ag"
+												},
+												{
+													"key": "group_id",
+													"value": "nlp-01"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "lag-summary",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:culster_id/consumer-groups/:group_id/lag-summary",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+											"path": [
+												"v3",
+												"clusters",
+												":culster_id",
+												"consumer-groups",
+												":group_id",
+												"lag-summary"
+											],
+											"variable": [
+												{
+													"key": "culster_id",
+													"value": "Dja5AfDJTH-rMtXW1we-Ag"
+												},
+												{
+													"key": "group_id",
+													"value": "nlp-01"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "lags",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:culster_id/consumer-groups/:group_id/lags",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+											"path": [
+												"v3",
+												"clusters",
+												":culster_id",
+												"consumer-groups",
+												":group_id",
+												"lags"
+											],
+											"variable": [
+												{
+													"key": "culster_id",
+													"value": "Dja5AfDJTH-rMtXW1we-Ag"
+												},
+												{
+													"key": "group_id",
+													"value": "nlp-01"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "lags/:topic_name",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:culster_id/consumer-groups/:group_id/lags/:topic_name/partitions/:partition_id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+											"path": [
+												"v3",
+												"clusters",
+												":culster_id",
+												"consumer-groups",
+												":group_id",
+												"lags",
+												":topic_name",
+												"partitions",
+												":partition_id"
+											],
+											"variable": [
+												{
+													"key": "culster_id",
+													"value": "Dja5AfDJTH-rMtXW1we-Ag"
+												},
+												{
+													"key": "group_id",
+													"value": "nlp-01"
+												},
+												{
+													"key": "topic_name",
+													"value": null
+												},
+												{
+													"key": "partition_id",
+													"value": null
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "topics",
+							"item": [
+								{
+									"name": "all",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+											"path": [
+												"v3",
+												"clusters",
+												":cluster_id",
+												"topics"
+											],
+											"variable": [
+												{
+													"key": "cluster_id",
+													"value": "x29JqB9RQWSsvZG2CtqE9Q"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "one",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics/:topic_name",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+											"path": [
+												"v3",
+												"clusters",
+												":cluster_id",
+												"topics",
+												":topic_name"
+											],
+											"variable": [
+												{
+													"key": "cluster_id",
+													"value": "Dja5AfDJTH-rMtXW1we-Ag"
+												},
+												{
+													"key": "topic_name",
+													"value": "test"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "add",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"topic_name\": \"elastic-logs\",\r\n    \"partitions_count\": 3,\r\n    \"replication_factor\": 1,\r\n    \"configs\": [\r\n        {\r\n            \"name\": \"cleanup.policy\",\r\n            \"value\": \"compact\"\r\n        },\r\n        {\r\n            \"name\": \"compression.type\",\r\n            \"value\": \"gzip\"\r\n        }\r\n    ]\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+											"path": [
+												"v3",
+												"clusters",
+												":cluster_id",
+												"topics"
+											],
+											"variable": [
+												{
+													"key": "cluster_id",
+													"value": "Dja5AfDJTH-rMtXW1we-Ag"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "delete",
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics/:topic_name",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+											"path": [
+												"v3",
+												"clusters",
+												":cluster_id",
+												"topics",
+												":topic_name"
+											],
+											"variable": [
+												{
+													"key": "cluster_id",
+													"value": "Dja5AfDJTH-rMtXW1we-Ag"
+												},
+												{
+													"key": "topic_name",
+													"value": "test"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "partitions",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics/:topic_name/partitions",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+											"path": [
+												"v3",
+												"clusters",
+												":cluster_id",
+												"topics",
+												":topic_name",
+												"partitions"
+											],
+											"variable": [
+												{
+													"key": "cluster_id",
+													"value": "Dja5AfDJTH-rMtXW1we-Ag"
+												},
+												{
+													"key": "topic_name",
+													"value": "test"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "partitions/:id",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics/:topic_name/partitions/:partition_id",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+											"path": [
+												"v3",
+												"clusters",
+												":cluster_id",
+												"topics",
+												":topic_name",
+												"partitions",
+												":partition_id"
+											],
+											"variable": [
+												{
+													"key": "cluster_id",
+													"value": "Dja5AfDJTH-rMtXW1we-Ag"
+												},
+												{
+													"key": "topic_name",
+													"value": "test"
+												},
+												{
+													"key": "partition_id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "reassignment",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics/-/partitions/-/reassignment",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+											"path": [
+												"v3",
+												"clusters",
+												":cluster_id",
+												"topics",
+												"-",
+												"partitions",
+												"-",
+												"reassignment"
+											],
+											"variable": [
+												{
+													"key": "cluster_id",
+													"value": "Dja5AfDJTH-rMtXW1we-Ag"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": ":id/reassignment",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics/:topic_name/partitions/-/reassignment",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+											"path": [
+												"v3",
+												"clusters",
+												":cluster_id",
+												"topics",
+												":topic_name",
+												"partitions",
+												"-",
+												"reassignment"
+											],
+											"variable": [
+												{
+													"key": "cluster_id",
+													"value": "Dja5AfDJTH-rMtXW1we-Ag"
+												},
+												{
+													"key": "topic_name",
+													"value": "nlp"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": ":id/reassignment",
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:cluster_id/topics/:topic_name/partitions/:partition_id/reassignment",
+											"protocol": "{{scheme}}",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+											"path": [
+												"v3",
+												"clusters",
+												":cluster_id",
+												"topics",
+												":topic_name",
+												"partitions",
+												":partition_id",
+												"reassignment"
+											],
+											"variable": [
+												{
+													"key": "cluster_id",
+													"value": "Dja5AfDJTH-rMtXW1we-Ag"
+												},
+												{
+													"key": "topic_name",
+													"value": "nlp"
+												},
+												{
+													"key": "partition_id",
+													"value": "1"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "clusters",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"v3",
+										"clusters"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "clusters/:id",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{kafka-rest-port}}{{kafka-rest-path}}/v3/clusters/:id",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{kafka-rest-port}}{{kafka-rest-path}}",
+									"path": [
+										"v3",
+										"clusters",
+										":id"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "Dja5AfDJTH-rMtXW1we-Ag"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "elasticsearch",
+			"item": [
+				{
+					"name": "indices",
+					"item": [
+						{
+							"name": "indices",
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "{{elastic-password}}",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "{{elastic-username}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{elastic-host}}:{{elastic-port}}{{elastic-path}}/_cat/indices/*?v&s=index",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{elastic-host}}"
+									],
+									"port": "{{elastic-port}}{{elastic-path}}",
+									"path": [
+										"_cat",
+										"indices",
+										"*"
+									],
+									"query": [
+										{
+											"key": "v",
+											"value": null
+										},
+										{
+											"key": "s",
+											"value": "index"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "indexes",
+					"item": [
+						{
+							"name": ":id",
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "{{elastic-password}}",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "{{elastic-username}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"settings\":{\r\n        \"index\":{\r\n            \"number_of_shards\": 1,\r\n            \"number_of_replicas\": 1\r\n        }\r\n    },\r\n    \"mappings\": {\r\n        \"properties\": {\r\n            \"type\": { \"type\": \"keyword\" },\r\n            \"language\": { \"type\": \"keyword\" },\r\n            \"title\": { \"type\": \"text\" },\r\n            \"copyright\":{ \"type\": \"text\", \"index\": false },\r\n            \"author\": { \"type\": \"text\" },\r\n            \"summary\": { \"type\": \"text\" },\r\n            \"publishedOn\": { \"type\": \"date\" },\r\n            \"updatedOn\": { \"type\": \"date\" },\r\n            \"kafka\": {\r\n                \"type\": \"object\",\r\n                \"properties\": {\r\n                    \"topic\": { \"type\": \"keyword\", \"index\": false },\r\n                    \"offset\": { \"type\": \"long\", \"index\": false },\r\n                    \"partition\": { \"type\": \"integer\", \"index\": false }\r\n                }\r\n            },\r\n            \"source\": {\r\n                \"type\": \"object\",\r\n                \"properties\": {\r\n                    \"name\": { \"type\": \"keyword\" },\r\n                    \"uid\": { \"type\": \"keyword\", \"index\": false },\r\n                    \"link\": { \"type\": \"keyword\", \"index\": false },\r\n                    \"filePath\": { \"type\": \"keyword\", \"index\": false },\r\n                    \"streamUrl\": { \"type\": \"keyword\", \"index\": false }\r\n                }\r\n            },\r\n            \"tags\": {\r\n                \"type\": \"nested\",\r\n                \"properties\": {\r\n                    \"key\": { \"type\": \"keyword\" },\r\n                    \"value\": { \"type\": \"text\" }\r\n                }\r\n            }\r\n        }\r\n    }\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{scheme}}://{{elastic-host}}:{{elastic-port}}{{elastic-path}}/:id",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{elastic-host}}"
+									],
+									"port": "{{elastic-port}}{{elastic-path}}",
+									"path": [
+										":id"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "test"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": ":id",
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "{{elastic-password}}",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "{{elastic-username}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{elastic-host}}:{{elastic-port}}{{elastic-path}}/:id",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{elastic-host}}"
+									],
+									"port": "{{elastic-port}}{{elastic-path}}",
+									"path": [
+										":id"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "story"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "home",
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "{{elastic-password}}",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "{{elastic-username}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{scheme}}://{{elastic-host}}:{{elastic-port}}{{elastic-path}}",
+							"protocol": "{{scheme}}",
+							"host": [
+								"{{elastic-host}}"
+							],
+							"port": "{{elastic-port}}{{elastic-path}}"
+						}
+					},
+					"response": [
+						{
+							"name": "home",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{elastic-host}}:{{elastic-port}}{{elastic-path}}",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{elastic-host}}"
+									],
+									"port": "{{elastic-port}}{{elastic-path}}"
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "X-elastic-product",
+									"value": "Elasticsearch"
+								},
+								{
+									"key": "content-type",
+									"value": "application/json; charset=UTF-8"
+								},
+								{
+									"key": "content-encoding",
+									"value": "gzip"
+								},
+								{
+									"key": "content-length",
+									"value": "326"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"name\": \"tno\",\n    \"cluster_name\": \"tno-es-cluster\",\n    \"cluster_uuid\": \"0WYCrEAZSg-aDYboOS2FDA\",\n    \"version\": {\n        \"number\": \"7.15.0\",\n        \"build_flavor\": \"default\",\n        \"build_type\": \"docker\",\n        \"build_hash\": \"79d65f6e357953a5b3cbcc5e2c7c21073d89aa29\",\n        \"build_date\": \"2021-09-16T03:05:29.143308416Z\",\n        \"build_snapshot\": false,\n        \"lucene_version\": \"8.9.0\",\n        \"minimum_wire_compatibility_version\": \"6.8.0\",\n        \"minimum_index_compatibility_version\": \"6.0.0-beta1\"\n    },\n    \"tagline\": \"You Know, for Search\"\n}"
+						}
+					]
+				},
+				{
+					"name": "health",
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "{{elastic-password}}",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "{{elastic-username}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{scheme}}://{{elastic-host}}:{{elastic-port}}{{elastic-path}}/_cat/health",
+							"protocol": "{{scheme}}",
+							"host": [
+								"{{elastic-host}}"
+							],
+							"port": "{{elastic-port}}{{elastic-path}}",
+							"path": [
+								"_cat",
+								"health"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "cat",
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "{{elastic-password}}",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "{{elastic-username}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{scheme}}://{{elastic-host}}:{{elastic-port}}{{elastic-path}}/_cat",
+							"protocol": "{{scheme}}",
+							"host": [
+								"{{elastic-host}}"
+							],
+							"port": "{{elastic-port}}{{elastic-path}}",
+							"path": [
+								"_cat"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "nodes",
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "{{elastic-password}}",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "{{elastic-username}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{scheme}}://{{elastic-host}}:{{elastic-port}}{{elastic-path}}/_cat/nodes",
+							"protocol": "{{scheme}}",
+							"host": [
+								"{{elastic-host}}"
+							],
+							"port": "{{elastic-port}}{{elastic-path}}",
+							"path": [
+								"_cat",
+								"nodes"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "services",
+			"item": [
+				{
+					"name": "nlp",
+					"item": [
+						{
+							"name": "health",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{nlp-port}}/health",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{nlp-port}}",
+									"path": [
+										"health"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "pause",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{nlp-port}}/pause",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{nlp-port}}",
+									"path": [
+										"pause"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "resume",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{nlp-port}}/resume",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{nlp-port}}",
+									"path": [
+										"resume"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "stop",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{nlp-port}}/stop",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{nlp-port}}",
+									"path": [
+										"stop"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "start",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{nlp-port}}/start",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{nlp-port}}",
+									"path": [
+										"start"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"auth": {
+						"type": "noauth"
+					},
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "syndication",
+					"item": [
+						{
+							"name": "health",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{syndication-port}}/health",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{syndication-port}}",
+									"path": [
+										"health"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "pause",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{syndication-port}}/pause",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{syndication-port}}",
+									"path": [
+										"pause"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "resume",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{syndication-port}}/resume",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{syndication-port}}",
+									"path": [
+										"resume"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "stop",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{syndication-port}}/stop",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{syndication-port}}",
+									"path": [
+										"stop"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "start",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"url": {
+									"raw": "{{scheme}}://{{host}}:{{syndication-port}}/start",
+									"protocol": "{{scheme}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{syndication-port}}",
+									"path": [
+										"start"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"auth": {
+						"type": "noauth"
+					},
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					]
+				}
+			]
+		}
+	],
+	"auth": {
+		"type": "bearer",
+		"bearer": [
+			{
+				"key": "token",
+				"value": "{{access-token}}",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	]
 }


### PR DESCRIPTION
We can now save `content.contentActions` with the API.

Note that the API simplifies the schema.  I have also updated the Postman tests.

> Will need to run `make refresh n=api-editor`