### PR TITLE
Tno 255

### DIFF
--- a/libs/java/service/src/main/java/ca/bc/gov/tno/services/data/config/DataSourceConfig.java
+++ b/libs/java/service/src/main/java/ca/bc/gov/tno/services/data/config/DataSourceConfig.java
@@ -229,6 +229,13 @@ public class DataSourceConfig {
   }
 
   /**
+   * Increment the failed attempts.
+   */
+  public void incrementFailedAttempts() {
+    this.failedAttempts++;
+  }
+
+  /**
    * @return List{ScheduleConfig} return the schedules
    */
   public List<ScheduleConfig> getSchedules() {

--- a/libs/java/service/src/main/java/ca/bc/gov/tno/services/data/config/DataSourceConfig.java
+++ b/libs/java/service/src/main/java/ca/bc/gov/tno/services/data/config/DataSourceConfig.java
@@ -59,7 +59,7 @@ public class DataSourceConfig {
   /**
    * Maximum number of failed attempts.
    */
-  private int failedAttempts;
+  public int failedAttempts;
 
   /**
    * An array of schedules for this data source.
@@ -226,13 +226,6 @@ public class DataSourceConfig {
    */
   public void setFailedAttempts(int failedAttempts) {
     this.failedAttempts = failedAttempts;
-  }
-
-  /**
-   * Increment the failed attempts.
-   */
-  public void incrementFailedAttempts() {
-    this.failedAttempts++;
   }
 
   /**

--- a/libs/java/service/src/main/java/ca/bc/gov/tno/services/events/ErrorEvent.java
+++ b/libs/java/service/src/main/java/ca/bc/gov/tno/services/events/ErrorEvent.java
@@ -2,6 +2,8 @@ package ca.bc.gov.tno.services.events;
 
 import org.springframework.context.ApplicationEvent;
 
+import ca.bc.gov.tno.services.data.config.DataSourceConfig;
+
 /**
  * ErrorEvent class, provides an event that indicates an error has occurred.
  */
@@ -12,8 +14,13 @@ public class ErrorEvent extends ApplicationEvent {
   private final Exception exception;
 
   /**
+   * The data source being processed.
+   */
+  private final DataSourceConfig config;
+
+  /**
    * Creates a new instance of an ErrorEvent, initializes with specified
-   * parameters.
+   * parameters. Retained while testing ongoing in select services.
    * 
    * @param source    The source of the event.
    * @param exception The exception that was thrown.
@@ -21,6 +28,20 @@ public class ErrorEvent extends ApplicationEvent {
   public ErrorEvent(final Object source, final Exception exception) {
     super(source);
     this.exception = exception;
+    this.config = null;
+  }
+
+  /**
+   * Creates a new instance of an ErrorEvent, initializes with specified
+   * parameters.
+   * 
+   * @param source    The source of the event.
+   * @param exception The exception that was thrown.
+   */
+  public ErrorEvent(final Object source, final Exception exception, final DataSourceConfig config) {
+    super(source);
+    this.exception = exception;
+    this.config = config;
   }
 
   /**
@@ -30,5 +51,14 @@ public class ErrorEvent extends ApplicationEvent {
    */
   public Exception getError() {
     return exception;
+  }
+
+  /**
+   * Get the config for the data data source being processed.
+   * 
+   * @return The exception that was thrown.
+   */
+  public DataSourceConfig getConfig() {
+    return config;
   }
 }

--- a/libs/java/service/src/main/java/ca/bc/gov/tno/services/handlers/ErrorHandler.java
+++ b/libs/java/service/src/main/java/ca/bc/gov/tno/services/handlers/ErrorHandler.java
@@ -66,7 +66,7 @@ public class ErrorHandler implements ApplicationListener<ErrorEvent> {
       state.incrementFailedAttempts();
       
       if (config != null) {
-        config.incrementFailedAttempts();
+        config.failedAttempts++;
         var result = dataSourceService.findByCode(config.getId());
         var dataSource = result.get();
         dataSource.setFailedAttempts(config.getFailedAttempts());

--- a/services/capture/src/main/java/ca/bc/gov/tno/services/capture/config/CaptureConfig.java
+++ b/services/capture/src/main/java/ca/bc/gov/tno/services/capture/config/CaptureConfig.java
@@ -57,7 +57,7 @@ public class CaptureConfig extends DataSourceConfig {
   private String timeZone;
 
   /**
-   * The command executing this capture process
+   * The curl or ffmpeg command executing this capture process
    */
   private String runningNow;
 
@@ -77,6 +77,8 @@ public class CaptureConfig extends DataSourceConfig {
   public CaptureConfig(DataSource dataSource) {
     super(dataSource);
 
+    setFailedAttempts(dataSource.getFailedAttempts());
+    setMaxFailedAttempts(dataSource.getRetryLimit());
     var connection = dataSource.getConnection();
 
     setAudioUrl((String) connection.get("audioUrl"));
@@ -210,7 +212,7 @@ public class CaptureConfig extends DataSourceConfig {
   }
 
   /**
-   * @param url the command for this capture process to set
+   * @param command The curl or ffmpeg command currently running
    */
   public void setRunningNow(String command) {
     this.runningNow = command;

--- a/services/capture/src/main/java/ca/bc/gov/tno/services/capture/handlers/FetchDataService.java
+++ b/services/capture/src/main/java/ca/bc/gov/tno/services/capture/handlers/FetchDataService.java
@@ -14,8 +14,6 @@ import ca.bc.gov.tno.services.data.config.ScheduleConfig;
 import ca.bc.gov.tno.services.data.events.TransactionBeginEvent;
 import ca.bc.gov.tno.services.data.events.TransactionCompleteEvent;
 import ca.bc.gov.tno.services.events.ErrorEvent;
-import ca.bc.gov.tno.services.handlers.ErrorHandler;
-import ca.bc.gov.tno.services.ServiceState;
 import ca.bc.gov.tno.services.capture.config.CaptureConfig;
 
 import org.springframework.scheduling.annotation.Async;
@@ -35,17 +33,13 @@ public class FetchDataService implements ApplicationListener<TransactionBeginEve
   private Object caller;
   private CaptureConfig captureConfig;
   private ScheduleConfig schedule;
-  private ServiceState state;
-  private ErrorHandler ehandler;
 
   /**
    * Create a new instance of a FetchDataService object.
    */
   @Autowired
-  public FetchDataService(final ApplicationEventPublisher eventPublisher, final ServiceState state, ErrorHandler ehandler) {
+  public FetchDataService(final ApplicationEventPublisher eventPublisher) {
     this.eventPublisher = eventPublisher;
-    this.state = state;
-    this.ehandler = ehandler;
   }
 
   /**


### PR DESCRIPTION
Changes for handling failed attempts per Data Source.

The main changes for this PR are to the error ErrorHandler class. The BaseScheduleService is waiting:

              synchronized (this) {
                wait();
              }

for the TransactionBeginEvent to complete and trigger a TransactionCompleteEvent. This will call handleTransactionCompleteEvent which executes:

        synchronized (this) {
          notify();
        }

To free up the BaseSheduleService. If an error occurs this wasn't happening (prior to my changes) so I added the code:

       if (source instanceof BaseScheduleService) {
          synchronized(source) {
            source.notify();
          }
        } 

which did the trick. This meant inserting the BaseScheduleService instance into the ErrorEvent rather than the actual caller, which results in the wrong class name being used in the error message.

I did a git rebase origin/dev, resolved all conflicts and then git rebase -i origin/dev to squash the commits, so I'm unsure why there are multiple commits in the PR.
