### PR TITLE
TNO-317: Use full source name

### DIFF
--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -145,7 +145,7 @@ export const ContentForm: React.FC = () => {
                             props.setFieldValue('dataSourceId', e.value);
                             props.setFieldValue('source', e.label);
                           }}
-                          width={FieldSize.Medium}
+                          width={FieldSize.Big}
                           options={dataSourceOptions}
                           required={!props.values.source}
                           isDisabled={!!props.values.otherSource}

--- a/app/editor/src/utils/getDataSourceOptions.ts
+++ b/app/editor/src/utils/getDataSourceOptions.ts
@@ -10,7 +10,9 @@ export const sortDataSource = <T extends IDataSourceModel>(a: T, b: T) => {
 };
 
 const displayName = (dataSource: IDataSourceModel) => {
-  return dataSource.name;
+  return dataSource.name !== dataSource.code
+    ? `${dataSource.name} (${dataSource.code})`
+    : dataSource.name;
 };
 
 export const getDataSourceOptions = <T extends IDataSourceModel>(

--- a/app/editor/src/utils/getDataSourceOptions.ts
+++ b/app/editor/src/utils/getDataSourceOptions.ts
@@ -10,7 +10,7 @@ export const sortDataSource = <T extends IDataSourceModel>(a: T, b: T) => {
 };
 
 const displayName = (dataSource: IDataSourceModel) => {
-  return dataSource.code;
+  return dataSource.name;
 };
 
 export const getDataSourceOptions = <T extends IDataSourceModel>(


### PR DESCRIPTION
Updated to have abbreviation in brackets after the name

![image](https://user-images.githubusercontent.com/15724124/166182892-dd1f93e0-c5ca-45e9-8987-77ed2197cec7.png)

