### PR TITLE
TNO-214: React tooltip fix

### DIFF
--- a/app/editor/src/App.tsx
+++ b/app/editor/src/App.tsx
@@ -23,6 +23,10 @@ function App() {
     });
   }, []);
 
+  React.useEffect(() => {
+    ReactTooltip.rebuild();
+  });
+
   return (
     <BrowserRouter>
       {keycloak ? (


### PR DESCRIPTION
When a variable is provided for the tooltip that starts out as undefined/null the tooltip will not be shown. The tooltip needs to be rebound after the variable is provided.

![image](https://user-images.githubusercontent.com/15724124/164315379-8025cd03-9c61-4238-bb30-43510977102a.png)
