### PR TITLE
Fix content search

### DIFF
--- a/libs/net/dal/Services/ContentService.cs
+++ b/libs/net/dal/Services/ContentService.cs
@@ -63,7 +63,7 @@ public class ContentService : BaseService<Content, long>, IContentService
         {
             var user = this.Context.Users.Find(filter.UserId);
             if (user != null)
-                query = query.Where(c => c.CreatedById == user.Key || c.UpdatedById == user.Key || c.Logs.Any(l => l.CreatedById == user.Key));
+                query = query.Where(c => c.OwnerId == user.Id || c.CreatedById == user.Key || c.UpdatedById == user.Key || c.Logs.Any(l => l.CreatedById == user.Key));
         }
 
         if (filter.CreatedOn.HasValue)


### PR DESCRIPTION
When searching for content it will now include the `Content.OwnerId` when determining if if should show up for the selected user.

![image](https://user-images.githubusercontent.com/3180256/169291795-91485220-a918-4c08-ae46-5d621d044092.png)
