### PR TITLE
TNO-333 Add etag caching

### DIFF
--- a/api/net/Areas/Admin/Controllers/ActionController.cs
+++ b/api/net/Areas/Admin/Controllers/ActionController.cs
@@ -1,0 +1,125 @@
+using System.Net;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using TNO.API.Areas.Admin.Models.Action;
+using TNO.API.Models;
+using TNO.DAL.Services;
+using TNO.Entities.Models;
+
+namespace TNO.API.Areas.Admin.Controllers;
+
+/// <summary>
+/// ActionController class, provides Action endpoints for the api.
+/// </summary>
+[Authorize]
+[ApiController]
+[Area("admin")]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[area]/actions")]
+[Route("api/[area]/actions")]
+[Route("v{version:apiVersion}/[area]/actions")]
+[Route("[area]/actions")]
+[ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.Unauthorized)]
+[ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.Forbidden)]
+public class ActionController : ControllerBase
+{
+    #region Variables
+    private readonly IActionService _service;
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    /// Creates a new instance of a ActionController object, initializes with specified parameters.
+    /// </summary>
+    /// <param name="service"></param>
+    public ActionController(IActionService service)
+    {
+        _service = service;
+    }
+    #endregion
+
+    #region Endpoints
+    /// <summary>
+    /// Find a page of content for the specified query filter.
+    /// </summary>
+    /// <returns></returns>
+    [HttpGet]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(IPaged<ActionModel>), (int)HttpStatusCode.OK)]
+    [SwaggerOperation(Tags = new[] { "Action" })]
+    public IActionResult FindAll()
+    {
+        var uri = new Uri(this.Request.GetDisplayUrl());
+        var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
+        return new JsonResult(_service.FindAll().Select(ds => new ActionModel(ds)));
+    }
+
+    /// <summary>
+    /// Find content for the specified 'id'.
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    [HttpGet("{id}")]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(ActionModel), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(string), (int)HttpStatusCode.NoContent)]
+    [SwaggerOperation(Tags = new[] { "Action" })]
+    public IActionResult FindById(int id)
+    {
+        var result = _service.FindById(id);
+
+        if (result == null) return new NoContentResult();
+        return new JsonResult(new ActionModel(result));
+    }
+
+    /// <summary>
+    /// Find content for the specified 'id'.
+    /// </summary>
+    /// <param name="model"></param>
+    /// <returns></returns>
+    [HttpPost]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(ActionModel), (int)HttpStatusCode.Created)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
+    [SwaggerOperation(Tags = new[] { "Action" })]
+    public IActionResult Add(ActionModel model)
+    {
+        var result = _service.Add(model.ToEntity());
+        return CreatedAtAction(nameof(FindById), new { id = result.Id }, new ActionModel(result));
+    }
+
+    /// <summary>
+    /// Find content for the specified 'id'.
+    /// </summary>
+    /// <param name="model"></param>
+    /// <returns></returns>
+    [HttpPut("{id}")]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(ActionModel), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
+    [SwaggerOperation(Tags = new[] { "Action" })]
+    public IActionResult Update(ActionModel model)
+    {
+        var result = _service.Update(model.ToEntity());
+        return new JsonResult(new ActionModel(result));
+    }
+
+    /// <summary>
+    /// Find content for the specified 'id'.
+    /// </summary>
+    /// <param name="model"></param>
+    /// <returns></returns>
+    [HttpDelete("{id}")]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(ActionModel), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
+    [SwaggerOperation(Tags = new[] { "Action" })]
+    public IActionResult Delete(ActionModel model)
+    {
+        _service.Delete(model.ToEntity());
+        return new JsonResult(model);
+    }
+    #endregion
+}

--- a/api/net/Areas/Admin/Controllers/DataSourceController.cs
+++ b/api/net/Areas/Admin/Controllers/DataSourceController.cs
@@ -9,7 +9,6 @@ using TNO.API.Areas.Admin.Models.DataSource;
 using TNO.API.Models;
 using TNO.DAL.Models;
 using TNO.DAL.Services;
-using TNO.Entities;
 using TNO.Entities.Models;
 
 namespace TNO.API.Areas.Admin.Controllers;

--- a/api/net/Areas/Admin/Models/Action/ActionModel.cs
+++ b/api/net/Areas/Admin/Models/Action/ActionModel.cs
@@ -1,0 +1,72 @@
+using TNO.API.Models;
+
+namespace TNO.API.Areas.Admin.Models.Action;
+
+/// <summary>
+/// ActionModel class, provides a model that represents an action.
+/// </summary>
+public class ActionModel : BaseTypeWithAuditColumnsModel<int>
+{
+    #region Properties
+    /// <summary>
+    /// get/set - The value label.
+    /// </summary>
+    public string ValueLabel { get; set; } = "";
+
+    /// <summary>
+    /// get/set - The value type of this action.
+    /// </summary>
+    public Entities.ValueType ValueType { get; set; } = Entities.ValueType.Boolean;
+
+    /// <summary>
+    /// get/set - The default value.
+    /// </summary>
+    public string DefaultValue { get; set; } = "";
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    /// Creates a new instance of an ActionModel.
+    /// </summary>
+    public ActionModel() { }
+
+    /// <summary>
+    /// Creates a new instance of an ActionModel, initializes with specified parameter.
+    /// </summary>
+    /// <param name="entity"></param>
+    public ActionModel(Entities.Action entity) : base(entity)
+    {
+        this.ValueLabel = entity.ValueLabel;
+        this.ValueType = entity.ValueType;
+        this.DefaultValue = entity.DefaultValue;
+    }
+    #endregion
+
+    #region Methods
+    /// <summary>
+    /// Creates a new instance of a Action object.
+    /// </summary>
+    /// <returns></returns>
+    public Entities.Action ToEntity()
+    {
+        var entity = (Entities.Action)this;
+        return entity;
+    }
+
+    /// <summary>
+    /// Explicit conversion to entity.
+    /// </summary>
+    /// <param name="model"></param>
+    public static explicit operator Entities.Action(ActionModel model)
+    {
+        var entity = new Entities.Action(model.Name, model.ValueType, model.ValueLabel)
+        {
+            Id = model.Id,
+            DefaultValue = model.DefaultValue,
+            Version = model.Version ?? 0
+        };
+
+        return entity;
+    }
+    #endregion
+}

--- a/api/net/Areas/Editor/Controllers/ActionController.cs
+++ b/api/net/Areas/Editor/Controllers/ActionController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Editor.Models.Action;
+using TNO.API.Filters;
 using TNO.API.Models;
 using TNO.DAL.Services;
 
@@ -43,10 +44,13 @@ public class ActionController : ControllerBase
     /// Return an array of Action.
     /// </summary>
     /// <returns></returns>
-    [HttpGet]
+    [HttpGet, HttpHead]
     [Produces("application/json")]
     [ProducesResponseType(typeof(IEnumerable<ActionModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotModified)]
     [SwaggerOperation(Tags = new[] { "Action" })]
+    [ETagCacheTableFilter("actions")]
+    [ResponseCache(Duration = 5 * 60)]
     public IActionResult FindAll()
     {
         return new JsonResult(_service.FindAll().Select(m => new ActionModel(m)));

--- a/api/net/Areas/Editor/Controllers/CacheController.cs
+++ b/api/net/Areas/Editor/Controllers/CacheController.cs
@@ -1,0 +1,55 @@
+using System.Net;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using TNO.API.Areas.Editor.Models.Cache;
+using TNO.API.Models;
+using TNO.DAL.Services;
+
+namespace TNO.API.Areas.Editor.Controllers;
+
+/// <summary>
+/// CacheController class, provides Cache endpoints for the api.
+/// </summary>
+[Authorize]
+[ApiController]
+[Area("editor")]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[area]/cache")]
+[Route("api/[area]/cache")]
+[Route("v{version:apiVersion}/[area]/cache")]
+[Route("[area]/cache")]
+[ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.Unauthorized)]
+[ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.Forbidden)]
+public class CacheController : ControllerBase
+{
+    #region Variables
+    private readonly ICacheService _service;
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    /// Creates a new instance of a CacheController object, initializes with specified parameters.
+    /// </summary>
+    /// <param name="service"></param>
+    public CacheController(ICacheService service)
+    {
+        _service = service;
+    }
+    #endregion
+
+    #region Endpoints
+    /// <summary>
+    /// Return an array of Cache.
+    /// </summary>
+    /// <returns></returns>
+    [HttpGet]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(IEnumerable<CacheModel>), (int)HttpStatusCode.OK)]
+    [SwaggerOperation(Tags = new[] { "Cache" })]
+    public IActionResult FindAll()
+    {
+        return new JsonResult(_service.FindAll().Select(m => new CacheModel(m)));
+    }
+    #endregion
+}

--- a/api/net/Areas/Editor/Controllers/CategoryController.cs
+++ b/api/net/Areas/Editor/Controllers/CategoryController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Editor.Models.Category;
+using TNO.API.Filters;
 using TNO.API.Models;
 using TNO.DAL.Services;
 
@@ -43,10 +44,13 @@ public class CategoryController : ControllerBase
     /// Return an array of Category.
     /// </summary>
     /// <returns></returns>
