### PR TITLE
TNO-336 Update services

### DIFF
--- a/app/editor/src/features/admin/sources/DataSource.tsx
+++ b/app/editor/src/features/admin/sources/DataSource.tsx
@@ -88,7 +88,7 @@ export const DataSource: React.FC<IDataSourceProps> = (props) => {
               <>
                 <Tab navigateTo="details" label="Details" exact activePaths={[`${id}`]} />
                 <Tab navigateTo="metrics" label="Reach/Earned Media" />
-                <Tab navigateTo="schedule" label="Service Schedule" />
+                <Tab navigateTo="schedule" label="Service Settings" />
                 <Tab navigateTo="ingesting" label="Ingesting" />
               </>
             }

--- a/app/editor/src/features/admin/sources/DataSourceDetails.tsx
+++ b/app/editor/src/features/admin/sources/DataSourceDetails.tsx
@@ -10,7 +10,6 @@ import { Col, Row } from 'tno-core/dist/components/flex';
 import { getDataSourceOptions, getSortableOptions } from 'utils';
 
 import { DataSourceActions, DataSourceStatus } from '.';
-import { Connection } from './media-types';
 import * as styled from './styled';
 
 interface IDataSourceDetailsProps {}
@@ -88,9 +87,6 @@ export const DataSourceDetails: React.FC<IDataSourceDetailsProps> = () => {
           <Col>
             <FormikCheckbox label="Enabled" name="isEnabled" />
             <DataSourceActions />
-          </Col>
-          <Col>
-            <Connection />
           </Col>
         </Row>
         <DataSourceStatus />

--- a/app/editor/src/features/admin/sources/schedules/Schedule.tsx
+++ b/app/editor/src/features/admin/sources/schedules/Schedule.tsx
@@ -5,6 +5,7 @@ import { DataSourceScheduleTypeName, IDataSourceModel } from 'hooks/api-editor';
 import React from 'react';
 import { Col, Row } from 'tno-core';
 
+import { Connection } from '../media-types';
 import { ScheduleAdvanced, ScheduleContinuous, ScheduleDaily } from '.';
 import { scheduleTypeOptions } from './constants';
 import * as styled from './styled';
@@ -69,6 +70,9 @@ export const Schedule: React.FC<IScheduleProps> = () => {
           <p>
             The topic should be unique, or all content stored within it should be the same format.
           </p>
+        </Col>
+        <Col>
+          <Connection />
         </Col>
       </Row>
       <hr />

--- a/libs/net/services/Controllers/StatusController.cs
+++ b/libs/net/services/Controllers/StatusController.cs
@@ -60,19 +60,5 @@ public class StatusController : ControllerBase
         _service.State.Resume();
         return new JsonResult(_service.State);
     }
-
-    /// <summary>
-    /// Request service to stop.
-    /// </summary>
-    /// <returns></returns>
-    [HttpPut("stop")]
-    [Produces("application/json")]
-    [ProducesResponseType(typeof(ServiceStateModel), (int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    public IActionResult StopService()
-    {
-        _service.State.Stop();
-        return new JsonResult(_service.State);
-    }
     #endregion
 }

--- a/libs/net/services/ServiceManager`.cs
+++ b/libs/net/services/ServiceManager`.cs
@@ -74,7 +74,8 @@ public abstract class ServiceManager<TDataSourceManager, TOption> : IServiceMana
         // Run at the shortest interval of all schedules.
         var delay = dataSources.Min(ds => ds.DataSourceSchedules.Where(s => s.Schedule?.DelayMS != 0).Min(s => s.Schedule?.DelayMS)) ?? _options.DefaultDelayMS;
 
-        while (this.State.Status != ServiceStatus.Stopped)
+        // Always keep looping until an unexpected failure occurs.
+        while (true)
         {
             if (this.State.Status != ServiceStatus.Running)
             {
@@ -137,8 +138,6 @@ public abstract class ServiceManager<TDataSourceManager, TOption> : IServiceMana
             // Fetch all data sources again to determine if there are any changes to the list.
             dataSources = await GetDataSourcesAsync();
         }
-
-        _logger.LogInformation("Service stopping");
     }
 
     /// <summary>

--- a/libs/net/services/ServiceState.cs
+++ b/libs/net/services/ServiceState.cs
@@ -62,14 +62,6 @@ public class ServiceState
     }
 
     /// <summary>
-    /// Change the status to stopped.
-    /// </summary>
-    public void Stop()
-    {
-        this.Status = ServiceStatus.Stopped;
-    }
-
-    /// <summary>
     /// Change the status to sleeping.
     /// </summary>
     public void Sleep()

--- a/libs/net/services/ServiceStatus.cs
+++ b/libs/net/services/ServiceStatus.cs
@@ -6,21 +6,17 @@ namespace TNO.Services;
 public enum ServiceStatus
 {
     /// <summary>
-    /// The service is stopped.
-    /// </summary>
-    Stopped = 0,
-    /// <summary>
     /// The service is running.
     /// </summary>
-    Running = 1,
+    Running = 0,
     /// <summary>
     /// The service is paused.
     /// A pause will only occur if a user has requested it.
     /// </summary>
-    Paused = 2,
+    Paused = 1,
     /// <summary>
     /// The service is sleeping.
     /// Sleeping can occur if failures have reached their maximum.
     /// </summary>
-    Sleeping = 3,
+    Sleeping = 2,
 }

--- a/openshift/kustomize/kafka/broker/base/statefulset.yaml
+++ b/openshift/kustomize/kafka/broker/base/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 2Gi
+            storage: 5Gi
   template:
     metadata:
       labels:

--- a/openshift/kustomize/kafka/broker/overlays/dev/kustomization.yaml
+++ b/openshift/kustomize/kafka/broker/overlays/dev/kustomization.yaml
@@ -31,4 +31,4 @@ patches:
         value: 1Gi
       - op: replace
         path: /spec/volumeClaimTemplates/0/spec/resources/requests/storage
-        value: 2Gi
+        value: 5Gi

--- a/openshift/kustomize/kafka/broker/overlays/prod/kustomization.yaml
+++ b/openshift/kustomize/kafka/broker/overlays/prod/kustomization.yaml
@@ -31,4 +31,4 @@ patches:
         value: 1Gi
       - op: replace
         path: /spec/volumeClaimTemplates/0/spec/resources/requests/storage
-        value: 2Gi
+        value: 5Gi

--- a/openshift/kustomize/kafka/broker/overlays/test/kustomization.yaml
+++ b/openshift/kustomize/kafka/broker/overlays/test/kustomization.yaml
@@ -31,4 +31,4 @@ patches:
         value: 1Gi
       - op: replace
         path: /spec/volumeClaimTemplates/0/spec/resources/requests/storage
-        value: 2Gi
+        value: 5Gi

--- a/openshift/kustomize/services/syndication/base/config-map.yaml
+++ b/openshift/kustomize/services/syndication/base/config-map.yaml
@@ -16,7 +16,5 @@ metadata:
     created-by: jeremy.foster
 type: Opaque
 data:
-  Kafka__ClientId: Syndication
-  IngestService__MaxFailLimit: "5"
-  IngestService__MediaTypes:
-    - Syndication
+  KAKFA_CLIENT_ID: Syndication
+  MAX_FAIL_LIMIT: "5"

--- a/openshift/kustomize/services/syndication/base/deploy.yaml
+++ b/openshift/kustomize/services/syndication/base/deploy.yaml
@@ -46,10 +46,10 @@ spec:
           resources:
             requests:
               cpu: 20m
-              memory: 250Mi
+              memory: 100Mi
             limits:
-              cpu: 100m
-              memory: 500Mi
+              cpu: 50m
+              memory: 150Mi
           env:
             # .NET Configuration
             - name: ASPNETCORE_ENVIRONMENT
@@ -90,14 +90,26 @@ spec:
                 configMapKeyRef:
                   name: services
                   key: KAFKA_BOOTSTRAP_SERVERS
+
+            # Syndication Service Configuration
+            - name: KAKFA_CLIENT_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: syndication-service
+                  key: KAKFA_CLIENT_ID
+            - name: IngestService__MaxFailLimit
+              valueFrom:
+                configMapKeyRef:
+                  name: syndication-service
+                  key: MAX_FAIL_LIMIT
           livenessProbe:
             httpGet:
               path: "/health"
               port: 8080
               scheme: HTTP
-            initialDelaySeconds: 120
-            timeoutSeconds: 60
-            periodSeconds: 30
+            initialDelaySeconds: 60
+            timeoutSeconds: 30
+            periodSeconds: 20
             successThreshold: 1
             failureThreshold: 3
           readinessProbe:
@@ -105,9 +117,9 @@ spec:
               path: "/health"
               port: 8080
               scheme: HTTP
-            initialDelaySeconds: 120
-            timeoutSeconds: 60
-            periodSeconds: 30
+            initialDelaySeconds: 60
+            timeoutSeconds: 30
+            periodSeconds: 20
             successThreshold: 1
             failureThreshold: 3
       dnsPolicy: ClusterFirst

--- a/openshift/kustomize/services/syndication/overlays/dev/kustomization.yaml
+++ b/openshift/kustomize/services/syndication/overlays/dev/kustomization.yaml
@@ -27,13 +27,13 @@ patches:
         value: 20m
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/memory
-        value: 250Mi
+        value: 100Mi
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/cpu
-        value: 100m
+        value: 50m
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 500Mi
+        value: 50m
       - op: replace
         path: /spec/triggers/1/imageChangeParams/from/name
         value: syndication-service:dev

--- a/openshift/kustomize/services/syndication/overlays/prod/kustomization.yaml
+++ b/openshift/kustomize/services/syndication/overlays/prod/kustomization.yaml
@@ -27,13 +27,13 @@ patches:
         value: 20m
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/memory
-        value: 250Mi
+        value: 100Mi
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/cpu
-        value: 100m
+        value: 50m
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 500Mi
+        value: 50m
       - op: replace
         path: /spec/triggers/1/imageChangeParams/from/name
         value: syndication-service:prod

--- a/openshift/kustomize/services/syndication/overlays/test/kustomization.yaml
+++ b/openshift/kustomize/services/syndication/overlays/test/kustomization.yaml
@@ -27,13 +27,13 @@ patches:
         value: 20m
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/memory
-        value: 250Mi
+        value: 100Mi
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/cpu
-        value: 100m
+        value: 50m
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 500Mi
+        value: 50m
       - op: replace
         path: /spec/triggers/1/imageChangeParams/from/name
         value: syndication-service:test

--- a/services/java/capture/pom.xml
+++ b/services/java/capture/pom.xml
@@ -132,16 +132,6 @@
       <artifactId>kafka-clients</artifactId>
       <version>${kafka.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-log4j-appender</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -200,11 +190,6 @@
       <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
-        <version>${kafka.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.kafka</groupId>
-        <artifactId>kafka-log4j-appender</artifactId>
         <version>${kafka.version}</version>
       </dependency>
 

--- a/services/java/capture/src/main/resources/log4j2.yml
+++ b/services/java/capture/src/main/resources/log4j2.yml
@@ -3,10 +3,6 @@ Configuration:
     property:
       - name: filename
         value: logs/app.log
-      - name: bootstrapServers
-        value: ${env:KAFKA_BOOTSTRAP_SERVERS}
-      - name: topic
-        value: ${env:KAFKA_LOGS_TOPIC}
 
   status: warn
 
@@ -34,16 +30,6 @@ Configuration:
     #     DefaultRollOverStrategy:
     #       max: 10
 
-    Kafka:
-      name: LogToKafka
-      topic: ${topic}
-      key: ${sys:pid}
-      Property:
-        - name: bootstrap.servers
-          value: ${bootstrapServers}
-      PatternLayout:
-        pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%-7t] %c{1}:%L - %m%n"
-
   Loggers:
     logger:
       - name: ca.bc.gov.tno
@@ -52,7 +38,6 @@ Configuration:
         AppenderRef:
           - ref: LogToConsole
           # - ref: LogToRollingFile
-          - ref: LogToKafka
 
     Root:
       level: error

--- a/services/java/clip/pom.xml
+++ b/services/java/clip/pom.xml
@@ -132,16 +132,6 @@
       <artifactId>kafka-clients</artifactId>
       <version>${kafka.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-log4j-appender</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -200,11 +190,6 @@
       <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
-        <version>${kafka.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.kafka</groupId>
-        <artifactId>kafka-log4j-appender</artifactId>
         <version>${kafka.version}</version>
       </dependency>
 

--- a/services/java/clip/src/main/resources/log4j2.yml
+++ b/services/java/clip/src/main/resources/log4j2.yml
@@ -3,10 +3,6 @@ Configuration:
     property:
       - name: filename
         value: logs/app.log
-      - name: bootstrapServers
-        value: ${env:KAFKA_BOOTSTRAP_SERVERS}
-      - name: topic
-        value: ${env:KAFKA_LOGS_TOPIC}
 
   status: warn
 
@@ -34,16 +30,6 @@ Configuration:
     #     DefaultRollOverStrategy:
     #       max: 10
 
-    Kafka:
-      name: LogToKafka
-      topic: ${topic}
-      key: ${sys:pid}
-      Property:
-        - name: bootstrap.servers
-          value: ${bootstrapServers}
-      PatternLayout:
-        pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%-7t] %c{1}:%L - %m%n"
-
   Loggers:
     logger:
       - name: ca.bc.gov.tno
@@ -52,7 +38,6 @@ Configuration:
         AppenderRef:
           # - ref: LogToRollingFile
           - ref: LogToConsole
-          - ref: LogToKafka
 
     Root:
       level: error

--- a/services/java/indexing/pom.xml
+++ b/services/java/indexing/pom.xml
@@ -119,16 +119,6 @@
       <artifactId>kafka-clients</artifactId>
       <version>3.0.0</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-log4j-appender</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/services/java/indexing/src/main/resources/log4j2.yml
+++ b/services/java/indexing/src/main/resources/log4j2.yml
@@ -3,10 +3,6 @@ Configuration:
     property:
       - name: filename
         value: logs/app.log
-      - name: bootstrapServers
-        value: ${env:KAFKA_BOOTSTRAP_SERVERS}
-      - name: topic
-        value: ${env:KAFKA_LOGS_TOPIC}
 
   status: warn
 
@@ -15,34 +11,24 @@ Configuration:
       name: LogToConsole
       PatternLayout:
         Pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%-7t] %c{1}:%L - %m%n"
-        
+
     #File:
     #  name: File
     #  fileName: logs/app.log
     #  PatternLayout:
     #    Pattern: "%d %p %C{1.} [%t] %m%n"
 
-    RollingFile:
-      - name: LogToRollingFile
-        fileName: ${filename}
-        filePattern: "logs/$${date:yyyy-MM}/app-%d{MM-dd-yyyy}-%i.log.gz"
-        PatternLayout:
-          pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%-7t] %c{1}:%L - %m%n"
-        Policies:
-          SizeBasedTriggeringPolicy:
-            size: 10MB
-        DefaultRollOverStrategy:
-          max: 10
-
-    Kafka:
-      name: LogToKafka
-      topic: ${topic}
-      key: ${sys:pid}
-      Property:
-        - name: bootstrap.servers
-          value: ${bootstrapServers}
-      PatternLayout:
-        pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%-7t] %c{1}:%L - %m%n"
+    # RollingFile:
+    #   - name: LogToRollingFile
+    #     fileName: ${filename}
+    #     filePattern: "logs/$${date:yyyy-MM}/app-%d{MM-dd-yyyy}-%i.log.gz"
+    #     PatternLayout:
+    #       pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%-7t] %c{1}:%L - %m%n"
+    #     Policies:
+    #       SizeBasedTriggeringPolicy:
+    #         size: 10MB
+    #     DefaultRollOverStrategy:
+    #       max: 10
 
   Loggers:
     logger:
@@ -51,8 +37,7 @@ Configuration:
         additivity: false
         AppenderRef:
           - ref: LogToConsole
-          - ref: LogToRollingFile
-          - ref: LogToKafka
+          # - ref: LogToRollingFile
 
     Root:
       level: error

--- a/services/java/nlp/pom.xml
+++ b/services/java/nlp/pom.xml
@@ -126,16 +126,6 @@
       <artifactId>kafka-clients</artifactId>
       <version>3.0.0</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-log4j-appender</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/services/java/nlp/src/main/resources/log4j2.yml
+++ b/services/java/nlp/src/main/resources/log4j2.yml
@@ -3,10 +3,6 @@ Configuration:
     property:
       - name: filename
         value: logs/app.log
-      - name: bootstrapServers
-        value: ${env:KAFKA_BOOTSTRAP_SERVERS}
-      - name: topic
-        value: ${env:KAFKA_LOGS_TOPIC}
 
   status: warn
 
@@ -15,34 +11,24 @@ Configuration:
       name: LogToConsole
       PatternLayout:
         Pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%-7t] %c{1}:%L - %m%n"
