### PR TITLE
TNO-331, 334, 328

### DIFF
--- a/app/editor/src/components/form/area/styled/Area.tsx
+++ b/app/editor/src/components/form/area/styled/Area.tsx
@@ -18,33 +18,15 @@ export const Area = styled.div`
     font-weight: 700;
   }
 
-  .lrg {
-    width: 680px;
-  }
-
-  .md {
-    width: 320px;
-  }
-
-  .md-lrg {
-    width: 400px;
-    margin-right: 40px;
-  }
-
-  .sm {
-    width: 140px;
-  }
-
-  .md-sm {
-    width: 200px;
-  }
-
   .space-right {
     margin-right: 35px;
   }
 
+  .commentary {
+    margin-top: 2%;
+  }
+
   .chk {
-    padding-bottom: 5%;
     margin-right: 2%;
     .label {
       width: 110px;

--- a/app/editor/src/components/form/checkbox/styled/Checkbox.tsx
+++ b/app/editor/src/components/form/checkbox/styled/Checkbox.tsx
@@ -19,6 +19,8 @@ export const Checkbox = styled.div<ICheckboxProps>`
     }};
   }
 
+  margin-bottom: 1%;
+
   p[role='alert'] {
     font-size: 0.85em;
     color: ${(props) => props.theme.css.dangerColor};

--- a/app/editor/src/components/form/timeinput/TimeInput.tsx
+++ b/app/editor/src/components/form/timeinput/TimeInput.tsx
@@ -1,9 +1,14 @@
 import { InputHTMLAttributes } from 'react';
+import MaskedInput from 'react-text-mask';
+import { Show } from 'tno-core';
 
 import * as styled from './styled';
+export interface ITimeInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+}
 
 /** Component that will enforce the HH:MM:SS time format */
