### PR TITLE
TNO-208 Fix content service

### DIFF
--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/converters/LocalDateTimeConverter.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/converters/LocalDateTimeConverter.java
@@ -4,12 +4,22 @@ import java.time.LocalDateTime;
 
 import javax.persistence.AttributeConverter;
 
+/**
+ * LocalDateTimeConverter class, provides a way to convert LocalDateTime to SQL
+ * Timestamp.
+ */
 public class LocalDateTimeConverter implements AttributeConverter<LocalDateTime, java.sql.Timestamp> {
+  /**
+   * Convert LocalDateTime to SQL Timestamp.
+   */
   @Override
   public java.sql.Timestamp convertToDatabaseColumn(LocalDateTime entityValue) {
     return entityValue == null ? null : java.sql.Timestamp.valueOf(entityValue);
   }
 
+  /**
+   * Convert SQL Timestamp to LocalDateTime.
+   */
   @Override
   public LocalDateTime convertToEntityAttribute(java.sql.Timestamp dbValue) {
     return dbValue == null ? null : dbValue.toLocalDateTime();

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/converters/ZonedDateTimeConverter.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/converters/ZonedDateTimeConverter.java
@@ -6,12 +6,22 @@ import java.time.ZonedDateTime;
 
 import javax.persistence.AttributeConverter;
 
+/**
+ * ZonedDateTimeConverter class, provides a way to convert ZoneDateTime to SQL
+ * timestamp.
+ */
 public class ZonedDateTimeConverter implements AttributeConverter<ZonedDateTime, java.sql.Timestamp> {
+  /**
+   * Convert ZonedDateTime to SQL Timestamp
+   */
   @Override
   public java.sql.Timestamp convertToDatabaseColumn(ZonedDateTime entityValue) {
     return entityValue == null ? null : Timestamp.valueOf(entityValue.toLocalDateTime());
   }
 
+  /**
+   * Convert SQL Timestamp to ZonedDateTime
+   */
   @Override
   public ZonedDateTime convertToEntityAttribute(java.sql.Timestamp dbValue) {
     var local = dbValue.toLocalDateTime();

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/ContentCategory.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/ContentCategory.java
@@ -93,6 +93,21 @@ public class ContentCategory extends AuditColumns {
    * specified
    * parameters.
    * 
+   * @param content  Content object
+   * @param category Category object
+   * @param score    Category score
+   * @param version  Row version value
+   */
+  public ContentCategory(Content content, Category category, int score, int version) {
+    this(content, category, score);
+    this.setVersion(version);
+  }
+
+  /**
+   * Creates a new instance of a ContentCategory object, initializes with
+   * specified
+   * parameters.
+   * 
    * @param content    Content object
    * @param categoryId Foreign key to Category object
    * @param score      Category score
@@ -105,6 +120,21 @@ public class ContentCategory extends AuditColumns {
     this.contentId = content.getId();
     this.categoryId = categoryId;
     this.score = score;
+  }
+
+  /**
+   * Creates a new instance of a ContentCategory object, initializes with
+   * specified
+   * parameters.
+   * 
+   * @param content    Content object
+   * @param categoryId Foreign key to Category object
+   * @param score      Category score
+   * @param version    Row version value
+   */
+  public ContentCategory(Content content, int categoryId, int score, int version) {
+    this(content, categoryId, score);
+    this.setVersion(version);
   }
 
   /**

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/ContentLink.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/ContentLink.java
@@ -83,12 +83,40 @@ public class ContentLink extends AuditColumns {
    * specified
    * parameters.
    * 
+   * @param content Content object
+   * @param link    Link object
+   * @param version Row version value
+   */
+  public ContentLink(Content content, Content link, int version) {
+    this(content, link);
+    this.setVersion(version);
+  }
+
+  /**
+   * Creates a new instance of a ContentLink object, initializes with
+   * specified
+   * parameters.
+   * 
    * @param contentId Foreign key to Content object
    * @param linkId    Foreign key to Link object
    */
   public ContentLink(int contentId, int linkId) {
     this.contentId = contentId;
     this.linkId = linkId;
+  }
+
+  /**
+   * Creates a new instance of a ContentLink object, initializes with
+   * specified
+   * parameters.
+   * 
+   * @param contentId Foreign key to Content object
+   * @param linkId    Foreign key to Link object
+   * @param version   Row version value
+   */
+  public ContentLink(int contentId, int linkId, int version) {
+    this(contentId, linkId);
+    this.setVersion(version);
   }
 
   /**

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/ContentReference.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/ContentReference.java
@@ -112,6 +112,20 @@ public class ContentReference extends AuditColumns {
   }
 
   /**
+   * Creates a new instance of a ContentReference object, initializes with
+   * specified parameters.
+   * 
+   * @param source  Data source abbreviation
+   * @param uid     Unique identify of the content
+   * @param topic   The Kafka topic it was stored in
+   * @param version Row version value
+   */
+  public ContentReference(String source, String uid, String topic, int version) {
+    this(source, uid, topic);
+    this.setVersion(version);
+  }
+
+  /**
    * @return String return the source
    */
   public String getSource() {

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/ContentTag.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/ContentTag.java
@@ -86,6 +86,20 @@ public class ContentTag extends AuditColumns {
    * parameters.
    * 
    * @param content Content object
+   * @param tag     Tag object
+   * @param version Row version value
+   */
+  public ContentTag(Content content, Tag tag, int version) {
+    this(content, tag);
+    this.setVersion(version);
+  }
+
+  /**
+   * Creates a new instance of a ContentTag object, initializes with
+   * specified
+   * parameters.
+   * 
+   * @param content Content object
    * @param tagId   Foreign key to Tag object
    */
   public ContentTag(Content content, String tagId) {
@@ -99,6 +113,20 @@ public class ContentTag extends AuditColumns {
     this.content = content;
     this.contentId = content.getId();
     this.tagId = tagId;
+  }
+
+  /**
+   * Creates a new instance of a ContentTag object, initializes with
+   * specified
+   * parameters.
+   * 
+   * @param content Content object
+   * @param tagId   Foreign key to Tag object
+   * @param version Row version value
+   */
+  public ContentTag(Content content, String tagId, int version) {
+    this(content, tagId);
+    this.setVersion(version);
   }
 
   /**

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/ContentTone.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/ContentTone.java
@@ -91,6 +91,20 @@ public class ContentTone extends AuditColumns {
    * Creates a new instance of a ContentTone object, initializes with specified
    * parameters.
    * 
+   * @param content  Content object
+   * @param tonePool TonePool object
+   * @param value    Tone value
+   * @param version  Row version value
+   */
+  public ContentTone(Content content, TonePool tonePool, int value, int version) {
+    this(content, tonePool, value);
+    this.setVersion(version);
+  }
+
+  /**
+   * Creates a new instance of a ContentTone object, initializes with specified
+   * parameters.
+   * 
    * @param content    Content object
    * @param tonePoolId Foreign key to TonePool object
    * @param value      Tone value
@@ -103,6 +117,20 @@ public class ContentTone extends AuditColumns {
     this.contentId = content.getId();
     this.tonePoolId = tonePoolId;
     this.value = value;
+  }
+
+  /**
+   * Creates a new instance of a ContentTone object, initializes with specified
+   * parameters.
+   * 
+   * @param content    Content object
+   * @param tonePoolId Foreign key to TonePool object
+   * @param value      Tone value
+   * @param version    Row version value
+   */
+  public ContentTone(Content content, int tonePoolId, int value, int version) {
+    this(content, tonePoolId, value);
+    this.setVersion(version);
   }
 
   /**

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/ContentType.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/ContentType.java
@@ -81,12 +81,40 @@ public class ContentType extends AuditColumns {
    * Creates a new instance of a ContentType object, initializes with specified
    * parameters.
    * 
+   * @param name Unique name
+   */
+  public ContentType(String name) {
+    if (name == null)
+      throw new NullPointerException("Parameter 'name' cannot be null.");
+    if (name.length() == 0)
+      throw new IllegalArgumentException("Parameter 'name' cannot be empty.");
+
+    this.name = name;
+  }
+
+  /**
+   * Creates a new instance of a ContentType object, initializes with specified
+   * parameters.
+   * 
    * @param id   Primary key
    * @param name Unique name
    */
   public ContentType(int id, String name) {
+    this(name);
     this.id = id;
-    this.name = name;
+  }
+
+  /**
+   * Creates a new instance of a ContentType object, initializes with specified
+   * parameters.
+   * 
+   * @param id      Primary key
+   * @param name    Unique name
+   * @param version Row version value
+   */
+  public ContentType(int id, String name, int version) {
+    this(id, name);
+    this.setVersion(version);
   }
 
   /**

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/ContentTypeAction.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/ContentTypeAction.java
@@ -86,6 +86,20 @@ public class ContentTypeAction extends AuditColumns {
    * parameters.
    * 
    * @param contentType ContentType object
+   * @param action      Action object
+   * @param version     Row version value
+   */
+  public ContentTypeAction(ContentType contentType, Action action, int version) {
+    this(contentType, action);
+    this.setVersion(version);
+  }
+
+  /**
+   * Creates a new instance of a ContentTypeAction object, initializes with
+   * specified
+   * parameters.
+   * 
+   * @param contentType ContentType object
    * @param actionId    Foreign key to Action object
    */
   public ContentTypeAction(ContentType contentType, int actionId) {
@@ -95,6 +109,20 @@ public class ContentTypeAction extends AuditColumns {
     this.contentType = contentType;
     this.contentTypeId = contentType.getId();
     this.actionId = actionId;
+  }
+
+  /**
+   * Creates a new instance of a ContentTypeAction object, initializes with
+   * specified
+   * parameters.
+   * 
+   * @param contentType ContentType object
+   * @param actionId    Foreign key to Action object
+   * @param version     Row version value
+   */
+  public ContentTypeAction(ContentType contentType, int actionId, int version) {
+    this(contentType, actionId);
+    this.setVersion(version);
   }
 
   /**

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/DataSource.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/DataSource.java
@@ -186,6 +186,25 @@ public class DataSource extends AuditColumns {
   }
 
   /**
+   * Creates a new instance of a DataSource object, initializes with specified
+   * parameters.
+   * 
+   * @param id         The primary key
+   * @param name       The unique name
+   * @param abbr       The unique abbreviation
+   * @param mediaType  Foreign key to the media type
+   * @param license    Foreign key to the license
+   * @param topic      The Kafka topic
+   * @param connection The connection information
+   * @param version    Row version value
+   */
+  public DataSource(int id, String name, String abbr, MediaType mediaType, License license,
+      String topic, Map<String, Object> connection, int version) {
+    this(id, name, abbr, mediaType, license, topic, connection);
+    this.setVersion(version);
+  }
+
+  /**
    * @return int return the id
    */
   public int getId() {

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/DataSourceSchedule.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/DataSourceSchedule.java
@@ -83,12 +83,40 @@ public class DataSourceSchedule extends AuditColumns {
    * specified
    * parameters.
    * 
+   * @param dataSource DataSource object
+   * @param schedule   Schedule object
+   * @param version    Row version value
+   */
+  public DataSourceSchedule(DataSource dataSource, Schedule schedule, int version) {
+    this(dataSource, schedule);
+    this.setVersion(version);
+  }
+
+  /**
+   * Creates a new instance of a DataSourceSchedule object, initializes with
+   * specified
+   * parameters.
+   * 
    * @param dataSourceId Foreign key to data source.
    * @param scheduleId   Foreign key to Schedule.
    */
   public DataSourceSchedule(int dataSourceId, int scheduleId) {
     this.dataSourceId = dataSourceId;
     this.scheduleId = scheduleId;
+  }
+
+  /**
+   * Creates a new instance of a DataSourceSchedule object, initializes with
+   * specified
+   * parameters.
+   * 
+   * @param dataSourceId Foreign key to data source.
+   * @param scheduleId   Foreign key to Schedule.
+   * @param version      Row version value
+   */
+  public DataSourceSchedule(int dataSourceId, int scheduleId, int version) {
+    this(dataSourceId, scheduleId);
+    this.setVersion(version);
   }
 
   /**

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/FileReference.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/FileReference.java
@@ -108,6 +108,24 @@ public class FileReference extends AuditColumns {
   }
 
   /**
+   * Creates a new instance of a FileReference object, initializes with specified
+   * parameters.
+   * 
+   * @param id          The primary key
+   * @param content     The content the file belongs to
+   * @param path        The path and name of the file
+   * @param mimeType    The file mimetype
+   * @param size        The size in bytes
+   * @param runningTime The running time of audio/video in milliseconds
+   * @param version     Row version value
+   */
+  public FileReference(int id, Content content, String path, String mimeType, int size,
+      int runningTime, int version) {
+    this(id, content, path, mimeType, size, runningTime);
+    this.setVersion(version);
+  }
+
+  /**
    * @return int return the id
    */
   public int getId() {

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/License.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/License.java
@@ -82,14 +82,44 @@ public class License extends AuditColumns {
    * Creates a new instance of a License object, initializes with specified
    * parameters.
    * 
+   * @param name Unique name
+   * @param ttl  Time to live in days
+   */
+  public License(String name, int ttl) {
+    if (name == null)
+      throw new NullPointerException("Parameter 'name' cannot be null.");
+    if (name.length() == 0)
+      throw new IllegalArgumentException("Parameter 'name' cannot be empty.");
+
+    this.name = name;
+    this.ttl = ttl;
+  }
+
+  /**
+   * Creates a new instance of a License object, initializes with specified
+   * parameters.
+   * 
    * @param id   Primary key
    * @param name Unique name
    * @param ttl  Time to live in days
    */
   public License(int id, String name, int ttl) {
+    this(name, ttl);
     this.id = id;
-    this.name = name;
-    this.ttl = ttl;
+  }
+
+  /**
+   * Creates a new instance of a License object, initializes with specified
+   * parameters.
+   * 
+   * @param id      Primary key
+   * @param name    Unique name
+   * @param ttl     Time to live in days
+   * @param version Row version value
+   */
+  public License(int id, String name, int ttl, int version) {
+    this(id, name, ttl);
+    this.setVersion(version);
   }
 
   /**

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/MediaType.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/MediaType.java
@@ -69,12 +69,40 @@ public class MediaType extends AuditColumns {
    * Creates a new instance of a MediaType object, initializes with specified
    * parameters.
    * 
+   * @param name Unique name
+   */
+  public MediaType(String name) {
+    if (name == null)
+      throw new NullPointerException("Parameter 'name' cannot be null.");
+    if (name.length() == 0)
+      throw new IllegalArgumentException("Parameter 'name' cannot be empty.");
+
+    this.name = name;
+  }
+
+  /**
+   * Creates a new instance of a MediaType object, initializes with specified
+   * parameters.
+   * 
    * @param id   Primary key
    * @param name Unique name
    */
   public MediaType(int id, String name) {
+    this(name);
     this.id = id;
-    this.name = name;
+  }
+
+  /**
+   * Creates a new instance of a MediaType object, initializes with specified
+   * parameters.
+   * 
+   * @param id      Primary key
+   * @param name    Unique name
+   * @param version Row version value
+   */
+  public MediaType(int id, String name, int version) {
+    this(id, name);
+    this.setVersion(version);
   }
 
   /**

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/PrintContent.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/PrintContent.java
@@ -98,6 +98,23 @@ public class PrintContent extends AuditColumns {
   }
 
   /**
+   * Creates a new instance of a PrintContent object, initializes with
+   * specified parameters.
+   * 
+   * @param content   The content this print content belongs with
+   * @param edition   The edition of the content
+   * @param section   The section of the content
+   * @param storyType The story type of the content
+   * @param byline    The byline of the content
+   * @param version   Row version value
+   */
+  public PrintContent(Content content, String edition, String section, String storyType,
+      String byline, int version) {
+    this(content, edition, section, storyType, byline);
+    this.setVersion(version);
+  }
+
+  /**
    * @return int return the contentId
    */
   public int getContentId() {

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/Role.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/Role.java
@@ -78,12 +78,40 @@ public class Role extends AuditColumns {
    * Creates a new instance of a Role object, initializes with specified
    * parameters.
    * 
+   * @param name Unique name
+   */
+  public Role(String name) {
+    if (name == null)
+      throw new NullPointerException("Parameter 'name' cannot be null.");
+    if (name.length() == 0)
+      throw new IllegalArgumentException("Parameter 'name' cannot be empty.");
+
+    this.name = name;
+  }
+
+  /**
+   * Creates a new instance of a Role object, initializes with specified
+   * parameters.
+   * 
    * @param id   Primary key
    * @param name Unique name
    */
   public Role(int id, String name) {
+    this(name);
     this.id = id;
-    this.name = name;
+  }
+
+  /**
+   * Creates a new instance of a Role object, initializes with specified
+   * parameters.
+   * 
+   * @param id      Primary key
+   * @param name    Unique name
+   * @param version Row version value
+   */
+  public Role(int id, String name, int version) {
+    this(id, name);
+    this.setVersion(version);
   }
 
   /**

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/RoleClaim.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/RoleClaim.java
@@ -79,12 +79,47 @@ public class RoleClaim extends AuditColumns {
    * Creates a new instance of a RoleClaim object, initializes with specified
    * parameters.
    * 
+   * @param role    The role.
+   * @param claim   The claim.
+   * @param version Row version value
+   */
+  public RoleClaim(Role role, Claim claim, int version) {
+    if (role == null)
+      throw new IllegalArgumentException("Parameter 'role' is required.");
+    if (claim == null)
+      throw new IllegalArgumentException("Parameter 'claim' is required.");
+
+    this.role = role;
+    this.roleId = role.getId();
+    this.claim = claim;
+    this.claimId = claim.getId();
+    this.setVersion(version);
+  }
+
+  /**
+   * Creates a new instance of a RoleClaim object, initializes with specified
+   * parameters.
+   * 
    * @param roleId  Foreign key The role.
    * @param claimId Foreign key The claim.
    */
   public RoleClaim(int roleId, int claimId) {
     this.roleId = roleId;
     this.claimId = claimId;
+  }
+
+  /**
+   * Creates a new instance of a RoleClaim object, initializes with specified
+   * parameters.
+   * 
+   * @param roleId  Foreign key The role.
+   * @param claimId Foreign key The claim.
+   * @param version Row version value
+   */
+  public RoleClaim(int roleId, int claimId, int version) {
+    this.roleId = roleId;
+    this.claimId = claimId;
+    this.setVersion(version);
   }
 
   /**

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/Schedule.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/Schedule.java
@@ -148,12 +148,40 @@ public class Schedule extends AuditColumns {
    * Creates a new instance of a Schedule object, initializes with specified
    * parameters.
    *
+   * @param name Unique name
+   */
+  public Schedule(String name) {
+    if (name == null)
+      throw new NullPointerException("Parameter 'name' cannot be null.");
+    if (name.length() == 0)
+      throw new IllegalArgumentException("Parameter 'name' cannot be empty.");
+
+    this.name = name;
+  }
+
+  /**
+   * Creates a new instance of a Schedule object, initializes with specified
+   * parameters.
+   *
    * @param id   Primary key
    * @param name Unique name
    */
   public Schedule(int id, String name) {
+    this(name);
     this.id = id;
-    this.name = name;
+  }
+
+  /**
+   * Creates a new instance of a Schedule object, initializes with specified
+   * parameters.
+   *
+   * @param id      Primary key
+   * @param name    Unique name
+   * @param version Row version value
+   */
+  public Schedule(int id, String name, int version) {
+    this(id, name);
+    this.setVersion(version);
   }
 
   /**

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/Series.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/Series.java
@@ -74,12 +74,40 @@ public class Series extends AuditColumns {
    * Creates a new instance of a Series object, initializes with specified
    * parameters.
    * 
+   * @param name Unique name
+   */
+  public Series(String name) {
+    if (name == null)
+      throw new NullPointerException("Parameter 'name' cannot be null.");
+    if (name.length() == 0)
+      throw new IllegalArgumentException("Parameter 'name' cannot be empty.");
+
+    this.name = name;
+  }
+
+  /**
+   * Creates a new instance of a Series object, initializes with specified
+   * parameters.
+   * 
    * @param id   Primary key
    * @param name Unique name
    */
   public Series(int id, String name) {
+    this(name);
     this.id = id;
-    this.name = name;
+  }
+
+  /**
+   * Creates a new instance of a Series object, initializes with specified
+   * parameters.
+   * 
+   * @param id      Primary key
+   * @param name    Unique name
+   * @param version Row version value
+   */
+  public Series(int id, String name, int version) {
+    this(id, name);
+    this.setVersion(version);
   }
 
   /**

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/Tag.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/Tag.java
@@ -92,6 +92,19 @@ public class Tag extends AuditColumns {
   }
 
   /**
+   * Creates a new instance of a Tag object, initializes with specified
+   * parameters.
+   * 
+   * @param id      Primary key
+   * @param name    Unique name
+   * @param version Row version value
+   */
+  public Tag(String id, String name, int version) {
+    this(id, name);
+    this.setVersion(version);
+  }
+
+  /**
    * @return String return the id
    */
   public String getId() {

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/TimeTracking.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/TimeTracking.java
@@ -106,6 +106,21 @@ public class TimeTracking extends AuditColumns {
    * parameters.
    * 
    * @param content  Content object
+   * @param user     User object
+   * @param effort   Number of minutes
+   * @param activity Description of effort
+   * @param version  Row version value
+   */
+  public TimeTracking(Content content, User user, float effort, String activity, int version) {
+    this(content, user, effort, activity);
+    this.setVersion(version);
+  }
+
+  /**
+   * Creates a new instance of a TimeTracking object, initializes with specified
+   * parameters.
+   * 
+   * @param content  Content object
    * @param userId   Foreign key to User object
    * @param effort   Number of minutes
    * @param activity Description of effort
@@ -131,6 +146,21 @@ public class TimeTracking extends AuditColumns {
    * Creates a new instance of a TimeTracking object, initializes with specified
    * parameters.
    * 
+   * @param content  Content object
+   * @param userId   Foreign key to User object
+   * @param effort   Number of minutes
+   * @param activity Description of effort
+   * @param version  Row version value
+   */
+  public TimeTracking(Content content, int userId, float effort, String activity, int version) {
+    this(content, userId, effort, activity);
+    this.setVersion(version);
+  }
+
+  /**
+   * Creates a new instance of a TimeTracking object, initializes with specified
+   * parameters.
+   * 
    * @param contentId Foreign key to Content object
    * @param userId    Foreign key to User object
    * @param effort    Number of minutes
@@ -148,6 +178,21 @@ public class TimeTracking extends AuditColumns {
     this.userId = userId;
     this.effort = effort;
     this.activity = activity;
+  }
+
+  /**
+   * Creates a new instance of a TimeTracking object, initializes with specified
+   * parameters.
+   * 
+   * @param contentId Foreign key to Content object
+   * @param userId    Foreign key to User object
+   * @param effort    Number of minutes
+   * @param activity  Description of effort
+   * @param version   Row version value
+   */
+  public TimeTracking(int contentId, int userId, float effort, String activity, int version) {
+    this(contentId, userId, effort, activity);
+    this.setVersion(version);
   }
 
   /**

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/TonePool.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/TonePool.java
@@ -97,12 +97,11 @@ public class TonePool extends AuditColumns {
    * Creates a new instance of a TonePool object, initializes with specified
    * parameters.
    * 
-   * @param id     Primary key
    * @param name   Unique name
    * @param owner  User object who owns this tone pool
    * @param shared Whether this tone pool is shared with everyone
    */
-  public TonePool(int id, String name, User owner, boolean shared) {
+  public TonePool(String name, User owner, boolean shared) {
     if (name == null)
       throw new NullPointerException("Parameter 'name' cannot be null.");
     if (name.length() == 0)
@@ -110,10 +109,57 @@ public class TonePool extends AuditColumns {
     if (owner == null)
       throw new NullPointerException("Parameter 'owner' cannot be null.");
 
-    this.id = id;
     this.name = name;
     this.owner = owner;
     this.ownerId = owner.getId();
+    this.shared = shared;
+  }
+
+  /**
+   * Creates a new instance of a TonePool object, initializes with specified
+   * parameters.
+   * 
+   * @param id     Primary key
+   * @param name   Unique name
+   * @param owner  User object who owns this tone pool
+   * @param shared Whether this tone pool is shared with everyone
+   */
+  public TonePool(int id, String name, User owner, boolean shared) {
+    this(name, owner, shared);
+    this.id = id;
+  }
+
+  /**
+   * Creates a new instance of a TonePool object, initializes with specified
+   * parameters.
+   * 
+   * @param id      Primary key
+   * @param name    Unique name
+   * @param owner   User object who owns this tone pool
+   * @param shared  Whether this tone pool is shared with everyone
+   * @param version Row version value
+   */
+  public TonePool(int id, String name, User owner, boolean shared, int version) {
+    this(id, name, owner, shared);
+    this.setVersion(version);
+  }
+
+  /**
+   * Creates a new instance of a TonePool object, initializes with specified
+   * parameters.
+   * 
+   * @param name    Unique name
+   * @param ownerId Foreign key to user who owns the tone pool
+   * @param shared  Whether this tone pool is shared with everyone
+   */
+  public TonePool(String name, int ownerId, boolean shared) {
+    if (name == null)
+      throw new NullPointerException("Parameter 'name' cannot be null.");
+    if (name.length() == 0)
+      throw new IllegalArgumentException("Parameter 'name' cannot be empty.");
+
+    this.name = name;
+    this.ownerId = ownerId;
     this.shared = shared;
   }
 
@@ -127,15 +173,23 @@ public class TonePool extends AuditColumns {
    * @param shared  Whether this tone pool is shared with everyone
    */
   public TonePool(int id, String name, int ownerId, boolean shared) {
-    if (name == null)
-      throw new NullPointerException("Parameter 'name' cannot be null.");
-    if (name.length() == 0)
-      throw new IllegalArgumentException("Parameter 'name' cannot be empty.");
-
+    this(name, ownerId, shared);
     this.id = id;
-    this.name = name;
-    this.ownerId = ownerId;
-    this.shared = shared;
+  }
+
+  /**
+   * Creates a new instance of a TonePool object, initializes with specified
+   * parameters.
+   * 
+   * @param id      Primary key
+   * @param name    Unique name
+   * @param ownerId Foreign key to user who owns the tone pool
+   * @param shared  Whether this tone pool is shared with everyone
+   * @param version Row version value
+   */
+  public TonePool(int id, String name, int ownerId, boolean shared, int version) {
+    this(id, name, ownerId, shared);
+    this.setVersion(version);
   }
 
   /**

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/User.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/User.java
@@ -116,14 +116,76 @@ public class User extends AuditColumns {
    * Creates a new instance of a user object, initializes with specified
    * parameters.
    * 
+   * @param username The unique username to identify the user.
+   * @param email    The user's email address.
+   */
+  public User(String username, String email) {
+    super();
+
+    if (username == null)
+      throw new NullPointerException("Parameter 'username' cannot be null.");
+    if (username.length() == 0)
+      throw new IllegalArgumentException("Parameter 'username' cannot be empty.");
+    if (email == null)
+      throw new NullPointerException("Parameter 'email' cannot be null.");
+    if (email.length() == 0)
+      throw new IllegalArgumentException("Parameter 'email' cannot be empty.");
+
+    this.username = username;
+    this.email = email;
+  }
+
+  /**
+   * Creates a new instance of a user object, initializes with specified
+   * parameters.
+   * 
    * @param id       The primary key.
    * @param username The unique username to identify the user.
    * @param email    The user's email address.
    */
   public User(int id, String username, String email) {
-    super();
+    this(username, email);
     this.id = id;
+  }
+
+  /**
+   * Creates a new instance of a user object, initializes with specified
+   * parameters.
+   * 
+   * @param id       The primary key.
+   * @param username The unique username to identify the user.
+   * @param email    The user's email address.
+   * @param version  Row version value
+   */
+  public User(int id, String username, String email, int version) {
+    this(id, username, email);
+    this.setVersion(version);
+  }
+
+  /**
+   * Creates a new instance of a user object, initializes with specified
+   * parameters.
+   * 
+   * @param username The unique username to identify the user.
+   * @param key      A unique key to identify the user.
+   * @param email    The user's email address.
+   */
+  public User(String username, UUID key, String email) {
+    if (username == null)
+      throw new NullPointerException("Parameter 'username' cannot be null.");
+    if (username.length() == 0)
+      throw new IllegalArgumentException("Parameter 'username' cannot be empty.");
+
+    if (key == null)
+      throw new NullPointerException("Parameter 'key' cannot be null.");
+
+    if (email == null)
+      throw new NullPointerException("Parameter 'email' cannot be null.");
+    if (email.length() == 0)
+      throw new IllegalArgumentException("Parameter 'email' cannot be empty.");
+
     this.username = username;
+    this.key = key;
     this.email = email;
   }
 
@@ -137,10 +199,23 @@ public class User extends AuditColumns {
    * @param email    The user's email address.
    */
   public User(int id, String username, UUID key, String email) {
+    this(username, key, email);
     this.id = id;
-    this.username = username;
-    this.key = key;
-    this.email = email;
+  }
+
+  /**
+   * Creates a new instance of a user object, initializes with specified
+   * parameters.
+   * 
+   * @param id       The primary key.
+   * @param username The unique username to identify the user.
+   * @param key      A unique key to identify the user.
+   * @param email    The user's email address.
+   * @param version  Row version value
+   */
+  public User(int id, String username, UUID key, String email, int version) {
+    this(id, username, key, email);
+    this.setVersion(version);
   }
 
   /**

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/UserRole.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/entities/UserRole.java
@@ -79,12 +79,38 @@ public class UserRole extends AuditColumns {
    * Creates a new instance of a UserRole object, initializes with specified
    * parameters.
    * 
+   * @param user    The user.
+   * @param role    The role.
+   * @param version Row version value
+   */
+  public UserRole(User user, Role role, int version) {
+    this(user, role);
+    this.setVersion(version);
+  }
+
+  /**
+   * Creates a new instance of a UserRole object, initializes with specified
+   * parameters.
+   * 
    * @param userId Foreign key to The user.
    * @param roleId Foreign key to The role.
    */
   public UserRole(int userId, int roleId) {
     this.userId = userId;
     this.roleId = roleId;
+  }
+
+  /**
+   * Creates a new instance of a UserRole object, initializes with specified
+   * parameters.
+   * 
+   * @param userId  Foreign key to The user.
+   * @param roleId  Foreign key to The role.
+   * @param version Row version value
+   */
+  public UserRole(int userId, int roleId, int version) {
+    this(userId, roleId);
+    this.setVersion(version);
   }
 
   /**

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/repositories/interfaces/IActionRepository.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/repositories/interfaces/IActionRepository.java
@@ -13,5 +13,11 @@ import ca.bc.gov.tno.dal.db.entities.Action;
  */
 @Repository
 public interface IActionRepository extends JpaRepository<Action, Integer> {
+  /**
+   * Find the action by it's name.
+   * 
+   * @param name The name to search for.
+   * @return An Optional{Action} if found with the specified name.
+   */
   Optional<Action> findByName(String name);
 }

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/repositories/interfaces/IRefreshRepository.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/repositories/interfaces/IRefreshRepository.java
@@ -5,7 +5,15 @@ import org.springframework.data.repository.NoRepositoryBean;
 
 import java.io.Serializable;
 
+/**
+ * IRefreshRepository interface, provides a repository with a refresh feature.
+ */
 @NoRepositoryBean
 public interface IRefreshRepository<T, ID extends Serializable> extends JpaRepository<T, ID> {
+  /**
+   * Refresh the specified entity.
+   * 
+   * @param t The entity to refresh.
+   */
   void refresh(T t);
 }

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ActionService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ActionService.java
@@ -25,7 +25,8 @@ public class ActionService implements IActionService {
    * Creates a new instance of a ActionService object, initializes with
    * specified parameters.
    * 
-   * @param repository The action repository.
+   * @param sessionFactory The session factory.
+   * @param repository     The action repository.
    */
   @Autowired
   public ActionService(final SessionFactory sessionFactory, final IActionRepository repository) {

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ContentActionService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ContentActionService.java
@@ -69,7 +69,7 @@ public class ContentActionService implements IContentActionService {
    * @return A new instance of the content action if it exists.
    */
   @Override
-  public List<ContentAction> findById(int contentId) {
+  public List<ContentAction> findByContentId(int contentId) {
     var session = sessionFactory.getCurrentSession();
     var ts = session.beginTransaction();
 

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ContentCategoryService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ContentCategoryService.java
@@ -69,7 +69,7 @@ public class ContentCategoryService implements IContentCategoryService {
    * @return A new instance of the content category if it exists.
    */
   @Override
-  public List<ContentCategory> findById(int contentId) {
+  public List<ContentCategory> findByContentId(int contentId) {
     var session = sessionFactory.getCurrentSession();
     var ts = session.beginTransaction();
 

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ContentLinkService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ContentLinkService.java
@@ -69,7 +69,7 @@ public class ContentLinkService implements IContentLinkService {
    * @return A new instance of the content link if it exists.
    */
   @Override
-  public List<ContentLink> findById(int contentId) {
+  public List<ContentLink> findByContentId(int contentId) {
     var session = sessionFactory.getCurrentSession();
     var ts = session.beginTransaction();
 

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ContentTagService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ContentTagService.java
@@ -69,7 +69,7 @@ public class ContentTagService implements IContentTagService {
    * @return A new instance of the content tag if it exists.
    */
   @Override
-  public List<ContentTag> findById(int contentId) {
+  public List<ContentTag> findByContentId(int contentId) {
     var session = sessionFactory.getCurrentSession();
     var ts = session.beginTransaction();
 

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ContentToneService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/ContentToneService.java
@@ -68,7 +68,7 @@ public class ContentToneService implements IContentToneService {
    * @return A new instance of the content tone if it exists.
    */
   @Override
-  public List<ContentTone> findById(int contentId) {
+  public List<ContentTone> findByContentId(int contentId) {
     var session = sessionFactory.getCurrentSession();
     var ts = session.beginTransaction();
 

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/Settings.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/Settings.java
@@ -1,5 +1,11 @@
 package ca.bc.gov.tno.dal.db.services;
 
+/**
+ * Settings static class, provides configuration settings.
+ */
 public class Settings {
+  /**
+   * Default DateTime format.
+   */
   public final static String dateTimeFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 }

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/interfaces/IContentActionService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/interfaces/IContentActionService.java
@@ -32,7 +32,7 @@ public interface IContentActionService {
    * @param contentId The content primary key.
    * @return A new instance of the content action if it exists.
    */
-  List<ContentAction> findById(int contentId);
+  List<ContentAction> findByContentId(int contentId);
 
   /**
    * Add a new content action to the content.

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/interfaces/IContentCategoryService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/interfaces/IContentCategoryService.java
@@ -32,7 +32,7 @@ public interface IContentCategoryService {
    * @param contentId The content primary key.
    * @return A new instance of the content category if it exists.
    */
-  List<ContentCategory> findById(int contentId);
+  List<ContentCategory> findByContentId(int contentId);
 
   /**
    * Add a new content category to the content.

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/interfaces/IContentLinkService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/interfaces/IContentLinkService.java
@@ -32,7 +32,7 @@ public interface IContentLinkService {
    * @param contentId The content primary key.
    * @return A new instance of the content link if it exists.
    */
-  List<ContentLink> findById(int contentId);
+  List<ContentLink> findByContentId(int contentId);
 
   /**
    * Add a new content link to the content.

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/interfaces/IContentTagService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/interfaces/IContentTagService.java
@@ -32,7 +32,7 @@ public interface IContentTagService {
    * @param contentId The content primary key.
    * @return A new instance of the content tag if it exists.
    */
-  List<ContentTag> findById(int contentId);
+  List<ContentTag> findByContentId(int contentId);
 
   /**
    * Add a new content tag to the content.

--- a/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/interfaces/IContentToneService.java
+++ b/libs/java/dal/db/dal-db/src/main/java/ca/bc/gov/tno/dal/db/services/interfaces/IContentToneService.java
@@ -32,7 +32,7 @@ public interface IContentToneService {
    * @param contentId The content primary key.
    * @return A new instance of the content tone if it exists.
    */
-  List<ContentTone> findById(int contentId);
+  List<ContentTone> findByContentId(int contentId);
 
   /**
    * Add a new content tone to the content.


### PR DESCRIPTION
Adding content should now save links.

Updating content should now add/update/delete child entities (links, fileReferences, tags, categories, actions, timeTrackings, tonePools).

Please note that to update a child entity you must set the `updatedOn = undefined` when using POST/PUT, otherwise it won't know to update it.  Additionally child entities that don't have their own unique primary key like `TimeTracking` require you to set the `createdOn = undefined` so that it knows it's a new entity that must be added.

> Requires `make refresh n=api-editor`