### PR TITLE
PSP-289: Update timelog to state variable

### DIFF
--- a/app/editor/src/features/content/form/PropertiesContentForm.tsx
+++ b/app/editor/src/features/content/form/PropertiesContentForm.tsx
@@ -4,7 +4,7 @@ import { FormikDatePicker } from 'components/formik/datepicker';
 import { Modal } from 'components/modal/Modal';
 import { Upload } from 'components/upload';
 import { useFormikContext } from 'formik';
-import { IUserModel } from 'hooks/api-editor';
+import { ITimeTrackingModel, IUserModel } from 'hooks/api-editor';
 import { useModal } from 'hooks/modal';
 import moment from 'moment';
 import React from 'react';
@@ -38,7 +38,7 @@ export const PropertiesContentForm: React.FC<IContentSubForms> = ({ setContent, 
   const [effort, setEffort] = React.useState(getTotalTime(values.timeTrackings));
 
   const userId = users.find((u: IUserModel) => u.username === keycloak.getUsername())?.id;
-  let timeLog = values.timeTrackings;
+  const [timeLog, setTimeLog] = React.useState<ITimeTrackingModel[]>(values.timeTrackings);
 
   React.useEffect(() => {
     setCategoryOptions(getSortableOptions(categories));
@@ -214,12 +214,15 @@ export const PropertiesContentForm: React.FC<IContentSubForms> = ({ setContent, 
           variant={ButtonVariant.action}
           onClick={() => {
             setEffort(effort!! + Number((values as any).prep));
-            timeLog.push({
-              userId: userId ?? 0,
-              activity: !!values.id ? 'Updated' : 'Created',
-              effort: (values as any).prep,
-              createdOn: new Date(),
-            });
+            setTimeLog([
+              ...timeLog,
+              {
+                userId: userId ?? 0,
+                activity: !!values.id ? 'Updated' : 'Created',
+                effort: (values as any).prep,
+                createdOn: new Date(),
+              },
+            ]);
             setFieldValue('timeTrackings', timeLog);
             setFieldValue('prep', '');
           }}

--- a/app/editor/src/features/content/form/PropertiesContentForm.tsx
+++ b/app/editor/src/features/content/form/PropertiesContentForm.tsx
@@ -4,7 +4,7 @@ import { FormikDatePicker } from 'components/formik/datepicker';
 import { Modal } from 'components/modal/Modal';
 import { Upload } from 'components/upload';
 import { useFormikContext } from 'formik';
-import { ITimeTrackingModel, IUserModel } from 'hooks/api-editor';
+import { IUserModel } from 'hooks/api-editor';
 import { useModal } from 'hooks/modal';
 import moment from 'moment';
 import React from 'react';
@@ -35,10 +35,13 @@ export const PropertiesContentForm: React.FC<IContentSubForms> = ({ setContent, 
   const [categoryOptions, setCategoryOptions] = React.useState<IOptionItem[]>([]);
   const [seriesOptions, setSeriesOptions] = React.useState<IOptionItem[]>([]);
   const [licenseOptions, setLicenseOptions] = React.useState<IOptionItem[]>([]);
-  const [effort, setEffort] = React.useState(getTotalTime(values.timeTrackings));
+  const [effort, setEffort] = React.useState(0);
 
   const userId = users.find((u: IUserModel) => u.username === keycloak.getUsername())?.id;
-  const [timeLog, setTimeLog] = React.useState<ITimeTrackingModel[]>(values.timeTrackings);
+
+  React.useEffect(() => {
+    setEffort(getTotalTime(values.timeTrackings));
+  }, [values.timeTrackings]);
 
   React.useEffect(() => {
     setCategoryOptions(getSortableOptions(categories));
@@ -214,8 +217,8 @@ export const PropertiesContentForm: React.FC<IContentSubForms> = ({ setContent, 
           variant={ButtonVariant.action}
           onClick={() => {
             setEffort(effort!! + Number((values as any).prep));
-            setTimeLog([
-              ...timeLog,
+            setFieldValue('timeTrackings', [
+              ...values.timeTrackings,
               {
                 userId: userId ?? 0,
                 activity: !!values.id ? 'Updated' : 'Created',
@@ -223,7 +226,6 @@ export const PropertiesContentForm: React.FC<IContentSubForms> = ({ setContent, 
                 createdOn: new Date(),
               },
             ]);
-            setFieldValue('timeTrackings', timeLog);
             setFieldValue('prep', '');
           }}
         >
@@ -244,7 +246,7 @@ export const PropertiesContentForm: React.FC<IContentSubForms> = ({ setContent, 
           hide={toggle}
           isShowing={isShowing}
           headerText="Prep Time Log"
-          body={<TimeLogTable totalTime={effort} data={timeLog} />}
+          body={<TimeLogTable totalTime={effort} data={values.timeTrackings} />}
           customButtons={
             <Button variant={ButtonVariant.action} onClick={toggle}>
               Close


### PR DESCRIPTION
Previously the time log would go stale and carry over incorrectly to a new snippet/ an existing one. Tied it to a state variable so it correctly resets to it's corresponding formik values when the "page" changes