### PR TITLE
Fix upload/download

### DIFF
--- a/app/editor/src/components/upload/Upload.tsx
+++ b/app/editor/src/components/upload/Upload.tsx
@@ -103,7 +103,7 @@ export const Upload: React.FC<IUploadProps> = ({
         hide={toggle}
         type="delete"
         headerText="Confirm Removal"
-        body="Are you sure you want to remove this file?"
+        body="Are you sure you want to remove this file?  You will still need to save before it is deleted."
         confirmText="Yes, Remove It"
         onConfirm={() => {
           if (!!fileRef.current) {

--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -127,7 +127,6 @@ export const ContentForm: React.FC<IContentFormProps> = ({ contentType = Content
       // If the upload fails, we still need to update the form from the original update.
       if (!!contentResult) {
         setContent(toForm(contentResult));
-        toast.error(`${contentResult.headline} file was not uploaded successfully.`);
         if (!originalId) navigate(`/contents/${contentResult.id}`);
       }
     }
@@ -197,9 +196,9 @@ export const ContentForm: React.FC<IContentFormProps> = ({ contentType = Content
                           ''
                         }
                         onChange={(newValue: any) => {
-                          props.setFieldValue('dataSourceId', newValue.value);
-                          props.setFieldValue('source', newValue.label);
                           const dataSource = dataSources.find((ds) => ds.id === newValue.value);
+                          props.setFieldValue('dataSourceId', newValue.value);
+                          props.setFieldValue('source', dataSource?.code ?? '');
                           if (!!dataSource) {
                             props.setFieldValue('mediaTypeId', dataSource.mediaTypeId);
                             props.setFieldValue('licenseId', dataSource.licenseId);

--- a/libs/net/dal/Extensions/FileReferenceExtensions.cs
+++ b/libs/net/dal/Extensions/FileReferenceExtensions.cs
@@ -12,7 +12,7 @@ namespace TNO.DAL.Extensions;
 public static class FileReferenceExtensions
 {
     /// <summary>
-    /// Determine the full path to the file for the specified 'fileReference'.
+    /// Determine the full path to the file.
     /// </summary>
     /// <param name="reference"></param>
     /// <param name="context"></param>
@@ -21,8 +21,22 @@ public static class FileReferenceExtensions
     /// <exception cref="ArgumentException"></exception>
     public static string GetFilePath(this IReadonlyFileReference fileReference, TNOContext context, StorageConfig storageConfig)
     {
+        return Path.Combine(fileReference.GetStoragePath(context, storageConfig), fileReference.Path);
+    }
+
+    /// <summary>
+    /// Determine the full path to the file for the specified 'fileReference'.
+    /// </summary>
+    /// <param name="reference"></param>
+    /// <param name="context"></param>
+    /// <param name="storageConfig"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException"></exception>
+    public static string GetStoragePath(this IReadonlyFileReference fileReference, TNOContext context, StorageConfig storageConfig)
+    {
         // Determine the DataLocation that will be used to store the file.
         var source = fileReference.Content?.DataSource?.Code ?? fileReference.Content?.Source;
+        if (String.IsNullOrWhiteSpace(source) && fileReference.Content?.DataSourceId != null) source = context.DataSources.Find(fileReference.Content?.DataSourceId)?.Code;
 
         DataLocation location;
         if (fileReference.Content?.DataSource?.DataLocationId != null)
@@ -39,7 +53,7 @@ public static class FileReferenceExtensions
         // TODO: Handle when the original file uploaded has different path than the new one.
         var dataConnection = JsonSerializer.Deserialize<Dictionary<string, object>>(location.Connection) ?? new Dictionary<string, object>();
         var connectionPath = dataConnection.ContainsKey("path") ? $"{((string?)dataConnection["path"])?.RemoveStartAndEnd("/")}" : "";
-        var path = Path.Combine(storageConfig.GetPath(), source ?? "", connectionPath);
+        var path = Path.Combine(storageConfig.GetPath(), connectionPath);
         return path.EndsWith('/') ? path : $"{path}/";
     }
 }

--- a/libs/net/dal/Models/ContentFileReference.cs
+++ b/libs/net/dal/Models/ContentFileReference.cs
@@ -109,42 +109,6 @@ public class ContentFileReference : IReadonlyFileReference
     #region Constructors
     /// <summary>
     /// Creates a new instance of a ContentFileReference, initializes with specified parameters.
-    /// Use this to update an existing FileReference.
-    /// Only use this contructor when the 'content' already exists in the database.
-    /// </summary>
-    /// <param name="fileReference"></param>
-    /// <param name="file"></param>
-    /// <exception cref="ArgumentNullException"></exception>
-    public ContentFileReference(FileReference fileReference, IFormFile file)
-    {
-        this.Content = fileReference?.Content ?? throw new ArgumentNullException(nameof(fileReference), "Parameter 'fileReference' and 'fileReference.Content' cannot be null");
-        this.ContentId = fileReference.ContentId;
-        this.ContentVersion = fileReference.Content.Version;
-
-        this.File = file ?? throw new ArgumentNullException(nameof(file));
-        this.Id = fileReference.Id;
-        this.FileName = file.FileName;
-        this.Path = GenerateFileName(this.Content, file);
-        this.ContentType = file.ContentType;
-        this.Size = file.Length;
-        this.RunningTime = fileReference.RunningTime; // TODO: Calculate this somehow.
-        this.CreatedBy = fileReference.CreatedBy;
-        this.CreatedById = fileReference.CreatedById;
-        this.CreatedOn = fileReference.CreatedOn;
-        this.UpdatedBy = fileReference.UpdatedBy;
-        this.UpdatedById = fileReference.UpdatedById;
-        this.UpdatedOn = fileReference.UpdatedOn;
-        this.Version = fileReference.Version;
-
-        fileReference.FileName = this.FileName;
-        fileReference.Path = this.Path;
-        fileReference.Size = this.Size;
-        fileReference.ContentType = this.ContentType;
-        this.FileReference = fileReference;
-    }
-
-    /// <summary>
-    /// Creates a new instance of a ContentFileReference, initializes with specified parameters.
     /// Use this to create a new FileReference.
     /// Only use this contructor when the 'content' already exists in the database.
     /// </summary>
@@ -158,7 +122,7 @@ public class ContentFileReference : IReadonlyFileReference
         this.ContentVersion = content.Version;
 
         this.File = file ?? throw new ArgumentNullException(nameof(file));
-        this.Path = GenerateFileName(content, file);
+        this.Path = GenerateFilePath(content, file);
         this.FileName = file.FileName;
         this.ContentType = file.ContentType;
         this.Size = file.Length;
@@ -177,9 +141,57 @@ public class ContentFileReference : IReadonlyFileReference
             RunningTime = this.RunningTime
         };
     }
+
+    /// <summary>
+    /// Creates a new instance of a ContentFileReference, initializes with specified parameters.
+    /// Use this to update an existing FileReference.
+    /// Only use this contructor when the 'content' already exists in the database.
+    /// </summary>
+    /// <param name="fileReference"></param>
+    /// <param name="file"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public ContentFileReference(FileReference fileReference, IFormFile file)
+    {
+        this.Content = fileReference?.Content ?? throw new ArgumentNullException(nameof(fileReference), "Parameter 'fileReference' and 'fileReference.Content' cannot be null");
+        this.ContentId = fileReference.ContentId;
+        this.ContentVersion = fileReference.Content.Version;
+
+        this.File = file ?? throw new ArgumentNullException(nameof(file));
+        this.Id = fileReference.Id;
+        this.FileName = file.FileName;
+        this.Path = GenerateFilePath(this.Content, file);
+        this.ContentType = file.ContentType;
+        this.Size = file.Length;
+        this.RunningTime = fileReference.RunningTime; // TODO: Calculate this somehow.
+        this.CreatedBy = fileReference.CreatedBy;
+        this.CreatedById = fileReference.CreatedById;
+        this.CreatedOn = fileReference.CreatedOn;
+        this.UpdatedBy = fileReference.UpdatedBy;
+        this.UpdatedById = fileReference.UpdatedById;
+        this.UpdatedOn = fileReference.UpdatedOn;
+        this.Version = fileReference.Version;
+
+        fileReference.FileName = this.FileName;
+        fileReference.Path = this.Path;
+        fileReference.Size = this.Size;
+        fileReference.ContentType = this.ContentType;
+        this.FileReference = fileReference;
+    }
     #endregion
 
     #region Methods
+    /// <summary>
+    /// Generate the file path and name.
+    /// </summary>
+    /// <param name="content"></param>
+    /// <param name="file"></param>
+    /// <returns></returns>
+    public static string GenerateFilePath(Content content, IFormFile file)
+    {
+        var fileName = GenerateFileName(content, file);
+        return System.IO.Path.Combine(content.Source, fileName);
+    }
+
     /// <summary>
     /// Generate a unique name based on the content information.
     /// </summary>
@@ -200,7 +212,15 @@ public class ContentFileReference : IReadonlyFileReference
     /// <param name="obj"></param>
     public static explicit operator FileReference(ContentFileReference obj)
     {
-        return obj.FileReference;
+        var fileReference = obj.FileReference;
+        fileReference.FileName = obj.FileName;
+        fileReference.Path = obj.Path;
+        fileReference.Size = obj.Size;
+        fileReference.RunningTime = obj.RunningTime;
+        fileReference.ContentType = obj.ContentType;
+        fileReference.IsUploaded = obj.IsUploaded;
+        fileReference.Version = obj.Version;
+        return fileReference;
     }
     #endregion
 }

--- a/libs/net/entities/Interfaces/IReadonlyFileReference.cs
+++ b/libs/net/entities/Interfaces/IReadonlyFileReference.cs
@@ -13,6 +13,8 @@ public interface IReadonlyFileReference : IReadonlyAuditColumns
 
     string FileName { get; }
 
+    string Path { get; }
+
     long Size { get; }
 
     long RunningTime { get; }

--- a/libs/npm/core/src/hooks/summon/useSummon.tsx
+++ b/libs/npm/core/src/hooks/summon/useSummon.tsx
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance } from 'axios';
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import { isEmpty } from 'lodash';
 import React from 'react';
 import { toast } from 'react-toastify';
@@ -20,14 +20,10 @@ let axiosInstances = {
 /**
  * useSummon hook properties.
  */
-export interface ISummonProps {
+export interface ISummonProps extends AxiosRequestConfig<any> {
   lifecycleToasts?: ILifecycleToasts;
   selector?: Function;
   envelope?: typeof defaultEnvelope;
-  /**
-   * The base URL all requests will use.
-   */
-  baseURL?: string;
 }
 
 /**
@@ -39,6 +35,7 @@ export const useSummon = ({
   selector,
   envelope = defaultEnvelope,
   baseURL,
+  ...rest
 }: ISummonProps = {}) => {
   const state = React.useContext(SummonContext);
   let loadingToastId: React.ReactText | undefined = undefined;
@@ -49,8 +46,10 @@ export const useSummon = ({
 
   if (instance.current === undefined) {
     const summon = axios.create({
+      ...rest,
       baseURL,
       headers: {
+        ...rest.headers,
         'Access-Control-Allow-Origin': '*',
       },
     });


### PR DESCRIPTION
The upload/download was broken when the data source dropdown list was changed.  I've modified the design so that this won't happen, and also solved other issues I was aware of.

- Uploaded file path is now stored so that it doesn't change after first created
- Changing the data source after won't break the file

> Note that existing files already uploaded will probably not work.  I don't want to spend time moving them around at this point.