-export const TimeInput: React.FC<InputHTMLAttributes<HTMLInputElement>> = (props) => {
+export const TimeInput: React.FC<ITimeInputProps> = ({ label, ...rest }) => {
   const formatTime = (value: string) => {
     const chars = value.split('');
     const hours = [/[0-2]/, chars[0] === '2' ? /[0-3]/ : /[0-9]/] as any;
@@ -13,5 +18,12 @@ export const TimeInput: React.FC<InputHTMLAttributes<HTMLInputElement>> = (props
 
     return hours.concat(':').concat(minutes).concat(':').concat(seconds) as any;
   };
-  return <styled.TimeInput {...props} mask={formatTime} />;
+  return (
+    <styled.TimeInput>
+      <Show visible={!!label}>
+        <label>{label}</label>
+      </Show>
+      <MaskedInput className="masked-input" {...rest} mask={formatTime} />
+    </styled.TimeInput>
+  );
 };

--- a/app/editor/src/components/form/timeinput/styled/TimeInput.tsx
+++ b/app/editor/src/components/form/timeinput/styled/TimeInput.tsx
@@ -1,18 +1,22 @@
-import { InputHTMLAttributes } from 'react';
-import MaskedInput from 'react-text-mask';
 import styled from 'styled-components';
+import { Col } from 'tno-core';
 
-export const TimeInput = styled(MaskedInput)<InputHTMLAttributes<HTMLInputElement>>`
-  :required {
-    border-color: ${(props) => props.theme.css.inputRequiredBorderColor};
+export const TimeInput = styled(Col)`
+  label {
+    font-weight: 700;
   }
+  .masked-input {
+    :required {
+      border-color: ${(props) => props.theme.css.inputRequiredBorderColor};
+    }
 
-  :focus {
-    outline: 0;
-    box-shadow: 0 0 0 0.2rem #2684ff;
+    :focus {
+      outline: 0;
+      box-shadow: 0 0 0 0.2rem #2684ff;
+    }
+
+    border-radius: 0.25rem;
+    height: 2.125rem;
+    margin-right: 5%;
   }
-
-  border-radius: 0.25rem;
-  height: 2.5rem;
-  width: ${(props) => props.width};
 `;

--- a/app/editor/src/components/formik/textarea/styled/FormikTextArea.ts
+++ b/app/editor/src/components/formik/textarea/styled/FormikTextArea.ts
@@ -1,3 +1,5 @@
 import styled from 'styled-components';
 
-export const FormikTextArea = styled.div``;
+export const FormikTextArea = styled.div`
+  width: 100%;
+`;

--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -278,9 +278,32 @@ export const ContentForm: React.FC<IContentFormProps> = ({ contentType = Content
                           );
                         }}
                       />
-                      <ContentActions init filter={(a) => a.valueType === ValueType.Boolean} />
+                      {/* section one of actions */}
+                      <Col alignSelf="stretch">
+                        <ContentActions
+                          init
+                          filter={(a) =>
+                            a.valueType === ValueType.Boolean &&
+                            a.name !== 'Top Story' &&
+                            a.name !== 'On Ticker' &&
+                            a.name !== 'Non Qualified Subject'
+                          }
+                        />
+                      </Col>
+                      {/* section two of actions */}
+                      <Col alignSelf="stretch">
+                        <ContentActions
+                          init
+                          filter={(a) =>
+                            a.valueType === ValueType.Boolean &&
+                            a.name !== 'Alert' &&
+                            a.name !== 'Front Page' &&
+                            a.name !== 'Just In'
+                          }
+                        />
+                      </Col>
                     </Col>
-                    <Row>
+                    <Row className="commentary">
                       <ContentActions filter={(a) => a.valueType !== ValueType.Boolean} />
                     </Row>
                   </Col>

--- a/app/editor/src/features/content/form/ContentSummaryForm.tsx
+++ b/app/editor/src/features/content/form/ContentSummaryForm.tsx
@@ -1,4 +1,4 @@
-import { FieldSize, IOptionItem, OptionItem, RadioGroup } from 'components/form';
+import { FieldSize, IOptionItem, OptionItem, RadioGroup, TimeInput } from 'components/form';
 import { FormikRadioGroup, FormikSelect, FormikText, FormikTextArea } from 'components/formik';
 import { FormikDatePicker } from 'components/formik/datepicker';
 import { Modal } from 'components/modal/Modal';
@@ -46,6 +46,7 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
   const [seriesOptions, setSeriesOptions] = React.useState<IOptionItem[]>([]);
   const [licenseOptions, setLicenseOptions] = React.useState<IOptionItem[]>([]);
   const [effort, setEffort] = React.useState(0);
+  const [publishedOnTime, setPublishedOnTime] = React.useState<string>();
 
   const userId = users.find((u: IUserModel) => u.username === keycloak.getUsername())?.id;
   const file = values.fileReferences.length
@@ -55,6 +56,16 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
   React.useEffect(() => {
     setEffort(getTotalTime(values.timeTrackings));
   }, [values.timeTrackings]);
+
+  React.useEffect(() => {
+    const date = new Date(values.publishedOn);
+    const hours = publishedOnTime?.split(':');
+    if (!!hours && !publishedOnTime?.includes('_') && publishedOnTime !== '') {
+      date.setHours(Number(hours[0]), Number(hours[1]), Number(hours[2]));
+      setPublishedOnTime('');
+      setFieldValue('publishedOn', date);
+    }
+  }, [publishedOnTime, setFieldValue, values.publishedOn]);
 
   React.useEffect(() => {
     setCategoryOptions(getSortableOptions(categories));
@@ -144,8 +155,6 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
               label="Published On"
               required
               autoComplete="false"
-              showTimeSelect
-              dateFormat="MMMM D, yyyy hh:mm a"
               width={FieldSize.Medium}
               selectedDate={
                 !!values.publishedOn ? moment(values.publishedOn).toString() : undefined
@@ -158,6 +167,13 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
               onChange={(date: any) => {
                 setFieldValue('publishedOn', date);
               }}
+            />
+            <TimeInput
+              disabled={!values.publishedOn}
+              placeholder="HH:MM:SS"
+              required
+              label="Time"
+              onChange={(e) => setPublishedOnTime(e.target.value)}
             />
             <Show visible={contentType === ContentType.Snippet}>
               <FormikText name="page" label="Page" onChange={handleChange} />
@@ -179,7 +195,7 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
         <FormikTextArea
           name="summary"
           label="Summary"
-          width={FieldSize.Large}
+          width={FieldSize.Stretch}
           required
           value={values.summary}
           onChange={handleChange}


### PR DESCRIPTION
This PR includes:

- expanding content summary to full width of parent container
- fixing the margins and groupings of content actions
- adding way to manually add specific time to the content's publishedOn attribute as shown below

![timeinput](https://user-images.githubusercontent.com/15724124/170762701-2b6f11be-ba37-473b-a6e9-33231b93afb3.gif)
