### PR TITLE
Content service duplicates

### DIFF
--- a/api/net/Areas/Services/Controllers/ContentController.cs
+++ b/api/net/Areas/Services/Controllers/ContentController.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Services.Models.Content;
@@ -8,7 +7,6 @@ using TNO.API.Models;
 using TNO.DAL.Models;
 using TNO.DAL.Services;
 using TNO.Entities;
-using TNO.Entities.Models;
 
 namespace TNO.API.Areas.Services.Controllers;
 
@@ -46,6 +44,24 @@ public class ContentController : ControllerBase
     #endregion
 
     #region Endpoints
+    /// <summary>
+    /// Find content for the specified 'uid' and 'source'.
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <param name="source"></param>
+    /// <returns></returns>
+    [HttpGet("find")]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(ContentModel), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NoContent)]
+    [SwaggerOperation(Tags = new[] { "Content" })]
+    public IActionResult FindByUid([FromQuery] string uid, [FromQuery] string? source)
+    {
+        var result = _contentService.FindByUid(uid, source);
+        if (result == null) return new NoContentResult();
+        return new JsonResult(new ContentModel(result));
+    }
+
     /// <summary>
     /// Find content for the specified 'id'.
     /// </summary>

--- a/libs/net/core/Http/HttpRequestClient.cs
+++ b/libs/net/core/Http/HttpRequestClient.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Net;
 
 namespace TNO.Core.Http
 {
@@ -439,6 +440,9 @@ namespace TNO.Core.Http
 
             if (response.IsSuccessStatusCode)
             {
+                if (response.StatusCode == HttpStatusCode.NoContent)
+                    return default;
+
                 return await DeserializeAsync<TModel>(response);
             }
 
@@ -446,7 +450,7 @@ namespace TNO.Core.Http
             if ((onError?.Invoke(response) ?? false) == false)
             {
                 var error = new HttpClientRequestException(response);
-                _logger.LogError(error, error.Message);
+                _logger.LogError(error, "Request failed: {Message}", error.Message);
                 throw error;
             }
 

--- a/libs/net/dal/Services/ContentService.cs
+++ b/libs/net/dal/Services/ContentService.cs
@@ -138,6 +138,31 @@ public class ContentService : BaseService<Content, long>, IContentService
             .FirstOrDefault(c => c.Id == id);
     }
 
+    public Content? FindByUid(string uid, string? source)
+    {
+        var query = this.Context.Contents
+            .Include(c => c.ContentType)
+            .Include(c => c.MediaType)
+            .Include(c => c.Series)
+            .Include(c => c.License)
+            .Include(c => c.DataSource)
+            .Include(c => c.Owner)
+            .Include(c => c.PrintContent)
+            .Include(c => c.ActionsManyToMany).ThenInclude(ca => ca.Action)
+            .Include(c => c.CategoriesManyToMany).ThenInclude(cc => cc.Category)
+            .Include(c => c.TonePoolsManyToMany).ThenInclude(ct => ct.TonePool)
+            .Include(c => c.TagsManyToMany).ThenInclude(ct => ct.Tag)
+            .Include(c => c.TimeTrackings)
+            .Include(c => c.FileReferences)
+            .Include(c => c.Links)
+            .Where(c => c.Uid == uid);
+
+        if (!String.IsNullOrWhiteSpace(source))
+            query = query.Where(c => c.Source == source);
+
+        return query.FirstOrDefault();
+    }
+
     public override Content Add(Content entity)
     {
         entity.AddToContext(this.Context);

--- a/libs/net/dal/Services/Interfaces/IContentService.cs
+++ b/libs/net/dal/Services/Interfaces/IContentService.cs
@@ -8,4 +8,5 @@ namespace TNO.DAL.Services;
 public interface IContentService : IBaseService<Content, long>
 {
     IPaged<Content> Find(ContentFilter filter);
+    Content? FindByUid(string uid, string? source);
 }

--- a/libs/net/services/Helpers/ApiService.cs
+++ b/libs/net/services/Helpers/ApiService.cs
@@ -127,6 +127,18 @@ public class ApiService : IApiService
 
     #region Content Methods
     /// <summary>
+    /// Make an AJAX request to the api to find the specified content.
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <param name="source"></param>
+    /// <returns></returns>
+    public async Task<ContentModel?> FindContentByUidAsync(string uid, string? source)
+    {
+        var url = new Uri(_options.ApiUrl, $"services/contents/find?uid={uid}&source={source}");
+        return await _client.GetAsync<ContentModel?>(url);
+    }
+
+    /// <summary>
     /// Make an AJAX request to the api to add the specified content.
     /// </summary>
     /// <param name="content"></param>

--- a/libs/net/services/Interfaces/IApiService.cs
+++ b/libs/net/services/Interfaces/IApiService.cs
@@ -66,4 +66,12 @@ public interface IApiService
     /// </summary>
     /// <returns></returns>
     public Task<LookupModel?> GetLookupsAsync();
+
+    /// <summary>
+    /// Make an AJAX request to the api to find the specified content.
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <param name="source"></param>
+    /// <returns></returns>
+    Task<ContentModel?> FindContentByUidAsync(string uid, string? source);
 }

