### PR TITLE
TNO-214: React tooltip fix adjustment

### DIFF
--- a/app/editor/src/App.tsx
+++ b/app/editor/src/App.tsx
@@ -23,10 +23,6 @@ function App() {
     });
   }, []);
 
-  React.useEffect(() => {
-    ReactTooltip.rebuild();
-  });
-
   return (
     <BrowserRouter>
       {keycloak ? (

--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -13,6 +13,7 @@ import { useModal } from 'hooks/modal';
 import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
+import ReactTooltip from 'react-tooltip';
 import { useContent, useLookup } from 'store/hooks';
 import { Button, ButtonVariant, Col, Row, Tab, Tabs, useKeycloakWrapper } from 'tno-core';
 import { getDataSourceOptions, getSortableOptions } from 'utils';
@@ -59,6 +60,10 @@ export const ContentForm: React.FC = () => {
   React.useEffect(() => {
     setMediaTypeOptions(getSortableOptions(mediaTypes));
   }, [mediaTypes]);
+
+  React.useEffect(() => {
+    ReactTooltip.rebuild();
+  });
 
   const handleSubmit = async (values: IContentForm) => {
     const originalId = values.id;

--- a/app/editor/src/features/content/list-view/ContentListView.tsx
+++ b/app/editor/src/features/content/list-view/ContentListView.tsx
@@ -13,6 +13,7 @@ import { IContentModel, LogicalOperator } from 'hooks/api-editor';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { SortingRule } from 'react-table';
+import ReactTooltip from 'react-tooltip';
 import { useContent, useLookup } from 'store/hooks';
 import { useApp } from 'store/hooks';
 import { initialContentState } from 'store/slices';
@@ -50,6 +51,10 @@ export const ContentListView: React.FC = () => {
 
   const printContentId = (contentTypeOptions.find((ct) => ct.label === 'Print')?.value ??
     0) as number;
+
+  React.useEffect(() => {
+    ReactTooltip.rebuild();
+  });
 
   React.useEffect(() => {
     setContentTypeOptions(getSortableOptions(contentTypes));


### PR DESCRIPTION
Did some more testing, last fix was not adequate. But got some more answers.

This seems to do the trick now.

"For example, you render a generic tooltip in the root of your app, then load a list of content async. Elements in the list use the data-for={id} attribute to bind the tooltip on hover. Since the tooltip has already scanned for data-tip these new elements will not trigger.

One workaround for this is to trigger ReactTooltip.rebuild() after the data load to scan for the attribute again, to allow event wireup."