### PR TITLE
Content List View Bug Fix

### DIFF
--- a/app/editor/src/features/content/list-view/ContentListView.tsx
+++ b/app/editor/src/features/content/list-view/ContentListView.tsx
@@ -327,7 +327,7 @@ export const ContentListView: React.FC = () => {
           columns={columns}
           page={page}
           sortBy={sortBy}
-          onRowClick={(row) => navigate(`/contents/${row.id}`)}
+          onRowClick={(row) => navigate(`/contents/${row.original.id}`)}
           onChangePage={handleChangePage}
           onChangeSort={handleChangeSort}
         ></PagedTable>


### PR DESCRIPTION
When clicking a row, the wrong id was being provided. `row.original` contains the values we need.

`row.id` is the id of the row itself not the content

Ex)
Row 1 would have row.id of 0
Row 2 would have row.id of 1