--- a/libs/net/services/Runners/BaseService.cs
+++ b/libs/net/services/Runners/BaseService.cs
@@ -1,4 +1,5 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Builder;
@@ -49,6 +50,7 @@ public abstract class BaseService
         this.Configuration = Configure(builder).Build();
         ConfigureServices(builder.Services);
         this.App = builder.Build();
+        Console.OutputEncoding = Encoding.UTF8;
         _logger = this.App.Services.GetRequiredService<ILogger<BaseService>>();
     }
     #endregion

--- a/openshift/kustomize/services/content/base/deploy.yaml
+++ b/openshift/kustomize/services/content/base/deploy.yaml
@@ -49,7 +49,7 @@ spec:
               memory: 100Mi
             limits:
               cpu: 50m
-              memory: 150Mi
+              memory: 250Mi
           env:
             # .NET Configuration
             - name: ASPNETCORE_ENVIRONMENT

--- a/openshift/kustomize/services/content/overlays/dev/kustomization.yaml
+++ b/openshift/kustomize/services/content/overlays/dev/kustomization.yaml
@@ -33,7 +33,7 @@ patches:
         value: 50m
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 150Mi
+        value: 250Mi
       - op: replace
         path: /spec/triggers/1/imageChangeParams/from/name
         value: content-service:dev

--- a/openshift/kustomize/services/content/overlays/prod/kustomization.yaml
+++ b/openshift/kustomize/services/content/overlays/prod/kustomization.yaml
@@ -33,7 +33,7 @@ patches:
         value: 50m
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 150Mi
+        value: 250Mi
       - op: replace
         path: /spec/triggers/1/imageChangeParams/from/name
         value: content-service:prod

--- a/openshift/kustomize/services/content/overlays/test/kustomization.yaml
+++ b/openshift/kustomize/services/content/overlays/test/kustomization.yaml
@@ -33,7 +33,7 @@ patches:
         value: 50m
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 150Mi
+        value: 250Mi
       - op: replace
         path: /spec/triggers/1/imageChangeParams/from/name
         value: content-service:test

--- a/services/net/content/ContentManager.cs
+++ b/services/net/content/ContentManager.cs
@@ -112,7 +112,11 @@ public class ContentManager : ServiceManager<ContentOptions>
             TonePools = Array.Empty<ContentTonePoolModel>(),
             FileReferences = Array.Empty<FileReferenceModel>()
         };
-        await _api.AddContentAsync(content);
+
+        // Only add if doesn't already exist.
+        var exists = await _api.FindContentByUidAsync(content.Uid, content.Source);
+        if (exists == null)
+            await _api.AddContentAsync(content);
     }
     #endregion
 }

--- a/services/net/content/ContentService.cs
+++ b/services/net/content/ContentService.cs
@@ -37,7 +37,6 @@ public class ContentService : KafkaConsumerService
         base.ConfigureServices(services);
         services
             .Configure<ContentOptions>(this.Configuration.GetSection("Service"))
-            // .AddTransient<IServiceAction<ContentOptions>, ContentAction>()
             .AddSingleton<IServiceManager, ContentManager>();
 
         // TODO: Figure out how to validate without resulting in aggregating the config values.


### PR DESCRIPTION
The Content Service was built fast to pull content to Editors.  It was creating a lot of duplicates.  This update should reduce the duplication as it asks the API if the content identified by the `source` and `uid` already exists.

I've also increased the memory limit for the Content Service because 150Mi wasn't enough.