### PR TITLE
TNO-228 Yarn clean cache

### DIFF
--- a/app/editor/Dockerfile.nginx
+++ b/app/editor/Dockerfile.nginx
@@ -5,6 +5,7 @@ USER root
 WORKDIR /usr/src/app
 COPY package*.json yarn.lock ./
 
+RUN yarn cache clean
 RUN yarn
 COPY . ./
 

--- a/app/editor/Dockerfile.rhel8
+++ b/app/editor/Dockerfile.rhel8
@@ -5,6 +5,7 @@ USER root
 WORKDIR /usr/src/app
 COPY package*.json yarn.lock ./
 
+RUN yarn cache clean
 RUN yarn
 COPY . ./
 


### PR DESCRIPTION
When building in Openshift `yarn` runs into network issues.  Which causes the build to fail 90% of the time.  The Lab suggested to run `yarn cache clean` before building.  I'm not optimistic that this will resolve the issue.