### PR TITLE
TNO-341: Input sizing

### DIFF
--- a/app/editor/src/components/form/checkbox/styled/CheckboxField.tsx
+++ b/app/editor/src/components/form/checkbox/styled/CheckboxField.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { CheckboxVariant, ICheckboxProps } from '..';
 
 export const CheckboxField = styled.input<ICheckboxProps>`
+  box-sizing: border-box;
   cursor: pointer;
   margin: 1px 2px 1px 2px;
   text-decoration: ${(props) => (props.variant === CheckboxVariant.link ? 'underline' : 'none')};

--- a/app/editor/src/components/form/datepicker/styled/SelectDate.tsx
+++ b/app/editor/src/components/form/datepicker/styled/SelectDate.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { ISelectDateProps, SelectDateVariant } from '..';
 
 export const SelectDate = styled.div<ISelectDateProps>`
+  box-sizing: border-box;
   padding-right: 0.5em;
 
   .required:after {

--- a/app/editor/src/components/form/radio/styled/Radio.tsx
+++ b/app/editor/src/components/form/radio/styled/Radio.tsx
@@ -6,6 +6,7 @@ export const Radio = styled.input<IRadioProps>`
   label {
     cursor: hover;
   }
+  box-sizing: border-box;
   margin: 1px 2px 1px 2px;
   text-decoration: ${(props) => (props.variant === RadioVariant.link ? 'underline' : 'none')};
   font-weight: 400;

--- a/app/editor/src/components/form/text/styled/TextField.tsx
+++ b/app/editor/src/components/form/text/styled/TextField.tsx
@@ -5,6 +5,7 @@ import { ITextProps, TextVariant } from '..';
 
 export const TextField = styled.input<ITextProps>`
   padding: 0.375rem 0.75rem;
+  box-sizing: border-box;
   text-decoration: ${(props) => (props.variant === TextVariant.link ? 'underline' : 'none')};
   display: inline-block;
   width: ${(props) => props.width};

--- a/app/editor/src/components/form/textarea/styled/TextAreaField.tsx
+++ b/app/editor/src/components/form/textarea/styled/TextAreaField.tsx
@@ -6,6 +6,7 @@ import { ITextAreaProps } from '..';
 
 export const TextAreaField = styled.textarea<ITextAreaProps>`
   padding: 0.375rem 0.75rem;
+  box-sizing: border-box;
   text-decoration: ${(props) => (props.variant === TextVariant.link ? 'underline' : 'none')};
   display: inline-block;
   width: ${(props) => props.width};

--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -208,7 +208,7 @@ export const ContentForm: React.FC<IContentFormProps> = ({ contentType = Content
                       <FormikText
                         name="otherSource"
                         label="Other Source"
-                        width={FieldSize.Medium}
+                        width={FieldSize.Big}
                         onChange={(e) => {
                           const value = e.currentTarget.value;
                           props.setFieldValue('otherSource', value);

--- a/app/editor/src/features/content/form/ContentSummaryForm.tsx
+++ b/app/editor/src/features/content/form/ContentSummaryForm.tsx
@@ -145,7 +145,7 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
               name="categories[0].score"
               label="Score"
               type="number"
-              width={FieldSize.Stretch}
+              width={FieldSize.Medium}
               disabled={!values.categories.length}
             />
           </Row>


### PR DESCRIPTION
Adding border-box to the following elements allows to assigned width to account for the element's padding which was previously causing a mismatch in size. 

![image](https://user-images.githubusercontent.com/15724124/171259188-a503d508-3c9b-409d-8df6-6e4841dcd101.png)