-    [HttpGet]
+    [HttpGet, HttpHead]
     [Produces("application/json")]
     [ProducesResponseType(typeof(IEnumerable<CategoryModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotModified)]
     [SwaggerOperation(Tags = new[] { "Category" })]
+    [ETagCacheTableFilter("categories")]
+    [ResponseCache(Duration = 5 * 60)]
     public IActionResult FindAll()
     {
         return new JsonResult(_service.FindAll().Select(c => new CategoryModel(c)));

--- a/api/net/Areas/Editor/Controllers/ClaimController.cs
+++ b/api/net/Areas/Editor/Controllers/ClaimController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Editor.Models.Claim;
+using TNO.API.Filters;
 using TNO.API.Models;
 using TNO.DAL.Services;
 
@@ -43,10 +44,13 @@ public class ClaimController : ControllerBase
     /// Return an array of Claim.
     /// </summary>
     /// <returns></returns>
-    [HttpGet]
+    [HttpGet, HttpHead]
     [Produces("application/json")]
     [ProducesResponseType(typeof(IEnumerable<ClaimModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotModified)]
     [SwaggerOperation(Tags = new[] { "Claim" })]
+    [ETagCacheTableFilter("claims")]
+    [ResponseCache(Duration = 5 * 60)]
     public IActionResult Find()
     {
         return new JsonResult(_service.FindAll().Select(c => new ClaimModel(c)));

--- a/api/net/Areas/Editor/Controllers/ContentTypeController.cs
+++ b/api/net/Areas/Editor/Controllers/ContentTypeController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Editor.Models.ContentType;
+using TNO.API.Filters;
 using TNO.API.Models;
 using TNO.DAL.Services;
 
@@ -43,10 +44,13 @@ public class ContentTypeController : ControllerBase
     /// Return an array of ContentType.
     /// </summary>
     /// <returns></returns>
-    [HttpGet]
+    [HttpGet, HttpHead]
     [Produces("application/json")]
     [ProducesResponseType(typeof(IEnumerable<ContentTypeModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotModified)]
     [SwaggerOperation(Tags = new[] { "ContentType" })]
+    [ETagCacheTableFilter("content_types")]
+    [ResponseCache(Duration = 7 * 24 * 60 * 60)]
     public IActionResult FindAll()
     {
         return new JsonResult(_service.FindAll().Select(c => new ContentTypeModel(c)));

--- a/api/net/Areas/Editor/Controllers/DataLocationController.cs
+++ b/api/net/Areas/Editor/Controllers/DataLocationController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Editor.Models.DataLocation;
+using TNO.API.Filters;
 using TNO.API.Models;
 using TNO.DAL.Services;
 
@@ -43,10 +44,13 @@ public class DataLocationController : ControllerBase
     /// Return an array of DataLocation.
     /// </summary>
     /// <returns></returns>
-    [HttpGet]
+    [HttpGet, HttpHead]
     [Produces("application/json")]
     [ProducesResponseType(typeof(IEnumerable<DataLocationModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotModified)]
     [SwaggerOperation(Tags = new[] { "DataLocation" })]
+    [ETagCacheTableFilter("data_locations")]
+    [ResponseCache(Duration = 5 * 60)]
     public IActionResult FindAll()
     {
         return new JsonResult(_service.FindAll().Select(c => new DataLocationModel(c)));

--- a/api/net/Areas/Editor/Controllers/DataSourceController.cs
+++ b/api/net/Areas/Editor/Controllers/DataSourceController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Editor.Models.DataSource;
+using TNO.API.Filters;
 using TNO.API.Models;
 using TNO.DAL.Services;
 using TNO.Entities.Models;
@@ -50,10 +51,13 @@ public class DataSourceController : ControllerBase
     /// Find a page of content for the specified query filter.
     /// </summary>
     /// <returns></returns>
-    [HttpGet]
+    [HttpGet, HttpHead]
     [Produces("application/json")]
-    [ProducesResponseType(typeof(IPaged<DataSourceModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(IEnumerable<DataSourceModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotModified)]
     [SwaggerOperation(Tags = new[] { "DataSource" })]
+    [ETagCacheTableFilter("data_sources")]
+    [ResponseCache(Duration = 5 * 60)]
     public IActionResult FindAll()
     {
         var uri = new Uri(this.Request.GetDisplayUrl());

--- a/api/net/Areas/Editor/Controllers/LicenseController.cs
+++ b/api/net/Areas/Editor/Controllers/LicenseController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Editor.Models.License;
+using TNO.API.Filters;
 using TNO.API.Models;
 using TNO.DAL.Services;
 
@@ -43,10 +44,13 @@ public class LicenseController : ControllerBase
     /// Return an array of License.
     /// </summary>
     /// <returns></returns>
-    [HttpGet]
+    [HttpGet, HttpHead]
     [Produces("application/json")]
     [ProducesResponseType(typeof(IEnumerable<LicenseModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotModified)]
     [SwaggerOperation(Tags = new[] { "License" })]
+    [ETagCacheTableFilter("licenses")]
+    [ResponseCache(Duration = 5 * 60)]
     public IActionResult FindAll()
     {
         return new JsonResult(_service.FindAll().Select(c => new LicenseModel(c)));

--- a/api/net/Areas/Editor/Controllers/MediaTypeController.cs
+++ b/api/net/Areas/Editor/Controllers/MediaTypeController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Editor.Models.MediaType;
+using TNO.API.Filters;
 using TNO.API.Models;
 using TNO.DAL.Services;
 
@@ -43,10 +44,13 @@ public class MediaTypeController : ControllerBase
     /// Return an array of MediaType.
     /// </summary>
     /// <returns></returns>
-    [HttpGet]
+    [HttpGet, HttpHead]
     [Produces("application/json")]
     [ProducesResponseType(typeof(IEnumerable<MediaTypeModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotModified)]
     [SwaggerOperation(Tags = new[] { "MediaType" })]
+    [ETagCacheTableFilter("media_types")]
+    [ResponseCache(Duration = 5 * 60)]
     public IActionResult FindAll()
     {
         return new JsonResult(_service.FindAll().Select(c => new MediaTypeModel(c)));

--- a/api/net/Areas/Editor/Controllers/RoleController.cs
+++ b/api/net/Areas/Editor/Controllers/RoleController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Editor.Models.Role;
+using TNO.API.Filters;
 using TNO.API.Models;
 using TNO.DAL.Services;
 
@@ -43,10 +44,13 @@ public class RoleController : ControllerBase
     /// Return an array of Role.
     /// </summary>
     /// <returns></returns>
-    [HttpGet]
+    [HttpGet, HttpHead]
     [Produces("application/json")]
     [ProducesResponseType(typeof(IEnumerable<RoleModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotModified)]
     [SwaggerOperation(Tags = new[] { "Role" })]
+    [ETagCacheTableFilter("roles")]
+    [ResponseCache(Duration = 5 * 60)]
     public IActionResult FindAll()
     {
         return new JsonResult(_service.FindAll().Select(c => new RoleModel(c)));

--- a/api/net/Areas/Editor/Controllers/SeriesController.cs
+++ b/api/net/Areas/Editor/Controllers/SeriesController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Editor.Models.Series;
+using TNO.API.Filters;
 using TNO.API.Models;
 using TNO.DAL.Services;
 
@@ -43,10 +44,13 @@ public class SeriesController : ControllerBase
     /// Return an array of Series.
     /// </summary>
     /// <returns></returns>
-    [HttpGet]
+    [HttpGet, HttpHead]
     [Produces("application/json")]
     [ProducesResponseType(typeof(IEnumerable<SeriesModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotModified)]
     [SwaggerOperation(Tags = new[] { "Series" })]
+    [ETagCacheTableFilter("series")]
+    [ResponseCache(Duration = 5 * 60)]
     public IActionResult FindAll()
     {
         return new JsonResult(_service.FindAll().Select(c => new SeriesModel(c)));

--- a/api/net/Areas/Editor/Controllers/SourceActionController.cs
+++ b/api/net/Areas/Editor/Controllers/SourceActionController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Editor.Models.SourceAction;
+using TNO.API.Filters;
 using TNO.API.Models;
 using TNO.DAL.Services;
 
@@ -43,10 +44,13 @@ public class SourceActionController : ControllerBase
     /// Return an array of SourceSourceAction.
     /// </summary>
     /// <returns></returns>
-    [HttpGet]
+    [HttpGet, HttpHead]
     [Produces("application/json")]
     [ProducesResponseType(typeof(IEnumerable<SourceActionModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotModified)]
     [SwaggerOperation(Tags = new[] { "SourceAction" })]
+    [ETagCacheTableFilter("source_actions")]
+    [ResponseCache(Duration = 5 * 60)]
     public IActionResult FindAll()
     {
         return new JsonResult(_service.FindAll().Select(c => new SourceActionModel(c)));

--- a/api/net/Areas/Editor/Controllers/SourceMetricController.cs
+++ b/api/net/Areas/Editor/Controllers/SourceMetricController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Editor.Models.SourceMetric;
+using TNO.API.Filters;
 using TNO.API.Models;
 using TNO.DAL.Services;
 
@@ -43,10 +44,13 @@ public class SourceMetricController : ControllerBase
     /// Return an array of SourceMetric.
     /// </summary>
     /// <returns></returns>
-    [HttpGet]
+    [HttpGet, HttpHead]
     [Produces("application/json")]
     [ProducesResponseType(typeof(IEnumerable<SourceMetricModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotModified)]
     [SwaggerOperation(Tags = new[] { "SourceMetric" })]
+    [ETagCacheTableFilter("source_metrics")]
+    [ResponseCache(Duration = 5 * 60)]
     public IActionResult FindAll()
     {
         return new JsonResult(_service.FindAll().Select(c => new SourceMetricModel(c)));

--- a/api/net/Areas/Editor/Controllers/TagController.cs
+++ b/api/net/Areas/Editor/Controllers/TagController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Editor.Models.Tag;
+using TNO.API.Filters;
 using TNO.API.Models;
 using TNO.DAL.Services;
 
@@ -43,10 +44,13 @@ public class TagController : ControllerBase
     /// Return an array of Tag.
     /// </summary>
     /// <returns></returns>
-    [HttpGet]
+    [HttpGet, HttpHead]
     [Produces("application/json")]
     [ProducesResponseType(typeof(IEnumerable<TagModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotModified)]
     [SwaggerOperation(Tags = new[] { "Tag" })]
+    [ETagCacheTableFilter("tags")]
+    [ResponseCache(Duration = 5 * 60)]
     public IActionResult FindAll()
     {
         return new JsonResult(_service.FindAll().Select(c => new TagModel(c)));

--- a/api/net/Areas/Editor/Controllers/TonePoolController.cs
+++ b/api/net/Areas/Editor/Controllers/TonePoolController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Editor.Models.TonePool;
+using TNO.API.Filters;
 using TNO.API.Models;
 using TNO.DAL.Services;
 
@@ -43,10 +44,13 @@ public class TonePoolController : ControllerBase
     /// Return an array of TonePool.
     /// </summary>
     /// <returns></returns>
-    [HttpGet]
+    [HttpGet, HttpHead]
     [Produces("application/json")]
     [ProducesResponseType(typeof(IEnumerable<TonePoolModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotModified)]
     [SwaggerOperation(Tags = new[] { "TonePool" })]
+    [ETagCacheTableFilter("tone_pools")]
+    [ResponseCache(Duration = 5 * 60)]
     public IActionResult FindAll()
     {
         return new JsonResult(_service.FindAll().Select(c => new TonePoolModel(c)));

--- a/api/net/Areas/Editor/Controllers/UserController.cs
+++ b/api/net/Areas/Editor/Controllers/UserController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Editor.Models.User;
+using TNO.API.Filters;
 using TNO.DAL.Services;
 
 namespace TNO.API.Areas.Editor.Controllers;
@@ -40,10 +41,13 @@ public class UserController : ControllerBase
     /// Return an array of User.
     /// </summary>
     /// <returns></returns>
-    [HttpGet]
+    [HttpGet, HttpHead]
     [Produces("application/json")]
     [ProducesResponseType(typeof(IEnumerable<UserModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotModified)]
     [SwaggerOperation(Tags = new[] { "User" })]
+    [ETagCacheTableFilter("users")]
+    [ResponseCache(Duration = 5 * 60)]
     public IActionResult FindAll()
     {
         return new JsonResult(_service.FindAll().Select(c => new UserModel(c)));

--- a/api/net/Areas/Editor/Models/Cache/CacheModel.cs
+++ b/api/net/Areas/Editor/Models/Cache/CacheModel.cs
@@ -1,0 +1,44 @@
+using TNO.API.Models;
+
+namespace TNO.API.Areas.Editor.Models.Cache;
+
+/// <summary>
+/// CacheModel class, provides a model that represents an cache.
+/// </summary>
+public class CacheModel : AuditColumnsModel
+{
+    #region Properties
+    /// <summary>
+    /// get/set - The primary key to identify the cache item
+    /// </summary>
+    public string Key { get; set; } = "";
+
+    /// <summary>
+    /// get/set - The value label.
+    /// </summary>
+    public string Value { get; set; } = "";
+
+    /// <summary>
+    /// get/set - The default value.
+    /// </summary>
+    public string Description { get; set; } = "";
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    /// Creates a new instance of an CacheModel.
+    /// </summary>
+    public CacheModel() { }
+
+    /// <summary>
+    /// Creates a new instance of an CacheModel, initializes with specified parameter.
+    /// </summary>
+    /// <param name="entity"></param>
+    public CacheModel(Entities.Cache entity) : base(entity)
+    {
+        this.Key = entity.Key;
+        this.Value = entity.Value;
+        this.Description = entity.Description;
+    }
+    #endregion
+}

--- a/api/net/Filters/ETagCacheTableFilterAttribute.cs
+++ b/api/net/Filters/ETagCacheTableFilterAttribute.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using TNO.DAL.Services;
+
+namespace TNO.API.Filters;
+
+/// <summary>
+/// ETagCacheTableFilterAttribute class, provides a way to validate an ETag with the cache table.
+/// </summary>
+public class ETagCacheTableFilterAttribute : ActionFilterAttribute
+{
+    #region Properties
+    /// <summary>
+    /// get/set - The cache key.
+    /// </summary>
+    public string Key { get; set; }
+
+    /// <summary>
+    /// get/set - The cache value for the etag.
+    /// </summary>
+    public string? Value { get; set; }
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    /// Creates a new instance of an ETagCacheTableFilterAttribute object, initializes with specified parameter.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public ETagCacheTableFilterAttribute(string key)
+    {
+        this.Key = key ?? throw new ArgumentNullException(nameof(key));
+    }
+    #endregion
+
+    #region Methods
+    /// <summary>
+    /// Determines if the ETag matches cache.
+    /// If it does then it will return a 304:NotModified Http Status Code.
+    /// </summary>
+    /// <param name="context"></param>
+    public override void OnActionExecuting(ActionExecutingContext context)
+    {
+        var cacheService = context?.HttpContext?.RequestServices?.GetService<ICacheService>();
+        if (cacheService != null && context != null && (context?.HttpContext?.Request?.Method == HttpMethod.Head.Method || context?.HttpContext?.Request?.Method == HttpMethod.Get.Method))
+        {
+            var etag = context.HttpContext.Request.Headers.IfNoneMatch;
+            var cache = cacheService.FindById(this.Key);
+            this.Value = cache?.Value;
+            if (cache != null && cache.Value == etag)
+            {
+                context.HttpContext.Response.Headers.ETag = this.Value;
+                context.Result = new StatusCodeResult((int)HttpStatusCode.NotModified);
+            }
+            base.OnActionExecuting(context);
+        }
+    }
+
+    /// <summary>
+    /// Include the cache key as an ETag in the response.
+    /// </summary>
+    /// <param name="context"></param>
+    public override void OnActionExecuted(ActionExecutedContext context)
+    {
+        var cacheService = context?.HttpContext?.RequestServices?.GetService<ICacheService>();
+        if (cacheService != null && context != null)
+        {
+            if (this.Value != null)
+                context.HttpContext.Response.Headers.ETag = this.Value;
+            base.OnActionExecuted(context);
+        }
+    }
+    #endregion
+}

--- a/api/net/Program.cs
+++ b/api/net/Program.cs
@@ -187,6 +187,7 @@ builder.Services.AddVersionedApiExplorer(options =>
     options.SubstituteApiVersionInUrl = true;
 
 });
+builder.Services.AddMemoryCache();
 
 var app = builder.Build();
 

--- a/api/net/TNO.API.csproj
+++ b/api/net/TNO.API.csproj
@@ -9,13 +9,14 @@
     <AssemblyVersion>0.0.0.1</AssemblyVersion>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0"/>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0"/>
-		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.0"/>
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.1" />
 	</ItemGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\..\libs\net\core\TNO.Core.csproj"/>
-		<ProjectReference Include="..\..\libs\net\dal\TNO.DAL.csproj"/>
-		<ProjectReference Include="..\..\libs\net\reports\TNO.Reports.csproj"/>
+		<ProjectReference Include="..\..\libs\net\core\TNO.Core.csproj" />
+		<ProjectReference Include="..\..\libs\net\dal\TNO.DAL.csproj" />
+		<ProjectReference Include="..\..\libs\net\reports\TNO.Reports.csproj" />
 	</ItemGroup>
 </Project>

--- a/app/editor/src/features/access-request/AccessRequest.tsx
+++ b/app/editor/src/features/access-request/AccessRequest.tsx
@@ -37,7 +37,6 @@ export const AccessRequest: React.FC = (props) => {
           <FormikForm
             initialValues={{}}
             onSubmit={(values, { setSubmitting }) => {
-              console.debug(values);
               setSubmitting(false);
             }}
           >
@@ -65,7 +64,6 @@ export const AccessRequest: React.FC = (props) => {
           <FormikForm
             initialValues={register}
             onSubmit={(values, { setSubmitting }) => {
-              console.debug(values);
               setSubmitting(false);
             }}
           >

--- a/app/editor/src/hooks/api-editor/admin/useApiAdminDataSources.ts
+++ b/app/editor/src/hooks/api-editor/admin/useApiAdminDataSources.ts
@@ -3,8 +3,8 @@ import { defaultEnvelope, ILifecycleToasts } from 'tno-core';
 import { IDataSourceModel, IPaged, useApi } from '..';
 
 /**
- * Common hook to make requests to the PIMS APi.
- * @returns CustomAxios object setup for the PIMS API.
+ * Common hook to make requests to the API.
+ * @returns CustomAxios object setup for the API.
  */
 export const useApiAdminDataSources = (
   options: {

--- a/app/editor/src/hooks/api-editor/auth/useApiAuth.ts
+++ b/app/editor/src/hooks/api-editor/auth/useApiAuth.ts
@@ -4,8 +4,8 @@ import { defaultEnvelope, ILifecycleToasts } from 'tno-core';
 import { IUserInfoModel, useApi } from '..';
 
 /**
- * Common hook to make requests to the PIMS APi.
- * @returns CustomAxios object setup for the PIMS API.
+ * Common hook to make requests to the API.
+ * @returns CustomAxios object setup for the API.
  */
 export const useApiAuth = (
   options: {

--- a/app/editor/src/hooks/api-editor/editor/index.ts
+++ b/app/editor/src/hooks/api-editor/editor/index.ts
@@ -1,4 +1,5 @@
 export * from './useApiActions';
+export * from './useApiCache';
 export * from './useApiCategories';
 export * from './useApiContents';
 export * from './useApiContentTypes';

--- a/app/editor/src/hooks/api-editor/editor/useApiActions.ts
+++ b/app/editor/src/hooks/api-editor/editor/useApiActions.ts
@@ -3,8 +3,8 @@ import { defaultEnvelope, ILifecycleToasts } from 'tno-core';
 import { IActionModel, useApi } from '..';
 
 /**
- * Common hook to make requests to the PIMS APi.
- * @returns CustomAxios object setup for the PIMS API.
+ * Common hook to make requests to the API.
+ * @returns CustomAxios object setup for the API.
  */
 export const useApiActions = (
   options: {
@@ -17,8 +17,9 @@ export const useApiActions = (
   const api = useApi(options);
 
   return {
-    getActions: () => {
-      return api.get<IActionModel[]>(`/editor/actions`);
+    getActions: (etag: string | undefined = undefined) => {
+      const config = !!etag ? { headers: { 'If-None-Match': etag } } : undefined;
+      return api.get<IActionModel[]>(`/editor/actions`, config);
     },
   };
 };

--- a/app/editor/src/hooks/api-editor/editor/useApiCache.ts
+++ b/app/editor/src/hooks/api-editor/editor/useApiCache.ts
@@ -1,0 +1,24 @@
+import { defaultEnvelope, ILifecycleToasts } from 'tno-core';
+
+import { ICacheModel, useApi } from '..';
+
+/**
+ * Common hook to make requests to the APi.
+ * @returns CustomAxios object setup for the API.
+ */
+export const useApiCache = (
+  options: {
+    lifecycleToasts?: ILifecycleToasts;
+    selector?: Function;
+    envelope?: typeof defaultEnvelope;
+    baseURL?: string;
+  } = {},
+) => {
+  const api = useApi(options);
+
+  return {
+    getCache: () => {
+      return api.get<ICacheModel[]>(`/editor/cache`);
+    },
+  };
+};

--- a/app/editor/src/hooks/api-editor/editor/useApiCategories.ts
+++ b/app/editor/src/hooks/api-editor/editor/useApiCategories.ts
@@ -3,8 +3,8 @@ import { defaultEnvelope, ILifecycleToasts } from 'tno-core';
 import { IContentTypeModel, useApi } from '..';
 
 /**
- * Common hook to make requests to the PIMS APi.
- * @returns CustomAxios object setup for the PIMS API.
+ * Common hook to make requests to the API.
+ * @returns CustomAxios object setup for the API.
  */
 export const useApiCategories = (
   options: {
@@ -17,8 +17,9 @@ export const useApiCategories = (
   const api = useApi(options);
 
   return {
-    getCategories: () => {
-      return api.get<IContentTypeModel[]>(`/editor/categories`);
+    getCategories: (etag: string | undefined = undefined) => {
+      const config = !!etag ? { headers: { 'If-None-Match': etag } } : undefined;
+      return api.get<IContentTypeModel[]>(`/editor/categories`, config);
     },
   };
 };

--- a/app/editor/src/hooks/api-editor/editor/useApiContentTypes.ts
+++ b/app/editor/src/hooks/api-editor/editor/useApiContentTypes.ts
@@ -3,8 +3,8 @@ import { defaultEnvelope, ILifecycleToasts } from 'tno-core';
 import { IContentTypeModel, useApi } from '..';
 
 /**
- * Common hook to make requests to the PIMS APi.
- * @returns CustomAxios object setup for the PIMS API.
+ * Common hook to make requests to the API.
+ * @returns CustomAxios object setup for the API.
  */
 export const useApiContentTypes = (
   options: {
@@ -17,8 +17,9 @@ export const useApiContentTypes = (
   const api = useApi(options);
 
   return {
-    getContentTypes: () => {
-      return api.get<IContentTypeModel[]>(`/editor/content/types`);
+    getContentTypes: (etag: string | undefined = undefined) => {
+      const config = !!etag ? { headers: { 'If-None-Match': etag } } : undefined;
+      return api.get<IContentTypeModel[]>(`/editor/content/types`, config);
     },
   };
 };

--- a/app/editor/src/hooks/api-editor/editor/useApiContents.ts
+++ b/app/editor/src/hooks/api-editor/editor/useApiContents.ts
@@ -3,8 +3,8 @@ import { defaultEnvelope, ILifecycleToasts, toQueryString } from 'tno-core';
 import { IContentFilter, IContentModel, IPaged, useApi } from '..';
 
 /**
- * Common hook to make requests to the PIMS APi.
- * @returns CustomAxios object setup for the PIMS API.
+ * Common hook to make requests to the API.
+ * @returns CustomAxios object setup for the API.
  */
 export const useApiContents = (
   options: {

--- a/app/editor/src/hooks/api-editor/editor/useApiDataSources.ts
+++ b/app/editor/src/hooks/api-editor/editor/useApiDataSources.ts
@@ -3,8 +3,8 @@ import { defaultEnvelope, ILifecycleToasts } from 'tno-core';
 import { IDataSourceModel, useApi } from '..';
 
 /**
- * Common hook to make requests to the PIMS APi.
- * @returns CustomAxios object setup for the PIMS API.
+ * Common hook to make requests to the API.
+ * @returns CustomAxios object setup for the API.
  */
 export const useApiDataSources = (
   options: {
@@ -17,8 +17,9 @@ export const useApiDataSources = (
   const api = useApi(options);
 
   return {
-    getDataSources: () => {
-      return api.get<IDataSourceModel[]>(`/editor/data/sources`);
+    getDataSources: (etag: string | undefined = undefined) => {
+      const config = !!etag ? { headers: { 'If-None-Match': etag } } : undefined;
+      return api.get<IDataSourceModel[]>(`/editor/data/sources`, config);
     },
   };
 };

--- a/app/editor/src/hooks/api-editor/editor/useApiLicenses.ts
+++ b/app/editor/src/hooks/api-editor/editor/useApiLicenses.ts
@@ -3,8 +3,8 @@ import { defaultEnvelope, ILifecycleToasts } from 'tno-core';
 import { ILicenseModel, useApi } from '..';
 
 /**
- * Common hook to make requests to the PIMS APi.
- * @returns CustomAxios object setup for the PIMS API.
+ * Common hook to make requests to the API.
+ * @returns CustomAxios object setup for the API.
  */
 export const useApiLicenses = (
   options: {
@@ -17,8 +17,9 @@ export const useApiLicenses = (
   const api = useApi(options);
 
   return {
-    getLicenses: () => {
-      return api.get<ILicenseModel[]>(`/editor/licenses`);
+    getLicenses: (etag: string | undefined = undefined) => {
+      const config = !!etag ? { headers: { 'If-None-Match': etag } } : undefined;
+      return api.get<ILicenseModel[]>(`/editor/licenses`, config);
     },
   };
 };

--- a/app/editor/src/hooks/api-editor/editor/useApiMediaTypes.ts
+++ b/app/editor/src/hooks/api-editor/editor/useApiMediaTypes.ts
@@ -3,8 +3,8 @@ import { defaultEnvelope, ILifecycleToasts } from 'tno-core';
 import { IMediaTypeModel, useApi } from '..';
 
 /**
- * Common hook to make requests to the PIMS APi.
- * @returns CustomAxios object setup for the PIMS API.
+ * Common hook to make requests to the API.
+ * @returns CustomAxios object setup for the API.
  */
 export const useApiMediaTypes = (
   options: {
@@ -17,8 +17,9 @@ export const useApiMediaTypes = (
   const api = useApi(options);
 
   return {
-    getMediaTypes: () => {
-      return api.get<IMediaTypeModel[]>(`/editor/media/types`);
+    getMediaTypes: (etag: string | undefined = undefined) => {
+      const config = !!etag ? { headers: { 'If-None-Match': etag } } : undefined;
+      return api.get<IMediaTypeModel[]>(`/editor/media/types`, config);
     },
   };
 };

--- a/app/editor/src/hooks/api-editor/editor/useApiSeries.ts
+++ b/app/editor/src/hooks/api-editor/editor/useApiSeries.ts
@@ -3,8 +3,8 @@ import { defaultEnvelope, ILifecycleToasts } from 'tno-core';
 import { ISeriesModel, useApi } from '..';
 
 /**
- * Common hook to make requests to the PIMS APi.
- * @returns CustomAxios object setup for the PIMS API.
+ * Common hook to make requests to the API.
+ * @returns CustomAxios object setup for the API.
  */
 export const useApiSeries = (
   options: {
@@ -17,8 +17,9 @@ export const useApiSeries = (
   const api = useApi(options);
 
   return {
-    getSeries: () => {
-      return api.get<ISeriesModel[]>(`/editor/series`);
+    getSeries: (etag: string | undefined = undefined) => {
+      const config = !!etag ? { headers: { 'If-None-Match': etag } } : undefined;
+      return api.get<ISeriesModel[]>(`/editor/series`, config);
     },
   };
 };

--- a/app/editor/src/hooks/api-editor/editor/useApiSourceActions.ts
+++ b/app/editor/src/hooks/api-editor/editor/useApiSourceActions.ts
@@ -3,8 +3,8 @@ import { defaultEnvelope, ILifecycleToasts } from 'tno-core';
 import { ISourceActionModel, useApi } from '..';
 
 /**
- * Common hook to make requests to the PIMS APi.
- * @returns CustomAxios object setup for the PIMS API.
+ * Common hook to make requests to the API.
+ * @returns CustomAxios object setup for the API.
  */
 export const useApiSourceActions = (
   options: {
@@ -17,8 +17,9 @@ export const useApiSourceActions = (
   const api = useApi(options);
 
   return {
-    getActions: () => {
-      return api.get<ISourceActionModel[]>(`/editor/source/actions`);
+    getActions: (etag: string | undefined = undefined) => {
+      const config = !!etag ? { headers: { 'If-None-Match': etag } } : undefined;
+      return api.get<ISourceActionModel[]>(`/editor/source/actions`, config);
     },
   };
 };

--- a/app/editor/src/hooks/api-editor/editor/useApiSourceMetrics.ts
+++ b/app/editor/src/hooks/api-editor/editor/useApiSourceMetrics.ts
@@ -3,8 +3,8 @@ import { defaultEnvelope, ILifecycleToasts } from 'tno-core';
 import { ISourceMetricModel, useApi } from '..';
 
 /**
- * Common hook to make requests to the PIMS APi.
- * @returns CustomAxios object setup for the PIMS API.
+ * Common hook to make requests to the API.
+ * @returns CustomAxios object setup for the API.
  */
 export const useApiSourceMetrics = (
   options: {
@@ -17,8 +17,9 @@ export const useApiSourceMetrics = (
   const api = useApi(options);
 
   return {
-    getMetrics: () => {
-      return api.get<ISourceMetricModel[]>(`/editor/source/metrics`);
+    getMetrics: (etag: string | undefined = undefined) => {
+      const config = !!etag ? { headers: { 'If-None-Match': etag } } : undefined;
+      return api.get<ISourceMetricModel[]>(`/editor/source/metrics`, config);
     },
   };
 };

--- a/app/editor/src/hooks/api-editor/editor/useApiTags.ts
+++ b/app/editor/src/hooks/api-editor/editor/useApiTags.ts
@@ -3,8 +3,8 @@ import { defaultEnvelope, ILifecycleToasts } from 'tno-core';
 import { ITagModel, useApi } from '..';
 
 /**
- * Common hook to make requests to the PIMS APi.
- * @returns CustomAxios object setup for the PIMS API.
+ * Common hook to make requests to the API.
+ * @returns CustomAxios object setup for the API.
  */
 export const useApiTags = (
   options: {
@@ -17,8 +17,9 @@ export const useApiTags = (
   const api = useApi(options);
 
   return {
-    getTags: () => {
-      return api.get<ITagModel[]>(`/editor/tags`);
+    getTags: (etag: string | undefined = undefined) => {
+      const config = !!etag ? { headers: { 'If-None-Match': etag } } : undefined;
+      return api.get<ITagModel[]>(`/editor/tags`, config);
     },
   };
 };

--- a/app/editor/src/hooks/api-editor/editor/useApiTonePools.ts
+++ b/app/editor/src/hooks/api-editor/editor/useApiTonePools.ts
@@ -3,8 +3,8 @@ import { defaultEnvelope, ILifecycleToasts } from 'tno-core';
 import { ITonePoolModel, useApi } from '..';
 
 /**
- * Common hook to make requests to the PIMS APi.
- * @returns CustomAxios object setup for the PIMS API.
+ * Common hook to make requests to the API.
+ * @returns CustomAxios object setup for the API.
  */
 export const useApiTonePools = (
   options: {
@@ -17,8 +17,9 @@ export const useApiTonePools = (
   const api = useApi(options);
 
   return {
-    getTonePools: () => {
-      return api.get<ITonePoolModel[]>(`/editor/tone/pools`);
+    getTonePools: (etag: string | undefined = undefined) => {
+      const config = !!etag ? { headers: { 'If-None-Match': etag } } : undefined;
+      return api.get<ITonePoolModel[]>(`/editor/tone/pools`, config);
     },
   };
 };

--- a/app/editor/src/hooks/api-editor/editor/useApiUsers.ts
+++ b/app/editor/src/hooks/api-editor/editor/useApiUsers.ts
@@ -3,8 +3,8 @@ import { defaultEnvelope, ILifecycleToasts } from 'tno-core';
 import { IUserModel, useApi } from '..';
 
 /**
- * Common hook to make requests to the PIMS APi.
- * @returns CustomAxios object setup for the PIMS API.
+ * Common hook to make requests to the API.
+ * @returns CustomAxios object setup for the API.
  */
 export const useApiUsers = (
   options: {
@@ -17,8 +17,9 @@ export const useApiUsers = (
   const api = useApi(options);
 
   return {
-    getUsers: () => {
-      return api.get<IUserModel[]>(`/editor/users`);
+    getUsers: (etag: string | undefined = undefined) => {
+      const config = !!etag ? { headers: { 'If-None-Match': etag } } : undefined;
+      return api.get<IUserModel[]>(`/editor/users`, config);
     },
   };
 };

--- a/app/editor/src/hooks/api-editor/interfaces/ICacheModel.ts
+++ b/app/editor/src/hooks/api-editor/interfaces/ICacheModel.ts
@@ -1,0 +1,7 @@
+import { IAuditColumnsModel } from '.';
+
+export interface ICacheModel extends IAuditColumnsModel {
+  key: string;
+  value?: string;
+  description?: string;
+}

--- a/app/editor/src/hooks/api-editor/interfaces/index.ts
+++ b/app/editor/src/hooks/api-editor/interfaces/index.ts
@@ -1,5 +1,6 @@
 export * from './IActionModel';
 export * from './IAuditColumnsModel';
+export * from './ICacheModel';
 export * from './ICategoryModel';
 export * from './IContentActionModel';
 export * from './IContentCategoryModel';

--- a/app/editor/src/hooks/api-editor/reports/useApiReports.ts
+++ b/app/editor/src/hooks/api-editor/reports/useApiReports.ts
@@ -4,8 +4,8 @@ import { defaultEnvelope, ILifecycleToasts, toQueryString, useDownload } from 't
 import { useApi } from '..';
 
 /**
- * Common hook to make requests to the PIMS APi.
- * @returns CustomAxios object setup for the PIMS API.
+ * Common hook to make requests to the API.
+ * @returns CustomAxios object setup for the API.
  */
 export const useApiReports = (
   options: {

--- a/app/editor/src/store/hooks/app/useApp.ts
+++ b/app/editor/src/store/hooks/app/useApp.ts
@@ -38,7 +38,7 @@ interface IAppController {
   /**
    * Initialize application lookups and settings.
    */
-  init: (refresh?: boolean) => void;
+  init: () => Promise<void>;
 }
 
 /**
@@ -63,8 +63,8 @@ export const useApp = (): [IAppState, IAppController] => {
       isUserReady: () => userInfo.id !== 0,
       removeError: store.removeError,
       clearErrors: store.clearErrors,
-      init: (refresh: boolean = false) => {
-        init(refresh);
+      init: async () => {
+        await init();
       },
     }),
     [api, dispatch, store, init],

--- a/app/editor/src/store/hooks/lookup/utils/addOrUpdate.ts
+++ b/app/editor/src/store/hooks/lookup/utils/addOrUpdate.ts
@@ -1,0 +1,20 @@
+/**
+ * Update the value in the array, or add it to the array if it doesn't exist.
+ * @param value
+ * @param values
+ * @param find
+ * @returns
+ */
+export const addOrUpdate = <T>(value: T, values: T[], find: (value: T) => boolean) => {
+  let found = false;
+  const result = values.map((v) => {
+    if (find(v)) {
+      found = true;
+      return value;
+    }
+    return v;
+  });
+
+  if (!found) result.push(value);
+  return result;
+};

--- a/app/editor/src/store/hooks/lookup/utils/fetchIfNoneMatch.ts
+++ b/app/editor/src/store/hooks/lookup/utils/fetchIfNoneMatch.ts
@@ -1,0 +1,46 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { ICacheModel } from 'hooks/api-editor';
+
+import { addOrUpdate, getFromLocalStorage, initFromLocalStorage } from '.';
+
+export const fetchIfNoneMatch = async <T>(
+  key: string,
+  dispatch: <T>(
+    url: string,
+    request: () => Promise<AxiosResponse<T[], any>>,
+    response?: ((response: AxiosResponse<T[], any>) => void) | undefined,
+  ) => Promise<T[]>,
+  fetch: (etag?: string) => Promise<AxiosResponse<T[], any>>,
+  store: (results: T[]) => void,
+) => {
+  return await initFromLocalStorage<T>(key, async (items) => {
+    try {
+      let etag = getFromLocalStorage<ICacheModel[]>('cache', []).find((c) => c.key === key)?.value;
+
+      const result = await dispatch(
+        key,
+        () => fetch(etag),
+        (response) => {
+          etag = response.headers['etag'];
+        },
+      );
+
+      store(result);
+      const cache = addOrUpdate(
+        { key: key, value: etag },
+        getFromLocalStorage<ICacheModel[]>('cache', []),
+        (c) => c.key === key,
+      );
+      localStorage.setItem('cache', JSON.stringify(cache));
+
+      return result;
+    } catch (error) {
+      const ae = error as AxiosError;
+      if (ae.response?.status === 304) {
+        store(items);
+        return items;
+      }
+      throw error;
+    }
+  });
+};

--- a/app/editor/src/store/hooks/lookup/utils/index.ts
+++ b/app/editor/src/store/hooks/lookup/utils/index.ts
@@ -1,2 +1,4 @@
+export * from './addOrUpdate';
+export * from './fetchIfNoneMatch';
 export * from './getFromLocalStorage';
 export * from './initFromLocalStorage';

--- a/app/editor/src/store/hooks/lookup/utils/initFromLocalStorage.ts
+++ b/app/editor/src/store/hooks/lookup/utils/initFromLocalStorage.ts
@@ -4,17 +4,19 @@ import { getFromLocalStorage } from '.';
  * Initialize values from local storage, or from the specified action.
  * If the action returns a new value it will be stored in local storage.
  * @param name The key to identify the value in local storage.
- * @param defaultValue The default value if local storage doesn't contain a value.
  * @param action An action to perform with the values from local storage.
  * @returns The value returned from the action.
  */
 export const initFromLocalStorage = async <T>(
   name: string,
-  defaultValue: T,
-  action: (value: T) => Promise<T>,
+  action: (value: T[]) => Promise<T[]>,
 ) => {
-  const value = getFromLocalStorage<T>(name, defaultValue);
+  const value = getFromLocalStorage<T[]>(name, []);
   const result = await action(value);
   if (value !== result) localStorage.setItem(name, JSON.stringify(result));
   return result;
+};
+
+export const genericFactory = <T>(type: new () => T): T => {
+  return new type();
 };

--- a/app/editor/src/store/hooks/useApiDispatcher.ts
+++ b/app/editor/src/store/hooks/useApiDispatcher.ts
@@ -1,6 +1,5 @@
 import { AxiosError, AxiosResponse } from 'axios';
 import { useAppStore } from 'store/slices';
-import { extractResponseData } from 'tno-core';
 
 export interface apiDispatcher<T> {
   (
@@ -18,14 +17,23 @@ export interface apiDispatcher<T> {
 export const useApiDispatcher = () => {
   const [, app] = useAppStore();
 
-  return async <T>(url: string, request: () => Promise<AxiosResponse<T, any>>) => {
+  return async <T>(
+    url: string,
+    request: () => Promise<AxiosResponse<T, any>>,
+    response: ((response: AxiosResponse<T, any>) => void) | undefined = undefined,
+  ) => {
     try {
       app.addRequest(url);
-      const response = await extractResponseData<T>(request);
-      return response;
+      const res = await request();
+      response?.(res);
+      const data = res.data as T;
+      return data;
     } catch (error) {
       // TODO: Capture error information.
       const ae = error as AxiosError;
+
+      if (ae.response?.status === 304) throw error;
+
       let message = 'An unexpected error has occurred.';
       if (typeof ae.response?.data === 'string') message = ae.response?.data;
       else if (ae.response?.data?.error) message = ae.response?.data?.error;

--- a/app/editor/src/store/slices/lookup/interfaces/ILookupState.ts
+++ b/app/editor/src/store/slices/lookup/interfaces/ILookupState.ts
@@ -1,5 +1,6 @@
 import {
   IActionModel,
+  ICacheModel,
   ICategoryModel,
   IContentTypeModel,
   IDataSourceModel,
@@ -14,6 +15,7 @@ import {
 } from 'hooks/api-editor';
 
 export interface ILookupState {
+  cache: ICacheModel[];
   actions: IActionModel[];
   sourceActions: ISourceActionModel[];
   sourceMetrics: ISourceMetricModel[];

--- a/app/editor/src/store/slices/lookup/lookupSlice.ts
+++ b/app/editor/src/store/slices/lookup/lookupSlice.ts
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import {
   IActionModel,
+  ICacheModel,
   ICategoryModel,
   IContentTypeModel,
   IDataSourceModel,
@@ -17,6 +18,7 @@ import {
 import { ILookupState } from './interfaces';
 
 export const initialLookupState: ILookupState = {
+  cache: [],
   actions: [],
   sourceActions: [],
   sourceMetrics: [],
@@ -35,6 +37,20 @@ export const lookupSlice = createSlice({
   name: 'lookup',
   initialState: initialLookupState,
   reducers: {
+    storeCache(state: ILookupState, action: PayloadAction<ICacheModel[]>) {
+      state.cache = action.payload;
+    },
+    updateCache(state: ILookupState, action: PayloadAction<ICacheModel>) {
+      let keyFound = false;
+      state.cache = state.cache.map((c) => {
+        if (c.key === action.payload.key) {
+          keyFound = true;
+          return { ...c, value: action.payload.value };
+        }
+        return c;
+      });
+      if (!keyFound) state.cache.push(action.payload);
+    },
     storeActions(state: ILookupState, action: PayloadAction<IActionModel[]>) {
       state.actions = action.payload;
     },
@@ -75,6 +91,7 @@ export const lookupSlice = createSlice({
 });
 
 export const {
+  storeCache,
   storeActions,
   storeSourceActions,
   storeSourceMetrics,
@@ -87,4 +104,5 @@ export const {
   storeTags,
   storeTonePools,
   storeUsers,
+  updateCache,
 } = lookupSlice.actions;

--- a/app/editor/src/store/slices/lookup/useLookupStore.ts
+++ b/app/editor/src/store/slices/lookup/useLookupStore.ts
@@ -1,5 +1,6 @@
 import {
   IActionModel,
+  ICacheModel,
   ICategoryModel,
   IContentTypeModel,
   IDataSourceModel,
@@ -17,6 +18,7 @@ import { useAppDispatch, useAppSelector } from 'store';
 
 import {
   storeActions,
+  storeCache,
   storeCategories,
   storeContentTypes,
   storeDataSources,
@@ -28,10 +30,13 @@ import {
   storeTags,
   storeTonePools,
   storeUsers,
+  updateCache,
 } from '.';
 import { ILookupState } from './interfaces';
 
 export interface ILookupStore {
+  storeCache: (cache: ICacheModel[]) => void;
+  updateCache: (cache: ICacheModel) => void;
   storeActions: (actions: IActionModel[]) => void;
   storeSourceActions: (actions: ISourceActionModel[]) => void;
   storeSourceMetrics: (metrics: ISourceMetricModel[]) => void;
@@ -52,6 +57,12 @@ export const useLookupStore = (): [ILookupState, ILookupStore] => {
 
   const controller = React.useMemo(
     () => ({
+      storeCache: (cache: ICacheModel[]) => {
+        dispatch(storeCache(cache));
+      },
+      updateCache: (cache: ICacheModel) => {
+        dispatch(updateCache(cache));
+      },
       storeActions: (actions: IActionModel[]) => {
         dispatch(storeActions(actions));
       },

--- a/libs/net/core/Data/CacheAttribute.cs
+++ b/libs/net/core/Data/CacheAttribute.cs
@@ -1,0 +1,37 @@
+namespace TNO.Core.Data;
+
+/// <summary>
+/// CacheAttribute class, provides a way to identify an entity for caching.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+public class CacheAttribute : Attribute
+{
+    #region Properties
+    /// <summary>
+    /// get/set - Unique key to identify this cache item.
+    /// </summary>
+    public string Key { get; set; }
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    /// Creates a new instance of a CacheAttribute object, initializes with specified parameter.
+    /// </summary>
+    /// <param name="key">Unique key to identify this cache item.</param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public CacheAttribute(string key)
+    {
+        this.Key = key ?? throw new ArgumentNullException(nameof(key));
+    }
+
+    /// <summary>
+    /// Creates a new instance of a CacheAttribute object, initializes with specified parameter.
+    /// </summary>
+    /// <param name="type">Name of type provides unique key to identify this cache item.</param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public CacheAttribute(Type type)
+    {
+        this.Key = type?.Name ?? throw new ArgumentNullException(nameof(type));
+    }
+    #endregion
+}

--- a/libs/net/core/Extensions/TypeExtensions.cs
+++ b/libs/net/core/Extensions/TypeExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using TNO.Core.Data;
 
 namespace TNO.Core.Extensions
 {
@@ -230,6 +231,17 @@ namespace TNO.Core.Extensions
             if (type.IsValueType)
                 return Activator.CreateInstance(type);
             return null;
+        }
+
+        /// <summary>
+        /// Get the cache key of the specified type, if they type has the 'CacheAttribute'.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public static string? GetCacheKey(this Type type)
+        {
+            var attr = type.GetCustomAttribute<CacheAttribute>();
+            return attr?.Key;
         }
         #endregion
     }

--- a/libs/net/dal/Configuration/CacheConfiguration.cs
+++ b/libs/net/dal/Configuration/CacheConfiguration.cs
@@ -1,0 +1,18 @@
+namespace TNO.DAL.Configuration;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TNO.Entities;
+
+public class CacheConfiguration : AuditColumnsConfiguration<Cache>
+{
+    public override void Configure(EntityTypeBuilder<Cache> builder)
+    {
+        builder.HasKey(m => m.Key);
+        builder.Property(m => m.Key).IsRequired().HasMaxLength(100).ValueGeneratedNever();
+        builder.Property(m => m.Value).IsRequired().HasMaxLength(150);
+        builder.Property(m => m.Description).IsRequired().HasMaxLength(2000).HasDefaultValueSql("''");
+
+        base.Configure(builder);
+    }
+}

--- a/libs/net/dal/Migrations/20220502202500_Initial.Designer.cs
+++ b/libs/net/dal/Migrations/20220502202500_Initial.Designer.cs
@@ -12,7 +12,7 @@ using TNO.DAL;
 namespace TNO.DAL.Migrations
 {
     [DbContext(typeof(TNOContext))]
-    [Migration("20220429162252_Initial")]
+    [Migration("20220502202500_Initial")]
     partial class Initial
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -124,6 +124,71 @@ namespace TNO.DAL.Migrations
                         .IsUnique();
 
                     b.ToTable("action");
+                });
+
+            modelBuilder.Entity("TNO.Entities.Cache", b =>
+                {
+                    b.Property<string>("Key")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)")
+                        .HasColumnName("key");
+
+                    b.Property<string>("CreatedBy")
+                        .IsRequired()
+                        .HasMaxLength(250)
+                        .HasColumnType("character varying(250)")
+                        .HasColumnName("created_by");
+
+                    b.Property<Guid>("CreatedById")
+                        .HasColumnType("uuid")
+                        .HasColumnName("created_by_id");
+
+                    b.Property<DateTime>("CreatedOn")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("created_on")
+                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasMaxLength(2000)
+                        .HasColumnType("character varying(2000)")
+                        .HasColumnName("description")
+                        .HasDefaultValueSql("''");
+
+                    b.Property<string>("UpdatedBy")
+                        .IsRequired()
+                        .HasMaxLength(250)
+                        .HasColumnType("character varying(250)")
+                        .HasColumnName("updated_by");
+
+                    b.Property<Guid>("UpdatedById")
+                        .HasColumnType("uuid")
+                        .HasColumnName("updated_by_id");
+
+                    b.Property<DateTime>("UpdatedOn")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("updated_on")
+                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+                    b.Property<string>("Value")
+                        .IsRequired()
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)")
+                        .HasColumnName("value");
+
+                    b.Property<long>("Version")
+                        .IsConcurrencyToken()
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("bigint")
+                        .HasColumnName("version")
+                        .HasDefaultValueSql("0");
+
+                    b.HasKey("Key");
+
+                    b.ToTable("cache");
                 });
 
             modelBuilder.Entity("TNO.Entities.Category", b =>

--- a/libs/net/dal/Migrations/20220502202500_Initial.cs
+++ b/libs/net/dal/Migrations/20220502202500_Initial.cs
@@ -39,6 +39,26 @@ namespace TNO.DAL.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "cache",
+                columns: table => new
+                {
+                    key = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    value = table.Column<string>(type: "character varying(150)", maxLength: 150, nullable: false),
+                    description = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false, defaultValueSql: "''"),
+                    created_by_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    created_by = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
+                    created_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    updated_by_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    updated_by = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
+                    updated_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    version = table.Column<long>(type: "bigint", nullable: false, defaultValueSql: "0")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_cache", x => x.key);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "category",
                 columns: table => new
                 {
@@ -1319,6 +1339,9 @@ namespace TNO.DAL.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             PreDown(migrationBuilder);
+            migrationBuilder.DropTable(
+                name: "cache");
+
             migrationBuilder.DropTable(
                 name: "content_action");
 

--- a/libs/net/dal/Migrations/Initial/Up/PostUp/00-Cache.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/00-Cache.sql
@@ -1,0 +1,135 @@
+DO $$
+DECLARE DEFAULT_USER_ID UUID := '00000000-0000-0000-0000-000000000000';
+BEGIN
+
+INSERT INTO public.cache (
+  "key"
+  , "value"
+  , "description"
+  , "created_by_id"
+  , "created_by"
+  , "updated_by_id"
+  , "updated_by"
+) VALUES (
+  'claims' -- key
+  , gen_random_uuid() -- value
+  , '' -- description
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+), (
+  'roles' -- key
+  , gen_random_uuid() -- value
+  , '' -- description
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+), (
+  'users' -- key
+  , gen_random_uuid() -- value
+  , '' -- description
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+), (
+  'actions' -- key
+  , gen_random_uuid() -- value
+  , '' -- description
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+), (
+  'source_actions' -- key
+  , gen_random_uuid() -- value
+  , '' -- description
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+), (
+  'source_metrics' -- key
+  , gen_random_uuid() -- value
+  , '' -- description
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+), (
+  'categories' -- key
+  , gen_random_uuid() -- value
+  , '' -- description
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+), (
+  'tags' -- key
+  , gen_random_uuid() -- value
+  , '' -- description
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+), (
+  'tone_pools' -- key
+  , gen_random_uuid() -- value
+  , '' -- description
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+), (
+  'content_types' -- key
+  , gen_random_uuid() -- value
+  , '' -- description
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+), (
+  'media_types' -- key
+  , gen_random_uuid() -- value
+  , '' -- description
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+), (
+  'licenses' -- key
+  , gen_random_uuid() -- value
+  , '' -- description
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+), (
+  'series' -- key
+  , gen_random_uuid() -- value
+  , '' -- description
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+), (
+  'data_locations' -- key
+  , gen_random_uuid() -- value
+  , '' -- description
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+), (
+  'data_sources' -- key
+  , gen_random_uuid() -- value
+  , '' -- description
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+);
+
+END $$;

--- a/libs/net/dal/Migrations/TNOContextModelSnapshot.cs
+++ b/libs/net/dal/Migrations/TNOContextModelSnapshot.cs
@@ -124,6 +124,71 @@ namespace TNO.DAL.Migrations
                     b.ToTable("action");
                 });
 
+            modelBuilder.Entity("TNO.Entities.Cache", b =>
+                {
+                    b.Property<string>("Key")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)")
+                        .HasColumnName("key");
+
+                    b.Property<string>("CreatedBy")
+                        .IsRequired()
+                        .HasMaxLength(250)
+                        .HasColumnType("character varying(250)")
+                        .HasColumnName("created_by");
+
+                    b.Property<Guid>("CreatedById")
+                        .HasColumnType("uuid")
+                        .HasColumnName("created_by_id");
+
+                    b.Property<DateTime>("CreatedOn")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("created_on")
+                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasMaxLength(2000)
+                        .HasColumnType("character varying(2000)")
+                        .HasColumnName("description")
+                        .HasDefaultValueSql("''");
+
+                    b.Property<string>("UpdatedBy")
+                        .IsRequired()
+                        .HasMaxLength(250)
+                        .HasColumnType("character varying(250)")
+                        .HasColumnName("updated_by");
+
+                    b.Property<Guid>("UpdatedById")
+                        .HasColumnType("uuid")
+                        .HasColumnName("updated_by_id");
+
+                    b.Property<DateTime>("UpdatedOn")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("updated_on")
+                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+                    b.Property<string>("Value")
+                        .IsRequired()
+                        .HasMaxLength(150)
+                        .HasColumnType("character varying(150)")
+                        .HasColumnName("value");
+
+                    b.Property<long>("Version")
+                        .IsConcurrencyToken()
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("bigint")
+                        .HasColumnName("version")
+                        .HasDefaultValueSql("0");
+
+                    b.HasKey("Key");
+
+                    b.ToTable("cache");
+                });
+
             modelBuilder.Entity("TNO.Entities.Category", b =>
                 {
                     b.Property<int>("Id")

--- a/libs/net/dal/Services/ActionService.cs
+++ b/libs/net/dal/Services/ActionService.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 
 namespace TNO.DAL.Services;
 
-public class ActionService : BaseService<Action, int>, IActionService
+public class ActionService : BaseService<Entities.Action, int>, IActionService
 {
     #region Properties
     #endregion

--- a/libs/net/dal/Services/BaseService`.cs
+++ b/libs/net/dal/Services/BaseService`.cs
@@ -1,7 +1,7 @@
 using System.Security.Claims;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using TNO.Entities;
+using TNO.DAL.Extensions;
 
 namespace TNO.DAL.Services;
 
@@ -36,6 +36,8 @@ public abstract class BaseService<TEntity, TKey> : BaseService, IBaseService<TEn
 
         this.Context.Entry(entity).State = EntityState.Added;
         this.Context.Add(entity);
+        this.Context.UpdateCache<TEntity>();
+
         this.Context.CommitTransaction();
         return entity;
     }
@@ -46,6 +48,8 @@ public abstract class BaseService<TEntity, TKey> : BaseService, IBaseService<TEn
 
         this.Context.Entry(entity).State = EntityState.Modified;
         this.Context.Update(entity);
+        this.Context.UpdateCache<TEntity>();
+
         this.Context.CommitTransaction();
         return entity;
     }
@@ -56,6 +60,8 @@ public abstract class BaseService<TEntity, TKey> : BaseService, IBaseService<TEn
 
         this.Context.Entry(entity).State = EntityState.Deleted;
         this.Context.Remove(entity);
+        this.Context.UpdateCache<TEntity>();
+
         this.Context.CommitTransaction();
     }
     #endregion

--- a/libs/net/dal/Services/CacheService.cs
+++ b/libs/net/dal/Services/CacheService.cs
@@ -1,0 +1,23 @@
+using System.Security.Claims;
+using Microsoft.Extensions.Logging;
+
+namespace TNO.DAL.Services;
+
+public class CacheService : BaseService<Entities.Cache, string>, ICacheService
+{
+    #region Properties
+    #endregion
+
+    #region Constructors
+    public CacheService(TNOContext dbContext, ClaimsPrincipal principal, IServiceProvider serviceProvider, ILogger<CacheService> logger) : base(dbContext, principal, serviceProvider, logger)
+    {
+    }
+    #endregion
+
+    #region Methods
+    public IEnumerable<Entities.Cache> FindAll()
+    {
+        return this.Context.Cache.ToArray();
+    }
+    #endregion
+}

--- a/libs/net/dal/Services/ContentService.cs
+++ b/libs/net/dal/Services/ContentService.cs
@@ -149,8 +149,6 @@ public class ContentService : BaseService<Content, long>, IContentService
     {
         var original = FindById(entity.Id) ?? throw new InvalidOperationException("Entity does not exist");
         this.Context.UpdateContext(original, entity);
-
-        // Extract all FileReferences marked for deletion.
         base.Update(original);
         return original;
     }

--- a/libs/net/dal/Services/Interfaces/IActionService.cs
+++ b/libs/net/dal/Services/Interfaces/IActionService.cs
@@ -1,7 +1,7 @@
 
 namespace TNO.DAL.Services;
 
-public interface IActionService : IBaseService<Action, int>
+public interface IActionService : IBaseService<Entities.Action, int>
 {
     IEnumerable<Entities.Action> FindAll();
     Entities.Action? FindByName(string name);

--- a/libs/net/dal/Services/Interfaces/ICacheService.cs
+++ b/libs/net/dal/Services/Interfaces/ICacheService.cs
@@ -1,0 +1,7 @@
+
+namespace TNO.DAL.Services;
+
+public interface ICacheService : IBaseService<Entities.Cache, string>
+{
+    IEnumerable<Entities.Cache> FindAll();
+}

--- a/libs/net/dal/TNOContext.cs
+++ b/libs/net/dal/TNOContext.cs
@@ -47,6 +47,7 @@ public class TNOContext : DbContext
     public DbSet<SourceAction> SourceActions => Set<SourceAction>();
     public DbSet<DataSourceSchedule> DataSourceSchedules => Set<DataSourceSchedule>();
     public DbSet<Schedule> Schedules => Set<Schedule>();
+    public DbSet<Cache> Cache => Set<Cache>();
     public DbSet<User> Users => Set<User>();
     public DbSet<UserRole> UserRoles => Set<UserRole>();
     public DbSet<Role> Roles => Set<Role>();

--- a/libs/net/entities/Action.cs
+++ b/libs/net/entities/Action.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using TNO.Core.Data;
 
 namespace TNO.Entities;
 
+[Cache("actions")]
 [Table("action")]
 public class Action : BaseType<int>
 {

--- a/libs/net/entities/Cache.cs
+++ b/libs/net/entities/Cache.cs
@@ -1,0 +1,57 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TNO.Entities;
+
+/// <summary>
+/// Cache class, provides an entity to store cache key values in the database.
+/// A cache key is used to determine whether the data represented by the key has been changed.
+/// </summary>
+[Table("cache")]
+public class Cache : AuditColumns
+{
+    #region Properties
+    /// <summary>
+    /// get/set - Primary key to uniquely identify the cache item.
+    /// </summary>
+    [Key]
+    [Column("key")]
+    public string Key { get; set; }
+
+    /// <summary>
+    /// get/set - The cache value to determine if cache has changed.
+    /// </summary>
+    [Column("value")]
+    public string Value { get; set; }
+
+    /// <summary>
+    /// get/set - A description of the cache item.
+    /// </summary>
+    [Column("description")]
+    public string Description { get; set; } = "";
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    /// Creates a new instance of a Cache entity, initializes with specified parameters.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="value"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public Cache(string key, Guid value) : this(key, value.ToString())
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of a Cache entity, initializes with specified parameters.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="value"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public Cache(string key, string value)
+    {
+        this.Key = key ?? throw new ArgumentNullException(nameof(key));
+        this.Value = value ?? throw new ArgumentNullException(nameof(value));
+    }
+    #endregion
+}

--- a/libs/net/entities/Category.cs
+++ b/libs/net/entities/Category.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using TNO.Core.Data;
 
 namespace TNO.Entities;
 
+[Cache("categories")]
 [Table("category")]
 public class Category : BaseType<int>
 {

--- a/libs/net/entities/Claim.cs
+++ b/libs/net/entities/Claim.cs
@@ -1,8 +1,10 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using TNO.Core.Data;
 
 namespace TNO.Entities;
 
+[Cache("claims")]
 [Table("claim")]
 public class Claim : AuditColumns
 {

--- a/libs/net/entities/ContentType.cs
+++ b/libs/net/entities/ContentType.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using TNO.Core.Data;
 
 namespace TNO.Entities;
 
+[Cache("content_types")]
 [Table("content_type")]
 public class ContentType : BaseType<int>
 {

--- a/libs/net/entities/DataLocation.cs
+++ b/libs/net/entities/DataLocation.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using TNO.Core.Data;
 
 namespace TNO.Entities;
 
@@ -6,6 +7,7 @@ namespace TNO.Entities;
 /// DataLocation class, provides a way to identify and describe a location where data will be uploaded and stored.
 /// Note this is not the same thing as the data source location.
 /// </summary>
+[Cache("data_locations")]
 [Table("data_location")]
 public class DataLocation : BaseType<int>
 {

--- a/libs/net/entities/DataSource.cs
+++ b/libs/net/entities/DataSource.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using TNO.Core.Data;
 
 namespace TNO.Entities;
 
@@ -7,6 +8,7 @@ namespace TNO.Entities;
 /// DataSource class, provides a way to desribe and store a source of data.
 /// Includes information on how to connect to the data source and how services are run and scheduled.
 /// </summary>
+[Cache("data_sources")]
 [Table("data_source")]
 public class DataSource : AuditColumns
 {

--- a/libs/net/entities/License.cs
+++ b/libs/net/entities/License.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using TNO.Core.Data;
 
 namespace TNO.Entities;
 
+[Cache("licenses")]
 [Table("license")]
 public class License : BaseType<int>
 {

--- a/libs/net/entities/MediaType.cs
+++ b/libs/net/entities/MediaType.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using TNO.Core.Data;
 
 namespace TNO.Entities;
 
+[Cache("media_types")]
 [Table("media_type")]
 public class MediaType : BaseType<int>
 {

--- a/libs/net/entities/Role.cs
+++ b/libs/net/entities/Role.cs
@@ -1,8 +1,10 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using TNO.Core.Data;
 
 namespace TNO.Entities;
 
+[Cache("roles")]
 [Table("role")]
 public class Role : AuditColumns
 {

--- a/libs/net/entities/Series.cs
+++ b/libs/net/entities/Series.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using TNO.Core.Data;
 
 namespace TNO.Entities;
 
+[Cache("series")]
 [Table("series")]
 public class Series : BaseType<int>
 {

--- a/libs/net/entities/SourceAction.cs
+++ b/libs/net/entities/SourceAction.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using TNO.Core.Data;
 
 namespace TNO.Entities;
 
+[Cache("source_actions")]
 [Table("source_action")]
 public class SourceAction : BaseType<int>
 {

--- a/libs/net/entities/SourceMetric.cs
+++ b/libs/net/entities/SourceMetric.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using TNO.Core.Data;
 
 namespace TNO.Entities;
 
+[Cache("source_metrics")]
 [Table("source_metric")]
 public class SourceMetric : BaseType<int>
 {

--- a/libs/net/entities/Tag.cs
+++ b/libs/net/entities/Tag.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using TNO.Core.Data;
 
 namespace TNO.Entities;
 
+[Cache("tags")]
 [Table("tag")]
 public class Tag : BaseType<string>
 {

--- a/libs/net/entities/TonePool.cs
+++ b/libs/net/entities/TonePool.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using TNO.Core.Data;
 
 namespace TNO.Entities;
 
+[Cache("tone_pools")]
 [Table("tone_pool")]
 public class TonePool : BaseType<int>
 {

--- a/libs/net/entities/User.cs
+++ b/libs/net/entities/User.cs
@@ -1,8 +1,10 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using TNO.Core.Data;
 
 namespace TNO.Entities;
 
+[Cache("users")]
 [Table("user")]
 public class User : AuditColumns
 {


### PR DESCRIPTION
I've added a way to tracking ETag caching for specific API endpoints.  This allows the app to make light AJAX requests without requiring additional load on the database.  Essentially the app sends a request with an ETag asking if it already has the latest version of the data.  If it does, the API will return a 304 response.

This still requires a heavy first load on the initial load of the application regrettably.  Until we offload cache to another server (i.e. Redis) there isn't much we can do about this.

I can also increase the complexity of the app to only make a request for the cache table and then compare against it's local copy before making even the light requests.  But I'm less incline to do this, as it doesn't really solve the initial load issue.

> Requires `make db-refresh`, `make refresh n=api`, and `make refresh n=editor`

![image](https://user-images.githubusercontent.com/3180256/166408970-27c1392b-f8c0-4d57-93ea-0c50f251de88.png)
