### PR TITLE
TNO-226 Migrate to CrunchyDB

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,9 @@
   "yaml.schemaStore.enable": false,
   "cSpell.words": [
     "formik",
-    "insertable"
+    "insertable",
+    "Kustomization",
+    "kustomize"
   ],
   "java.configuration.updateBuildConfiguration": "interactive"
 }

--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -64,7 +64,7 @@ port-forward: ## Port forward to a pod (n=label name, i=pod index, l=local port,
 	@cd ./scripts; ./port-forward.sh $(n) $(if $(i),$(i),0) $(l) $(r)
 
 db-connect: ## Port forward to the database (e=environment, l=local port, r=remote port).
-	$(info Port forward to the database [e=$(if $(i),$(i),dev)] $(l):$(r))
-	@cd ./scripts; ./database-connect.sh $(if $(i),$(i),dev) $(l) $(r)
+	$(info Port forward to the database [e=$(if $(e),$(e),dev)] $(l):$(r))
+	@cd ./scripts; ./database-connect.sh $(if $(e),$(e),dev) $(l) $(r)
 
 .PHONY: local

--- a/openshift/kustomize/README.md
+++ b/openshift/kustomize/README.md
@@ -1,0 +1,16 @@
+# Kustomize
+
+To setup monitoring of your PostgreSQL HA cluster you will need to install [Kustomize](https://kustomize.io/).
+
+Information on installation [here](https://kubectl.docs.kubernetes.io/installation/kustomize/).
+
+For Windows installation. Open a command prompt as an administrator.
+
+`choco install Kustomize`
+
+## Solution Installation
+
+| Service                                                 | Description                                               |
+| ------------------------------------------------------- | --------------------------------------------------------- |
+| [CrunchyDB HA Cluster](./postgres/crunchy/README.md)    | High availability PostgreSQL database cluster.            |
+| [CrunchyDB HA Monitoring](./postgres/monitor/README.md) | High availability PostgreSQL database cluster monitoring. |

--- a/openshift/kustomize/postgres/crunchy/README.md
+++ b/openshift/kustomize/postgres/crunchy/README.md
@@ -1,0 +1,23 @@
+# CrunchyDB HA Cluster
+
+Original information source from Exchange Lab [here](https://github.com/bcgov/how-to-workshops/tree/master/crunchydb/high-availablility).
+
+To install the CrunchyDB HA Cluster in the **dev** namespace, run the following command.
+
+`oc kustomize ./overlays/dev | oc create -f -`
+
+## Manually Backup
+
+To perform an adhoc backup of the database run the following command.
+
+```
+oc annotate -n 9b301c-test postgrescluster postgres-cluster \
+  postgres-operator.crunchydata.com/pgbackrest-backup="$( date '+%F_%H:%M:%S' )"
+```
+
+Subsequent runs will require the `--overwrite` attribute.
+
+```
+oc annotate -n 9b301c-test postgrescluster postgres-cluster --overwrite \
+  postgres-operator.crunchydata.com/pgbackrest-backup="$( date '+%F_%H:%M:%S' )"
+```

--- a/openshift/kustomize/postgres/crunchy/base/deploy.yaml
+++ b/openshift/kustomize/postgres/crunchy/base/deploy.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: postgres-cluster
+  namespace: default
+  labels:
+    name: postgres-cluster
+    solution: tno
+    app: tno-database
+spec:
+  monitoring:
+    pgmonitor:
+      exporter:
+        image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.0.4-0
+      resources:
+        requests:
+          cpu: 25m
+          memory: 100Mi
+        limits:
+          cpu: 50m
+          memory: 250Mi
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-0
+  postgresVersion: 13
+  instances:
+    - name: tno-database
+      replicas: 3
+      resources:
+        requests:
+          cpu: 50m
+          memory: 250Mi
+        limits:
+          cpu: 250m
+          memory: 2Gi
+      dataVolumeClaimSpec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Gi
+        storageClassName: netapp-block-standard
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    postgres-operator.crunchydata.com/cluster: hippo-ha
+                    postgres-operator.crunchydata.com/instance-set: postgres
+  backups:
+    pgbackrest:
+      global:
+        repo1-retention-full: "2"
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0
+      repoHost:
+        resources:
+          requests:
+            cpu: 50m
+            memory: 100Mi
+          limits:
+            cpu: 250m
+            memory: 1Gi
+      repos:
+        - name: repo1
+          schedules:
+            # Full backup every day at 8:00am UTC
+            full: "0 8 * * *"
+            # Incremental backup every 4 hours, except at 8am UTC (when the full backup is running)
+            incremental: "0 0,4,12,16,20 * * *"
+          volume:
+            volumeClaimSpec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 5Gi
+              storageClassName: netapp-file-backup
+      manual:
+        repoName: repo1
+        options:
+          - --type=full
+  proxy:
+    pgBouncer:
+      config:
+        global:
+          client_tls_sslmode: disable
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-3
+      replicas: 2
+      resources:
+        requests:
+          cpu: 25m
+          memory: 100Mi
+        limits:
+          cpu: 50m
+          memory: 250Mi
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    postgres-operator.crunchydata.com/cluster: hippo-ha
+                    postgres-operator.crunchydata.com/role: pgbouncer

--- a/openshift/kustomize/postgres/crunchy/base/kustomization.yaml
+++ b/openshift/kustomize/postgres/crunchy/base/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - role.yaml
+  - network.yaml
+  - deploy.yaml

--- a/openshift/kustomize/postgres/crunchy/base/network.yaml
+++ b/openshift/kustomize/postgres/crunchy/base/network.yaml
@@ -1,0 +1,51 @@
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: postgres-cluster
+  namespace: default
+  labels:
+    name: postgres-cluster
+    solution: tno
+    app: tno-database
+    postgres-operator.crunchydata.com/cluster: postgres-cluster
+spec:
+  podSelector:
+    matchLabels:
+      postgres-operator.crunchydata.com/cluster: postgres-cluster
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              postgres-operator.crunchydata.com/cluster: postgres-cluster
+      ports:
+        - protocol: TCP
+          port: 5432
+        - protocol: TCP
+          port: 8008
+        - protocol: TCP
+          port: 2022
+
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: postgres-cluster-monitoring
+  namespace: default
+  labels:
+    name: postgres-cluster
+    solution: tno
+    app: tno-database
+    postgres-operator.crunchydata.com/cluster: postgres-cluster
+spec:
+  podSelector:
+    matchLabels:
+      postgres-operator.crunchydata.com/cluster: postgres-cluster
+  ingress:
+    - from:
+        - namespaceSelector:
+            name: 9b301c
+            environment: tools
+      ports:
+        - protocol: TCP
+          port: 9187

--- a/openshift/kustomize/postgres/crunchy/base/role.yaml
+++ b/openshift/kustomize/postgres/crunchy/base/role.yaml
@@ -1,0 +1,41 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: postgres-cluster-monitoring
+  namespace: default
+  labels:
+    name: postgres-cluster-monitoring
+    solution: tno
+    app: tno-database
+    app.kubernetes.io/name: postgres-operator-monitoring
+    vendor: crunchydata
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: postgres-cluster-monitoring
+  namespace: default
+  labels:
+    name: postgres-cluster-monitoring
+    solution: tno
+    app: tno-database
+    vendor: crunchydata
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: postgres-cluster-monitoring
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-sa
+    namespace: 9b301c-tools

--- a/openshift/kustomize/postgres/crunchy/overlays/dev/deploy.yaml
+++ b/openshift/kustomize/postgres/crunchy/overlays/dev/deploy.yaml
@@ -1,0 +1,4 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: postgres-cluster

--- a/openshift/kustomize/postgres/crunchy/overlays/dev/kustomization.yaml
+++ b/openshift/kustomize/postgres/crunchy/overlays/dev/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-dev
+
+resources:
+  - ../../base
+
+patches:
+  - deploy.yaml
+  # - target:
+  #     kind: PostgresCluster
+  #     name: .*
+  #   patch: |-
+  #     - op: replace
+  #       path: /metadata/name
+  #       value: tno-cluster

--- a/openshift/kustomize/postgres/crunchy/overlays/prod/deploy.yaml
+++ b/openshift/kustomize/postgres/crunchy/overlays/prod/deploy.yaml
@@ -1,0 +1,4 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: postgres-cluster

--- a/openshift/kustomize/postgres/crunchy/overlays/prod/kustomization.yaml
+++ b/openshift/kustomize/postgres/crunchy/overlays/prod/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-prod
+
+resources:
+  - ../../base
+
+patches:
+  - deploy.yaml

--- a/openshift/kustomize/postgres/crunchy/overlays/test/deploy.yaml
+++ b/openshift/kustomize/postgres/crunchy/overlays/test/deploy.yaml
@@ -1,0 +1,4 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: postgres-cluster

--- a/openshift/kustomize/postgres/crunchy/overlays/test/kustomization.yaml
+++ b/openshift/kustomize/postgres/crunchy/overlays/test/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-test
+
+resources:
+  - ../../base
+
+patches:
+  - deploy.yaml

--- a/openshift/kustomize/postgres/monitor/README.md
+++ b/openshift/kustomize/postgres/monitor/README.md
@@ -1,0 +1,11 @@
+# CrunchyDB Monitoring
+
+Run the following command to install in the tools namespace.
+
+`oc kustomize . | oc create -f -`
+
+## More information on setup
+
+The Exchange Lab provided the following repo for setup, configuration, and installation of monitoring CrunchyDB.
+
+[https://github.com/bcgov/how-to-workshops/tree/master/crunchydb/monitoring](https://github.com/bcgov/how-to-workshops/tree/master/crunchydb/monitoring)

--- a/openshift/kustomize/postgres/monitor/grafana-config.yaml
+++ b/openshift/kustomize/postgres/monitor/grafana-config.yaml
@@ -1,0 +1,28 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: grafana-config
+data:
+  grafana.ini: |+
+    [auth]
+    disable_login_form = true
+    disable_signout_menu = true
+    oauth_auto_login = true
+    [auth.anonymous]
+    enabled = false
+    [auth.basic]
+    enabled = true
+    [auth.proxy]
+    auto_sign_up = true
+    enabled = true
+    header_name = X-Forwarded-User
+    header_property = username
+    [log]
+    level = warn
+    mode = console
+    [paths]
+    data = /var/lib/grafana
+    logs = /var/log/grafana
+    plugins = /var/lib/grafana/plugins
+    provisioning = /etc/grafana/provisioning/

--- a/openshift/kustomize/postgres/monitor/grafana-netpol.yaml
+++ b/openshift/kustomize/postgres/monitor/grafana-netpol.yaml
@@ -1,0 +1,50 @@
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-grafana-route
+spec:
+  podSelector:
+    matchLabels:
+      name: crunchy-grafana
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  policyTypes:
+    - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-grafana-to-prometheus
+spec:
+  podSelector:
+    matchLabels:
+      name: crunchy-prometheus
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              name: crunchy-grafana
+      ports:
+        - protocol: TCP
+          port: 9090
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-prometheus-to-alertmanager
+spec:
+  podSelector:
+    matchLabels:
+      name: crunchy-alertmanager
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              name: crunchy-prometheus
+      ports:
+        - protocol: TCP
+          port: 9093

--- a/openshift/kustomize/postgres/monitor/grafana-oauth.yaml
+++ b/openshift/kustomize/postgres/monitor/grafana-oauth.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crunchy-grafana
+spec:
+  template:
+    spec:
+      containers:
+        - name: grafana
+          volumeMounts:
+            - name: grafana-config
+              mountPath: /etc/grafana/
+        - name: grafana-proxy
+          ports:
+            - name: grafana-proxy
+              containerPort: 9091
+              protocol: TCP
+          imagePullPolicy: IfNotPresent
+          image: image-registry.openshift-image-registry.svc:5000/openshift/oauth-proxy:v4.4
+          args:
+            - "--provider=openshift"
+            - "--pass-basic-auth=false"
+            - "--https-address="
+            - "--http-address=:9091"
+            - "--email-domain=*"
+            - "--upstream=http://localhost:3000"
+            - "--cookie-secret=asdf"
+            - "--openshift-service-account=grafana"
+            - "--skip-auth-regex=^/metrics"
+            - '--openshift-sar={"namespace": "9b301c-tools", "resource": "services", "verb": "get"}'
+      volumes:
+        - name: grafana-config
+          configMap:
+            name: grafana-config
+            defaultMode: 420

--- a/openshift/kustomize/postgres/monitor/grafana-route.yaml
+++ b/openshift/kustomize/postgres/monitor/grafana-route.yaml
@@ -1,0 +1,15 @@
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: crunchy-grafana
+spec:
+  to:
+    kind: Service
+    name: crunchy-grafana
+    weight: 100
+  port:
+    targetPort: grafana-proxy
+  tls:
+    termination: edge
+  wildcardPolicy: None

--- a/openshift/kustomize/postgres/monitor/kustomization.yaml
+++ b/openshift/kustomize/postgres/monitor/kustomization.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: 9b301c-tools
+
+resources:
+  - "grafana-config.yaml"
+  - "grafana-route.yaml"
+  - "grafana-netpol.yaml"
+  - "github.com/CrunchyData/postgres-operator-examples/kustomize/monitoring"
+
+patches:
+  - target:
+      version: v1
+      kind: Deployment
+      labelSelector: "app.kubernetes.io/name=postgres-operator-monitoring"
+    patch: |-
+      - op: remove
+        path: "/spec/template/spec/securityContext/fsGroup"
+  - target:
+      version: v1
+      kind: PersistentVolumeClaim
+      name: prometheusdata
+    patch: |-
+      - op: add
+        path: "/spec/storageClassName"
+        value: netapp-block-standard
+  - target:
+      version: v1
+      group: rbac.authorization.k8s.io
+      kind: ClusterRole
+      labelSelector: "vendor=crunchydata"
+    patch: |-
+      - op: replace
+        path: "/kind"
+        value: "Role"
+  - target:
+      version: v1
+      group: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+      labelSelector: "vendor=crunchydata"
+    patch: |-
+      - op: replace
+        path: "/kind"
+        value: "RoleBinding"
+      - op: replace
+        path: "/roleRef/kind"
+        value: "Role"
+  - target:
+      version: v1
+      kind: Service
+      name: crunchy-grafana
+    patch: |-
+      - op: add
+        path: "/spec/ports/-"
+        value:
+          name: grafana-proxy
+          protocol: TCP
+          port: 9091
+          targetPort: grafana-proxy
+  - target:
+      version: v1
+      kind: ServiceAccount
+      name: grafana
+    patch: |-
+      - op: add
+        path: "/metadata/annotations/serviceaccounts.openshift.io~1oauth-redirectreference.primary"
+        value: >-
+          {"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"crunchy-grafana"}}
+  - path: grafana-oauth.yaml

--- a/openshift/scripts/database-connect.sh
+++ b/openshift/scripts/database-connect.sh
@@ -9,6 +9,7 @@ if [ ! $1 ]; then
   die "First argument require to specify the environment [dev,test,prod,tools]."
 fi
 
-POD_NAME=$(oc get pods -n 9b301c-$1 --selector app=database --selector role=master --no-headers -o custom-columns=POD:.metadata.name)
+POD_NAME=$(oc get pods -n 9b301c-$1 --selector postgres-operator.crunchydata.com/role=master --no-headers -o custom-columns=POD:.metadata.name)
 
 oc port-forward $POD_NAME ${2:-22222}:${3:-5432} -n 9b301c-$1
+

--- a/openshift/templates/api/deploy.yaml
+++ b/openshift/templates/api/deploy.yaml
@@ -45,7 +45,7 @@ parameters:
     displayName: Database Connection String
     description: PostgreSQL database connection string.
     required: true
-    value: Host=tno-database:5432;Database=tno;Include Error Detail=true;Log Parameters=true;
+    value: Host=postgres-cluster-primary:5432;Database=postgres-cluster;Include Error Detail=true;Log Parameters=true;
 
   - name: KEYCLOAK_AUTHORITY
     displayName: Keycloak Authority URL
@@ -67,7 +67,7 @@ parameters:
     displayName: Database Secret Name
     description: Name of the database secrets object.
     required: true
-    value: tno-database
+    value: postgres-cluster-pguser-postgres-cluster
 
   - name: ELASTIC_SECRETS_NAME
     displayName: Elasticsearch Secret Name
@@ -242,12 +242,12 @@ objects:
                   valueFrom:
                     secretKeyRef:
                       name: ${DB_SECRETS_NAME}
-                      key: POSTGRESQL_USER
+                      key: user
                 - name: DB_POSTGRES_PASSWORD
                   valueFrom:
                     secretKeyRef:
                       name: ${DB_SECRETS_NAME}
-                      key: POSTGRESQL_PASSWORD
+                      key: password
 
                 - name: ELASTIC_URIS
                   valueFrom:

--- a/openshift/templates/elastic/cluster/deploy.yaml
+++ b/openshift/templates/elastic/cluster/deploy.yaml
@@ -200,9 +200,9 @@ objects:
                           - ${SOLUTION_NAME}-${APP_NAME}-cluster
                   topologyKey: "kubernetes.io/hostname"
           volumes:
-            - name: backup
-              persistentVolumeClaim:
-                claimName: ${SOLUTION_NAME}-database-backup
+            # - name: backup
+            #   persistentVolumeClaim:
+            #     claimName: ${SOLUTION_NAME}-database-backup
           containers:
             - name: ${SOLUTION_NAME}-${APP_NAME}
               image: ${IMAGE}:${IMAGE_TAG}

--- a/openshift/templates/postgres/crunchy/deploy.yaml
+++ b/openshift/templates/postgres/crunchy/deploy.yaml
@@ -1,0 +1,290 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: cruncydb-pgsql-persistent
+  annotations:
+    description: |-
+      CrunchyDB database cluster, with persistent storage.
+    iconClass: icon-postgresql
+    openshift.io/display-name: CrunchyDB Postgresql (Persistent)
+    openshift.io/long-description:
+      This template deploys a CrunchyDB postgresql HA
+      cluster with persistent storage.
+    tags: postgresql
+
+parameters:
+  - name: SOLUTION_NAME
+    displayName: Solution Group Name
+    description: The name of the solution (e.g tno).
+    required: true
+    value: tno
+  - name: APP_NAME
+    displayName: Application Name
+    description: The name of the application (e.g. api-editor.dev).
+    required: true
+    value: database
+
+  - name: PROJECT_NAMESPACE
+    displayName: OpenShift Project Namespace
+    description: The namespace of the OpenShift project containing the application.
+    required: true
+    value: 9b301c
+  - name: ENV_NAME
+    displayName: Environment name
+    description: The name for this environment [dev, test, prod]
+    required: true
+    value: dev
+
+  - name: DB_IMAGE
+    displayName: Crunchy DB Image
+    description: The image to deploy.
+    value: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-0
+  - name: POSTGRES_VERSION
+    displayName: PostgreSQL Version Number
+    description: The version number of the database.
+    value: "13"
+
+  - name: STORAGE_CLASS
+    displayName: The Storage Class Name
+    description: The storage class name is the type of storage [netapp-file-standard, netapp-file-extended, netapp-file-backup, netapp-block-standard, netapp-block-extended]
+    required: true
+    value: netapp-block-standard
+  - name: ACCESS_MODE
+    displayName: The Storage Access Mode
+    description: The storage access mode [ReadWriteOnce, ReadWriteMany]
+    required: true
+    value: ReadWriteOnce
+  - name: VOLUME_CAPACITY
+    displayName: Persistent Volume Capacity
+    description: Volume space available for data, e.g. 512Mi, 2Gi.
+    required: true
+    value: 2Gi
+
+  - name: DB_MONITOR_IMAGE
+    displayName: Crunchy DB Monitoring Image
+    description: The monitoring image to deploy
+    value: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.0.4-0
+
+  - name: DB_BACKUP_IMAGE
+    displayName: Crunchy DB Backup Image
+    description: The backup image to deploy
+    value: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0
+
+  - name: BACKUP_STORAGE_CLASS
+    displayName: The Backup Storage Class Name
+    description: The backup storage class name is the type of storage [netapp-file-standard, netapp-file-extended, netapp-file-backup, netapp-block-standard, netapp-block-extended]
+    required: true
+    value: netapp-file-backup
+  - name: BACKUP_ACCESS_MODE
+    displayName: The Backup Storage Access Mode
+    description: The backup storage access mode [ReadWriteOnce, ReadWriteMany]
+    required: true
+    value: ReadWriteOnce
+  - name: BACKUP_VOLUME_CAPACITY
+    displayName: Backup persistent Volume Capacity
+    description: Backup volume space available for data, e.g. 512Mi, 2Gi.
+    required: true
+    value: 5Gi
+
+  - name: DB_BOUNCER_IMAGE
+    displayName: Crunchy DB Bouncer Image
+    description: The bouncer image to deploy
+    value: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-3
+  - name: BOUNCER_REPLICAS
+    displayName: Bouncer Replicas
+    description: The number of DB Bouncer replicas to use.
+    required: true
+    value: "2"
+
+  - name: REPLICAS
+    displayName: Replicas
+    description: The number of StatefulSet replicas to use.
+    required: true
+    value: "3"
+  - name: CPU_REQUEST
+    displayName: "Requested Minimum Resources CPU Limit"
+    description: "The requested minimum resources CPU limit (in cores) for this build."
+    required: true
+    value: 50m
+  - name: CPU_LIMIT
+    displayName: "Resources CPU Limit"
+    description: "The resources CPU limit (in cores) for this build."
+    required: true
+    value: 500m
+  - name: MEMORY_REQUEST
+    displayName: "Requested Minimum Memory Limit"
+    description: "Minimum requested amount of memory the container can use."
+    required: true
+    value: 250Mi
+  - name: MEMORY_LIMIT
+    displayName: "Memory Limit"
+    description: "Maximum amount of memory the container can use."
+    required: true
+    value: 2Gi
+
+  - name: MONITOR_CPU_REQUEST
+    displayName: "Requested Minimum Resources CPU Limit"
+    description: "The requested minimum resources CPU limit (in cores) for this build."
+    required: true
+    value: 25m
+  - name: MONITOR_CPU_LIMIT
+    displayName: "Resources CPU Limit"
+    description: "The resources CPU limit (in cores) for this build."
+    required: true
+    value: 50m
+  - name: MONITOR_MEMORY_REQUEST
+    displayName: "Requested Minimum Memory Limit"
+    description: "Minimum requested amount of memory the container can use."
+    required: true
+    value: 100Mi
+  - name: MONITOR_MEMORY_LIMIT
+    displayName: "Memory Limit"
+    description: "Maximum amount of memory the container can use."
+    required: true
+    value: 250Mi
+
+  - name: BACKUP_CPU_REQUEST
+    displayName: "Requested Minimum Resources CPU Limit"
+    description: "The requested minimum resources CPU limit (in cores) for this build."
+    required: true
+    value: 50m
+  - name: BACKUP_CPU_LIMIT
+    displayName: "Resources CPU Limit"
+    description: "The resources CPU limit (in cores) for this build."
+    required: true
+    value: 250m
+  - name: BACKUP_MEMORY_REQUEST
+    displayName: "Requested Minimum Memory Limit"
+    description: "Minimum requested amount of memory the container can use."
+    required: true
+    value: 100Mi
+  - name: BACKUP_MEMORY_LIMIT
+    displayName: "Memory Limit"
+    description: "Maximum amount of memory the container can use."
+    required: true
+    value: 1Gi
+
+  - name: BOUNCER_CPU_REQUEST
+    displayName: "Requested Minimum Resources CPU Limit"
+    description: "The requested minimum resources CPU limit (in cores) for this build."
+    required: true
+    value: 25m
+  - name: BOUNCER_CPU_LIMIT
+    displayName: "Resources CPU Limit"
+    description: "The resources CPU limit (in cores) for this build."
+    required: true
+    value: 50m
+  - name: BOUNCER_MEMORY_REQUEST
+    displayName: "Requested Minimum Memory Limit"
+    description: "Minimum requested amount of memory the container can use."
+    required: true
+    value: 100Mi
+  - name: BOUNCER_MEMORY_LIMIT
+    displayName: "Memory Limit"
+    description: "Maximum amount of memory the container can use."
+    required: true
+    value: 250Mi
+
+objects:
+  - apiVersion: postgres-operator.crunchydata.com/v1beta1
+    kind: PostgresCluster
+    metadata:
+      name: ${SOLUTION_NAME}-cluster
+      namespace: ${PROJECT_NAMESPACE}-${ENV_NAME}
+      labels:
+        name: ${SOLUTION_NAME}-cluster
+        solution: ${SOLUTION_NAME}
+        app: ${APP_NAME}
+    spec:
+      monitoring:
+        pgmonitor:
+          exporter:
+            image: ${DB_MONITOR_IMAGE}
+          resources:
+            requests:
+              cpu: ${MONITOR_CPU_REQUEST}
+              memory: ${MONITOR_MEMORY_REQUEST}
+            limits:
+              cpu: ${MONITOR_CPU_LIMIT}
+              memory: ${MONITOR_MEMORY_LIMIT}
+      image: ${DB_IMAGE}
+      postgresVersion: ${{POSTGRES_VERSION}}
+      instances:
+        - name: ${APP_NAME}
+          replicas: ${{REPLICAS}}
+          resources:
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
+          dataVolumeClaimSpec:
+            accessModes:
+              - ${ACCESS_MODE}
+            resources:
+              requests:
+                storage: ${VOLUME_CAPACITY}
+            storageClassName: ${STORAGE_CLASS}
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  podAffinityTerm:
+                    topologyKey: kubernetes.io/hostname
+                    labelSelector:
+                      matchLabels:
+                        postgres-operator.crunchydata.com/cluster: hippo-ha
+                        postgres-operator.crunchydata.com/instance-set: ${SOLUTION_NAME}
+      backups:
+        pgbackrest:
+          global:
+            repo1-retention-full: "2"
+          image: ${DB_BACKUP_IMAGE}
+          repoHost:
+            resources:
+              requests:
+                cpu: ${BACKUP_CPU_REQUEST}
+                memory: ${BACKUP_MEMORY_REQUEST}
+              limits:
+                cpu: ${BACKUP_CPU_LIMIT}
+                memory: ${BACKUP_MEMORY_LIMIT}
+          repos:
+            - name: repo1
+              schedules:
+                # Full backup every day at 8:00am UTC
+                full: "0 8 * * *"
+                # Incremental backup every 4 hours, except at 8am UTC (when the full backup is running)
+                incremental: "0 0,4,12,16,20 * * *"
+              volume:
+                volumeClaimSpec:
+                  accessModes:
+                    - ${BACKUP_ACCESS_MODE}
+                  resources:
+                    requests:
+                      storage: ${BACKUP_VOLUME_CAPACITY}
+                  storageClassName: ${BACKUP_STORAGE_CLASS}
+      proxy:
+        pgBouncer:
+          config:
+            global:
+              client_tls_sslmode: disable
+          image: ${DB_BOUNCER_IMAGE}
+          replicas: ${{BOUNCER_REPLICAS}}
+          resources:
+            requests:
+              cpu: ${BOUNCER_CPU_REQUEST}
+              memory: ${BOUNCER_MEMORY_REQUEST}
+            limits:
+              cpu: ${BOUNCER_CPU_LIMIT}
+              memory: ${BOUNCER_MEMORY_LIMIT}
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  podAffinityTerm:
+                    topologyKey: kubernetes.io/hostname
+                    labelSelector:
+                      matchLabels:
+                        postgres-operator.crunchydata.com/cluster: hippo-ha
+                        postgres-operator.crunchydata.com/role: pgbouncer

--- a/openshift/templates/postgres/crunchy/monitor/kustomization.yaml
+++ b/openshift/templates/postgres/crunchy/monitor/kustomization.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: LICENSE-tools
+
+resources:
+  - "grafana-config.yaml"
+  - "grafana-route.yaml"
+  - "grafana-netpol.yaml"
+  - "github.com/CrunchyData/postgres-operator-examples/kustomize/monitoring"
+
+patches:
+  - target:
+      version: v1
+      kind: Deployment
+      labelSelector: "app.kubernetes.io/name=postgres-operator-monitoring"
+    patch: |-
+      - op: remove
+        path: "/spec/template/spec/securityContext/fsGroup"
+  - target:
+      version: v1
+      kind: PersistentVolumeClaim
+      name: prometheusdata
+    patch: |-
+      - op: add
+        path: "/spec/storageClassName"
+        value: netapp-block-standard
+  - target:
+      version: v1
+      group: rbac.authorization.k8s.io
+      kind: ClusterRole
+      labelSelector: "vendor=crunchydata"
+    patch: |-
+      - op: replace
+        path: "/kind"
+        value: "Role"
+  - target:
+      version: v1
+      group: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+      labelSelector: "vendor=crunchydata"
+    patch: |-
+      - op: replace
+        path: "/kind"
+        value: "RoleBinding"
+      - op: replace
+        path: "/roleRef/kind"
+        value: "Role"
+  - target:
+      version: v1
+      kind: Service
+      name: crunchy-grafana
+    patch: |-
+      - op: add
+        path: "/spec/ports/-"
+        value:
+          name: grafana-proxy
+          protocol: TCP
+          port: 9091
+          targetPort: grafana-proxy
+  - target:
+      version: v1
+      kind: ServiceAccount
+      name: grafana
+    patch: |-
+      - op: add
+        path: "/metadata/annotations/serviceaccounts.openshift.io~1oauth-redirectreference.primary"
+        value: >-
+          {"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"crunchy-grafana"}}
+  - path: grafana-oauth.yaml

--- a/openshift/templates/postgres/crunchy/network-policy.yaml
+++ b/openshift/templates/postgres/crunchy/network-policy.yaml
@@ -1,0 +1,87 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: cruncydb-pgsql-persistent-network-policy
+  annotations:
+    description: |-
+      CrunchyDB database cluster, with persistent storage.
+    iconClass: icon-postgresql
+    openshift.io/display-name: CrunchyDB Postgresql (Persistent)
+    openshift.io/long-description:
+      This template deploys a CrunchyDB postgresql HA
+      cluster with persistent storage.
+    tags: postgresql
+
+parameters:
+  - name: SOLUTION_NAME
+    displayName: Solution Group Name
+    description: The name of the solution (e.g tno).
+    required: true
+    value: tno
+  - name: APP_NAME
+    displayName: Application Name
+    description: The name of the application (e.g. api-editor.dev).
+    required: true
+    value: database
+
+  - name: PROJECT_NAMESPACE
+    displayName: OpenShift Project Namespace
+    description: The namespace of the OpenShift project containing the application.
+    required: true
+    value: 9b301c
+  - name: ENV_NAME
+    displayName: Environment name
+    description: The name for this environment [dev, test, prod]
+    required: true
+    value: dev
+
+objects:
+  - kind: NetworkPolicy
+    apiVersion: networking.k8s.io/v1
+    metadata:
+      name: ${SOLUTION_NAME}-${APP_NAME}
+      namespace: ${PROJECT_NAMESPACE}-${ENV_NAME}
+      labels:
+        name: ${SOLUTION_NAME}-${APP_NAME}
+        solution: ${SOLUTION_NAME}
+        app: ${APP_NAME}
+        postgres-operator.crunchydata.com/cluster: ${SOLUTION_NAME}-cluster
+    spec:
+      podSelector:
+        matchLabels:
+          postgres-operator.crunchydata.com/cluster: ${SOLUTION_NAME}-cluster
+      ingress:
+        - from:
+            - podSelector:
+                matchLabels:
+                  postgres-operator.crunchydata.com/cluster: ${SOLUTION_NAME}-cluster
+          ports:
+            - protocol: TCP
+              port: 5432
+            - protocol: TCP
+              port: 8008
+            - protocol: TCP
+              port: 2022
+
+  - kind: NetworkPolicy
+    apiVersion: networking.k8s.io/v1
+    metadata:
+      name: ${SOLUTION_NAME}-${APP_NAME}-monitoring
+      namespace: ${PROJECT_NAMESPACE}-${ENV_NAME}
+      labels:
+        name: ${SOLUTION_NAME}-${APP_NAME}
+        solution: ${SOLUTION_NAME}
+        app: ${APP_NAME}
+        postgres-operator.crunchydata.com/cluster: ${SOLUTION_NAME}-cluster
+    spec:
+      podSelector:
+        matchLabels:
+          postgres-operator.crunchydata.com/cluster: ${SOLUTION_NAME}-cluster
+      ingress:
+        - from:
+            - namespaceSelector:
+                name: ${PROJECT_NAMESPACE}
+                environment: tools
+          ports:
+            - protocol: TCP
+              port: 9187

--- a/openshift/templates/postgres/crunchy/role-binding.yaml
+++ b/openshift/templates/postgres/crunchy/role-binding.yaml
@@ -1,0 +1,77 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: cruncydb-pgsql-persistent-role-binding
+  annotations:
+    description: |-
+      CrunchyDB database cluster, with persistent storage.
+    iconClass: icon-postgresql
+    openshift.io/display-name: CrunchyDB Postgresql (Persistent)
+    openshift.io/long-description:
+      This template deploys a CrunchyDB postgresql HA
+      cluster with persistent storage.
+    tags: postgresql
+
+parameters:
+  - name: SOLUTION_NAME
+    displayName: Solution Group Name
+    description: The name of the solution (e.g tno).
+    required: true
+    value: tno
+  - name: APP_NAME
+    displayName: Application Name
+    description: The name of the application (e.g. api-editor.dev).
+    required: true
+    value: database
+
+  - name: PROJECT_NAMESPACE
+    displayName: OpenShift Project Namespace
+    description: The namespace of the OpenShift project containing the application.
+    required: true
+    value: 9b301c
+  - name: ENV_NAME
+    displayName: Environment name
+    description: The name for this environment [dev, test, prod]
+    required: true
+    value: dev
+
+objects:
+  - kind: Role
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: ${SOLUTION_NAME}-${APP_NAME}-monitoring
+      namespace: ${PROJECT_NAMESPACE}-${ENV_NAME}
+      labels:
+        name: ${SOLUTION_NAME}-${APP_NAME}-monitoring
+        solution: ${SOLUTION_NAME}
+        app: ${APP_NAME}
+        app.kubernetes.io/name: postgres-operator-monitoring
+        vendor: crunchydata
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - pods
+        verbs:
+          - get
+          - list
+          - watch
+
+  - kind: RoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: ${SOLUTION_NAME}-${APP_NAME}-monitoring
+      namespace: ${PROJECT_NAMESPACE}-${ENV_NAME}
+      labels:
+        name: ${SOLUTION_NAME}-${APP_NAME}-monitoring
+        solution: ${SOLUTION_NAME}
+        app: ${APP_NAME}
+        vendor: crunchydata
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: ${SOLUTION_NAME}-${APP_NAME}-monitoring
+    subjects:
+      - kind: ServiceAccount
+        name: prometheus-sa
+        namespace: ${PROJECT_NAMESPACE}-tools

--- a/openshift/templates/tekton/pipelines/complete.yaml
+++ b/openshift/templates/tekton/pipelines/complete.yaml
@@ -136,15 +136,15 @@ objects:
             - name: SERVICE
               value: ${SOLUTION_NAME}-${NGINX_NAME}
 
-        - name: database-backup
-          taskRef:
-            name: oc-backup
-            kind: Task
-          params:
-            - name: PROJECT_NAMESPACE
-              value: $(params.PROJECT_SHORTNAME)-$(params.DEPLOY_TO)
-            - name: DEPLOYMENT_CONFIG
-              value: ${SOLUTION_NAME}-${BACKUP_NAME}
+        # - name: database-backup
+        #   taskRef:
+        #     name: oc-backup
+        #     kind: Task
+        #   params:
+        #     - name: PROJECT_NAMESPACE
+        #       value: $(params.PROJECT_SHORTNAME)-$(params.DEPLOY_TO)
+        #     - name: DEPLOYMENT_CONFIG
+        #       value: ${SOLUTION_NAME}-${BACKUP_NAME}
 
         - name: build-db-migration
           taskRef:
@@ -163,7 +163,7 @@ objects:
         - name: run-db-migration
           runAfter:
             - maintenance-on
-            - database-backup
+            # - database-backup
             - build-db-migration
           taskRef:
             name: db-migration
@@ -171,8 +171,8 @@ objects:
           params:
             - name: MIGRATION_IMAGE
               value: ${SOLUTION_NAME}-${MIGRATION_NAME}
-            - name: DB_APP_NAME
-              value: ${SOLUTION_NAME}-${DB_NAME}
+            - name: DB_SECRET_NAME
+              value: postgres-cluster-pguser-postgres-cluster
             - name: API_NAME
               value: ${SOLUTION_NAME}-${API_NAME}
             - name: IMAGE_TAG

--- a/openshift/templates/tekton/pipelines/db-migration.yaml
+++ b/openshift/templates/tekton/pipelines/db-migration.yaml
@@ -50,8 +50,8 @@ spec:
       params:
         - name: MIGRATION_IMAGE
           value: tno-db-migration
-        - name: DB_APP_NAME
-          value: tno-database
+        - name: DB_SECRET_NAME
+          value: postgres-cluster-pguser-postgres-cluster
         - name: API_NAME
           value: tno-api-editor
         - name: IMAGE_TAG

--- a/openshift/templates/tekton/pipelines/deploy.yaml
+++ b/openshift/templates/tekton/pipelines/deploy.yaml
@@ -93,28 +93,28 @@ objects:
             - name: SERVICE
               value: ${SOLUTION_NAME}-${NGINX_NAME}
 
-        - name: database-backup
-          taskRef:
-            name: oc-backup
-            kind: Task
-          params:
-            - name: PROJECT_NAMESPACE
-              value: $(params.PROJECT_SHORTNAME)-$(params.DEPLOY_TO)
-            - name: DEPLOYMENT_CONFIG
-              value: ${SOLUTION_NAME}-${BACKUP_NAME}
+        # - name: database-backup
+        #   taskRef:
+        #     name: oc-backup
+        #     kind: Task
+        #   params:
+        #     - name: PROJECT_NAMESPACE
+        #       value: $(params.PROJECT_SHORTNAME)-$(params.DEPLOY_TO)
+        #     - name: DEPLOYMENT_CONFIG
+        #       value: ${SOLUTION_NAME}-${BACKUP_NAME}
 
         - name: run-db-migration
           runAfter:
             - maintenance-on
-            - database-backup
+            # - database-backup
           taskRef:
             name: db-migration
             kind: Task
           params:
             - name: MIGRATION_IMAGE
               value: ${SOLUTION_NAME}-${MIGRATION_NAME}
-            - name: DB_APP_NAME
-              value: ${SOLUTION_NAME}-${DB_NAME}
+            - name: DB_SECRET_NAME
+              value: postgres-cluster-pguser-postgres-cluster
             - name: IMAGE_TAG
               value: $(params.IMAGE_TAG)
             - name: DEPLOY_TO

--- a/openshift/templates/tekton/tasks/db-migration.yaml
+++ b/openshift/templates/tekton/tasks/db-migration.yaml
@@ -14,10 +14,10 @@ spec:
       description: The name of the database migration image.
       type: string
       default: tno-db-migration
-    - name: DB_APP_NAME
-      description: The name of the database.
+    - name: DB_SECRET_NAME
+      description: The name of the database secrets.
       type: string
-      default: tno-database
+      default: postgres-cluster-pguser-postgres-cluster
     - name: API_NAME
       description: The name of the database.
       type: string
@@ -48,8 +48,8 @@ spec:
         PROJECT=$(params.PROJECT_SHORTNAME)-$(params.DEPLOY_TO)
         IMAGE=image-registry.apps.silver.devops.gov.bc.ca/$(params.PROJECT_SHORTNAME)-tools/$(params.MIGRATION_IMAGE):$(params.IMAGE_TAG)
         CONNECTION_STRING=$(oc -n $PROJECT get configmap $(params.API_NAME) -o jsonpath='{.data.CONNECTION_STRING}')
-        DB_USERNAME=$(oc -n $PROJECT get secret $(params.DB_APP_NAME) -o jsonpath='{.data.PATRONI_SUPERUSER_USERNAME}' | base64 -d)
-        DB_PASSWORD=$(oc -n $PROJECT get secret $(params.DB_APP_NAME) -o jsonpath='{.data.PATRONI_SUPERUSER_PASSWORD}' | base64 -d)
+        DB_USERNAME=$(oc -n $PROJECT get secret $(params.DB_SECRET_NAME) -o jsonpath='{.data.user}' | base64 -d)
+        DB_PASSWORD=$(oc -n $PROJECT get secret $(params.DB_SECRET_NAME) -o jsonpath='{.data.password}' | base64 -d)
 
         echo "Running database migration in $PROJECT"
         oc run $(params.MIGRATION_IMAGE) \


### PR DESCRIPTION
We now have a CrunchyDB HA cluster running in all our of our namespaces.  At some point I recreate DEV and TEST, but for now they can be used for testing and review.

> The only known issue presently is the amount of resources it takes to run the HA cluster.  It's about 50% of a silver namespace.

## Summary

- Switch from Patroni cluster to CrunchyDB HA cluster
- Add DB monitoring