### PR TITLE
Sign In Button

### DIFF
--- a/app/editor/src/features/home/styled/InfoPanelStyled.tsx
+++ b/app/editor/src/features/home/styled/InfoPanelStyled.tsx
@@ -32,7 +32,7 @@ export const InfoPanel = styled.div<IInfoPanelProps>`
     .headerSection {
       margin-top: 100px;
       .signIn {
-        width: 96px;
+        text-align: center;
       }
     }
   }


### PR DESCRIPTION
Tiny fix that caught my eye. Was previously some empty space next to the "Sign In" text on the login panel. 

**Before:**
![image](https://user-images.githubusercontent.com/15724124/166136193-73e0bc7b-8423-4464-a67c-0216ffb6fe51.png)
**After:**
![image](https://user-images.githubusercontent.com/15724124/166136137-14426b9b-3ae7-4ccf-af7e-f1b4ce4c9c1b.png)