-        
+
     #File:
     #  name: File
     #  fileName: logs/app.log
     #  PatternLayout:
     #    Pattern: "%d %p %C{1.} [%t] %m%n"
 
-    RollingFile:
-      - name: LogToRollingFile
-        fileName: ${filename}
-        filePattern: "logs/$${date:yyyy-MM}/app-%d{MM-dd-yyyy}-%i.log.gz"
-        PatternLayout:
-          pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%-7t] %c{1}:%L - %m%n"
-        Policies:
-          SizeBasedTriggeringPolicy:
-            size: 10MB
-        DefaultRollOverStrategy:
-          max: 10
-
-    Kafka:
-      name: LogToKafka
-      topic: ${topic}
-      key: ${sys:pid}
-      Property:
-        - name: bootstrap.servers
-          value: ${bootstrapServers}
-      PatternLayout:
-        pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%-7t] %c{1}:%L - %m%n"
+    # RollingFile:
+    #   - name: LogToRollingFile
+    #     fileName: ${filename}
+    #     filePattern: "logs/$${date:yyyy-MM}/app-%d{MM-dd-yyyy}-%i.log.gz"
+    #     PatternLayout:
+    #       pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%-7t] %c{1}:%L - %m%n"
+    #     Policies:
+    #       SizeBasedTriggeringPolicy:
+    #         size: 10MB
+    #     DefaultRollOverStrategy:
+    #       max: 10
 
   Loggers:
     logger:
