### PR TITLE
Fix content list view filter

### DIFF
--- a/app/editor/src/features/content/list-view/ContentListView.tsx
+++ b/app/editor/src/features/content/list-view/ContentListView.tsx
@@ -18,7 +18,14 @@ import { useApp } from 'store/hooks/app/useApp';
 import { initialContentState } from 'store/slices';
 import { getSortableOptions, getUserOptions } from 'utils';
 
-import { columns, defaultPage, fieldTypes, logicalOperators, timeFrames } from './constants';
+import {
+  columns,
+  defaultFilter,
+  defaultPage,
+  fieldTypes,
+  logicalOperators,
+  timeFrames,
+} from './constants';
 import * as styled from './ContentListViewStyled';
 import { IContentListFilter, ISortBy } from './interfaces';
 import { makeFilter } from './makeFilter';
@@ -30,7 +37,7 @@ export const ContentListView: React.FC = () => {
     { filter, filterAdvanced, sortBy },
     { findContent },
     { storeFilter, storeFilterAdvanced, storeSortBy },
-  ] = useContent();
+  ] = useContent({ filter: { ...defaultFilter, userId: userInfo?.id ?? 0 } });
   const navigate = useNavigate();
 
   const [mediaTypeOptions, setMediaTypes] = React.useState<IOptionItem[]>([]);
@@ -47,14 +54,6 @@ export const ContentListView: React.FC = () => {
     setMediaTypes(getSortableOptions(mediaTypes, [new OptionItem<number>('All Media', 0)]));
     setUsers(getUserOptions(users, [new OptionItem<number>('All Users', 0)]));
   }, [contentTypes, mediaTypes, users]);
-
-  React.useEffect(() => {
-    // Only update filter if the userInfo changes.
-    if (userInfo?.id) {
-      storeFilter({ ...filter, userId: userInfo?.id });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userInfo?.id]);
 
   const fetch = React.useCallback(
     async (filter: IContentListFilter, sortBy: ISortBy[]) => {

--- a/app/editor/src/features/content/list-view/constants/defaultFilter.ts
+++ b/app/editor/src/features/content/list-view/constants/defaultFilter.ts
@@ -1,0 +1,16 @@
+import { IContentListFilter } from '../interfaces';
+import { defaultPage } from './defaultPage';
+
+export const defaultFilter: IContentListFilter = {
+  pageIndex: defaultPage.pageIndex,
+  pageSize: defaultPage.pageIndex,
+  mediaTypeId: 0,
+  contentTypeId: 0,
+  ownerId: 0,
+  userId: 0,
+  timeFrame: 0,
+  included: '',
+  onTicker: '',
+  commentary: '',
+  topStory: '',
+};

--- a/app/editor/src/features/content/list-view/constants/index.ts
+++ b/app/editor/src/features/content/list-view/constants/index.ts
@@ -1,4 +1,5 @@
 export * from './columns';
+export * from './defaultFilter';
 export * from './defaultPage';
 export * from './fieldTypes';
 export * from './logicalOperators';

--- a/app/editor/src/store/hooks/content/useContent.ts
+++ b/app/editor/src/store/hooks/content/useContent.ts
@@ -2,7 +2,7 @@ import { IContentFilter, IContentModel, IPaged } from 'hooks';
 import { useApiContents } from 'hooks/api-editor/editor';
 import React from 'react';
 import { IContentStore, useContentStore } from 'store/slices';
-import { IContentState } from 'store/slices/content';
+import { IContentProps, IContentState } from 'store/slices/content';
 
 interface IContentHook {
   getContent: (id: number) => Promise<IContentModel>;
@@ -12,8 +12,8 @@ interface IContentHook {
   deleteContent: (content: IContentModel) => Promise<IContentModel>;
 }
 
-export const useContent = (): [IContentState, IContentHook, IContentStore] => {
-  const [state, store] = useContentStore();
+export const useContent = (props?: IContentProps): [IContentState, IContentHook, IContentStore] => {
+  const [state, store] = useContentStore(props);
   const api = useApiContents();
 
   const hook: IContentHook = React.useMemo(

--- a/app/editor/src/store/slices/content/useContentStore.ts
+++ b/app/editor/src/store/slices/content/useContentStore.ts
@@ -5,9 +5,14 @@ import {
 } from 'features/content/list-view/interfaces';
 import React from 'react';
 import { useAppDispatch, useAppSelector } from 'store';
+import useDeepCompareEffect from 'tno-core/dist/hooks/useDeepCompareEffect';
 
 import { storeFilter, storeFilterAdvanced, storeSortBy } from '.';
 import { IContentState } from './interfaces';
+
+export interface IContentProps {
+  filter: IContentListFilter;
+}
 
 export interface IContentStore {
   storeFilter: (filter: IContentListFilter) => void;
@@ -15,7 +20,7 @@ export interface IContentStore {
   storeSortBy: (sortBy: ISortBy[]) => void;
 }
 
-export const useContentStore = (): [IContentState, IContentStore] => {
+export const useContentStore = (props?: IContentProps): [IContentState, IContentStore] => {
   const dispatch = useAppDispatch();
   const state = useAppSelector((store) => store.content);
 
@@ -33,6 +38,12 @@ export const useContentStore = (): [IContentState, IContentStore] => {
     }),
     [dispatch],
   );
+
+  useDeepCompareEffect(() => {
+    if (props?.filter) {
+      controller.storeFilter(props?.filter);
+    }
+  }, [controller, props?.filter]);
 
   return [state, controller];
 };


### PR DESCRIPTION
The content list view filter wasn't correctly displaying/updating when returning to the page.  I've provided a way to set the default filter and removed one of the `React.useEffect(...)` calls.  Seems to be working now.

> Requires an `make npm-refresh`

I've noticed a few other minor issues with the page that will need to be resolved in the future.

- Table formatting when it has rows
- Paging button styling
- Table doesn't extend to end of div properly
- Need to keep the active filter when returning to the page instead of starting over with default filter
- Need to place filter parameters into URL so it can be shared or returned to from expired session.  This will need a common hook to handle.