### PR TITLE
Rename DataSource.ScheduleType

### DIFF
--- a/libs/net/dal/Migrations/20220421130605_Initial.Designer.cs
+++ b/libs/net/dal/Migrations/20220421130605_Initial.Designer.cs
@@ -12,7 +12,7 @@ using TNO.DAL;
 namespace TNO.DAL.Migrations
 {
     [DbContext(typeof(TNOContext))]
-    [Migration("20220420221740_Initial")]
+    [Migration("20220421130605_Initial")]
     partial class Initial
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -1267,7 +1267,8 @@ namespace TNO.DAL.Migrations
                     b.Property<int>("ScheduleType")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("integer")
-                        .HasDefaultValue(0);
+                        .HasDefaultValue(0)
+                        .HasColumnName("schedule_type");
 
                     b.Property<string>("ShortName")
                         .IsRequired()

--- a/libs/net/dal/Migrations/20220421130605_Initial.cs
+++ b/libs/net/dal/Migrations/20220421130605_Initial.cs
@@ -450,7 +450,7 @@ namespace TNO.DAL.Migrations
                     data_location_id = table.Column<int>(type: "integer", nullable: false),
                     media_type_id = table.Column<int>(type: "integer", nullable: false),
                     license_id = table.Column<int>(type: "integer", nullable: false),
-                    ScheduleType = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    schedule_type = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
                     topic = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
                     connection = table.Column<string>(type: "json", nullable: false),
                     last_ran_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),

--- a/libs/net/dal/Migrations/TNOContextModelSnapshot.cs
+++ b/libs/net/dal/Migrations/TNOContextModelSnapshot.cs
@@ -1265,7 +1265,8 @@ namespace TNO.DAL.Migrations
                     b.Property<int>("ScheduleType")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("integer")
-                        .HasDefaultValue(0);
+                        .HasDefaultValue(0)
+                        .HasColumnName("schedule_type");
 
                     b.Property<string>("ShortName")
                         .IsRequired()

--- a/libs/net/entities/DataSource.cs
+++ b/libs/net/entities/DataSource.cs
@@ -41,6 +41,7 @@ public class DataSource : AuditColumns
 
     public virtual License? License { get; set; }
 
+    [Column("schedule_type")]
     public DataSourceScheduleType ScheduleType { get; set; }
 
     [Column("topic")]


### PR DESCRIPTION
Forgot to provide a database column name override for DataSource.ScheduleType.

> Requires you run a `make db-refresh`