@@ -51,8 +37,7 @@ Configuration:
         additivity: false
         AppenderRef:
           - ref: LogToConsole
-          - ref: LogToRollingFile
-          - ref: LogToKafka
+          # - ref: LogToRollingFile
 
     Root:
       level: error

--- a/services/java/syndication/pom.xml
+++ b/services/java/syndication/pom.xml
@@ -127,16 +127,6 @@
       <artifactId>kafka-clients</artifactId>
       <version>${kafka.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-log4j-appender</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -195,11 +185,6 @@
       <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
-        <version>${kafka.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.kafka</groupId>
-        <artifactId>kafka-log4j-appender</artifactId>
         <version>${kafka.version}</version>
       </dependency>
 

--- a/services/java/syndication/src/main/resources/log4j2.yml
+++ b/services/java/syndication/src/main/resources/log4j2.yml
@@ -3,10 +3,6 @@ Configuration:
     property:
       - name: filename
         value: logs/app.log
-      - name: bootstrapServers
-        value: ${env:KAFKA_BOOTSTRAP_SERVERS}
-      - name: topic
-        value: ${env:KAFKA_LOGS_TOPIC}
 
   status: debug
 
@@ -34,16 +30,6 @@ Configuration:
     #     DefaultRollOverStrategy:
     #       max: 10
 
-    Kafka:
-      name: LogToKafka
-      topic: ${topic}
-      key: ${sys:pid}
-      Property:
-        - name: bootstrap.servers
-          value: ${bootstrapServers}
-      PatternLayout:
-        pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%-7t] %c{1}:%L - %m%n"
-
   Loggers:
     logger:
       - name: ca.bc.gov.tno
@@ -52,7 +38,6 @@ Configuration:
         AppenderRef:
           - ref: LogToConsole
           # - ref: LogToRollingFile
-          - ref: LogToKafka
 
     Root:
       level: error

--- a/services/net/syndication/appsettings.Staging.json
+++ b/services/net/syndication/appsettings.Staging.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Debug",
+      "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
   },

--- a/services/net/syndication/appsettings.json
+++ b/services/net/syndication/appsettings.json
@@ -2,7 +2,7 @@
   "BaseUrl": "/",
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Warning",
       "Microsoft.AspNetCore": "Warning"
     }
   },


### PR DESCRIPTION
Remove kafka logger from Java services.  It was causing the PVC storage to fill up very quickly.

Moved 'Connection Settings' to the 'Service Settings' tab in Data Source management.