### PR TITLE
TNO-213 Fix Keycloak

### DIFF
--- a/auth/keycloak/config/realm-export.json
+++ b/auth/keycloak/config/realm-export.json
@@ -315,7 +315,6 @@
       ],
       "tno-app": [],
       "security-admin-console": [],
-      "tno-api": [],
       "admin-cli": [],
       "tno-service-account": [
         {
@@ -829,57 +828,6 @@
       "optionalClientScopes": ["address", "phone", "offline_access", "microprofile-jwt"]
     },
     {
-      "id": "a55cc0a7-a563-4c80-b352-5fb9f9529c03",
-      "clientId": "tno-api",
-      "name": "Today's News Online API",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "redirectUris": [],
-      "webOrigins": [],
-      "notBefore": 0,
-      "bearerOnly": true,
-      "consentRequired": false,
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": true,
-      "serviceAccountsEnabled": false,
-      "publicClient": false,
-      "frontchannelLogout": false,
-      "protocol": "openid-connect",
-      "attributes": {
-        "id.token.as.detached.signature": "false",
-        "saml.assertion.signature": "false",
-        "saml.force.post.binding": "false",
-        "saml.multivalued.roles": "false",
-        "saml.encrypt": "false",
-        "login_theme": "keycloak",
-        "oauth2.device.authorization.grant.enabled": "false",
-        "backchannel.logout.revoke.offline.tokens": "false",
-        "saml.server.signature": "false",
-        "saml.server.signature.keyinfo.ext": "false",
-        "use.refresh.tokens": "true",
-        "exclude.session.state.from.auth.response": "false",
-        "oidc.ciba.grant.enabled": "false",
-        "saml.artifact.binding": "false",
-        "backchannel.logout.session.required": "true",
-        "client_credentials.use_refresh_token": "false",
-        "saml_force_name_id_format": "false",
-        "require.pushed.authorization.requests": "false",
-        "saml.client.signature": "false",
-        "tls.client.certificate.bound.access.tokens": "false",
-        "saml.authnstatement": "false",
-        "display.on.consent.screen": "false",
-        "saml.onetimeuse.condition": "false"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
-      "nodeReRegistrationTimeout": -1,
-      "defaultClientScopes": ["web-origins", "profile", "roles", "email"],
-      "optionalClientScopes": ["address", "phone", "offline_access", "microprofile-jwt"]
-    },
-    {
       "id": "89ff6cf4-3755-4329-adab-ccfb74052c97",
       "clientId": "tno-app",
       "name": "Today's News Online",
@@ -1193,7 +1141,7 @@
           }
         }
       ],
-      "defaultClientScopes": ["web-origins", "profile", "roles", "email"],
+      "defaultClientScopes": ["web-origins", "tno-audience", "profile", "roles", "email"],
       "optionalClientScopes": ["address", "phone", "offline_access", "microprofile-jwt"]
     },
     {
@@ -1300,7 +1248,7 @@
           }
         }
       ],
-      "defaultClientScopes": ["web-origins", "profile", "roles", "email"],
+      "defaultClientScopes": ["web-origins", "tno-audience", "profile", "roles", "email"],
       "optionalClientScopes": ["address", "phone", "offline_access", "microprofile-jwt"],
       "authorizationSettings": {
         "allowRemoteResourceManagement": true,

--- a/libs/net/services/Config/ServiceOptions.cs
+++ b/libs/net/services/Config/ServiceOptions.cs
@@ -14,9 +14,9 @@ public class ServiceOptions
     public int MaxRetryLimit { get; set; } = 5;
 
     /// <summary>
-    /// get/set - Default millisecond delay between process cycle.  This stops run-away threads (default: 1 second).
+    /// get/set - Default millisecond delay between process cycle.  This stops run-away threads (default: 30 second).
     /// </summary>
-    public int DefaultDelayMS { get; set; } = 1000;
+    public int DefaultDelayMS { get; set; } = 30000;
 
     /// <summary>
     /// get/set - The URL to the API.

--- a/openshift/kustomize/services/syndication/base/deploy.yaml
+++ b/openshift/kustomize/services/syndication/base/deploy.yaml
@@ -85,11 +85,6 @@ spec:
                 configMapKeyRef:
                   name: services
                   key: KEYCLOAK_AUTHORITY
-            - name: Auth__Keycloak__Realm
-              valueFrom:
-                configMapKeyRef:
-                  name: services
-                  key: KEYCLOAK_REALM
             - name: Auth__Keycloak__Audience
               valueFrom:
                 configMapKeyRef:

--- a/services/net/capture/appsettings.Development.json
+++ b/services/net/capture/appsettings.Development.json
@@ -13,9 +13,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "http://host.docker.internal:40001",
+      "Authority": "http://host.docker.internal:40001/auth/realms/tno",
       "Audience": "tno-service-account",
-      "Realm": "tno",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },

--- a/services/net/capture/appsettings.Staging.json
+++ b/services/net/capture/appsettings.Staging.json
@@ -12,9 +12,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "https://dev.oidc.gov.bc.ca",
+      "Authority": "https://dev.oidc.gov.bc.ca/auth/realms/gcpe",
       "Audience": "tno-service-account",
-      "Realm": "gcpe",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },

--- a/services/net/capture/appsettings.json
+++ b/services/net/capture/appsettings.json
@@ -17,9 +17,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "https://oidc.gov.bc.ca",
+      "Authority": "https://oidc.gov.bc.ca/auth/realms/gcpe",
       "Audience": "tno-service-account",
-      "Realm": "gcpe",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },

--- a/services/net/clip/appsettings.Development.json
+++ b/services/net/clip/appsettings.Development.json
@@ -14,9 +14,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "http://host.docker.internal:40001",
+      "Authority": "http://host.docker.internal:40001/auth/realms/tno",
       "Audience": "tno-service-account",
-      "Realm": "tno",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },

--- a/services/net/clip/appsettings.Staging.json
+++ b/services/net/clip/appsettings.Staging.json
@@ -12,9 +12,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "https://dev.oidc.gov.bc.ca",
+      "Authority": "https://dev.oidc.gov.bc.ca/auth/realms/gcpe",
       "Audience": "tno-service-account",
-      "Realm": "gcpe",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },

--- a/services/net/clip/appsettings.json
+++ b/services/net/clip/appsettings.json
@@ -18,9 +18,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "https://oidc.gov.bc.ca",
+      "Authority": "https://oidc.gov.bc.ca/auth/realms/gcpe",
       "Audience": "tno-service-account",
-      "Realm": "gcpe",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },

--- a/services/net/command/appsettings.Development.json
+++ b/services/net/command/appsettings.Development.json
@@ -12,9 +12,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "http://host.docker.internal:40001",
+      "Authority": "http://host.docker.internal:40001/auth/realms/tno",
       "Audience": "tno-service-account",
-      "Realm": "tno",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },

--- a/services/net/command/appsettings.Staging.json
+++ b/services/net/command/appsettings.Staging.json
@@ -12,9 +12,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "https://dev.oidc.gov.bc.ca",
+      "Authority": "https://dev.oidc.gov.bc.ca/auth/realms/gcpe",
       "Audience": "tno-service-account",
-      "Realm": "gcpe",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },

--- a/services/net/command/appsettings.json
+++ b/services/net/command/appsettings.json
@@ -15,9 +15,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "https://oidc.gov.bc.ca",
+      "Authority": "https://oidc.gov.bc.ca/auth/realms/gcpe",
       "Audience": "tno-service-account",
-      "Realm": "gcpe",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },

--- a/services/net/content/appsettings.Development.json
+++ b/services/net/content/appsettings.Development.json
@@ -11,9 +11,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "http://host.docker.internal:40001",
+      "Authority": "http://host.docker.internal:40001/auth/realms/tno",
       "Audience": "tno-service-account",
-      "Realm": "tno",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },

--- a/services/net/content/appsettings.Staging.json
+++ b/services/net/content/appsettings.Staging.json
@@ -11,9 +11,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "https://dev.oidc.gov.bc.ca",
+      "Authority": "https://dev.oidc.gov.bc.ca/auth/realms/gcpe",
       "Audience": "tno-service-account",
-      "Realm": "gcpe",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },

--- a/services/net/content/appsettings.json
+++ b/services/net/content/appsettings.json
@@ -14,9 +14,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "https://oidc.gov.bc.ca",
+      "Authority": "https://oidc.gov.bc.ca/auth/realms/gcpe",
       "Audience": "tno-service-account",
-      "Realm": "gcpe",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },

--- a/services/net/nlp/appsettings.Development.json
+++ b/services/net/nlp/appsettings.Development.json
@@ -11,9 +11,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "http://host.docker.internal:40001",
+      "Authority": "http://host.docker.internal:40001/auth/realms/tno",
       "Audience": "tno-service-account",
-      "Realm": "tno",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },

--- a/services/net/nlp/appsettings.Staging.json
+++ b/services/net/nlp/appsettings.Staging.json
@@ -11,9 +11,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "https://dev.oidc.gov.bc.ca",
+      "Authority": "https://dev.oidc.gov.bc.ca/auth/realms/gcpe",
       "Audience": "tno-service-account",
-      "Realm": "gcpe",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },

--- a/services/net/nlp/appsettings.json
+++ b/services/net/nlp/appsettings.json
@@ -14,9 +14,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "https://oidc.gov.bc.ca",
+      "Authority": "https://oidc.gov.bc.ca/auth/realms/gcpe",
       "Audience": "tno-service-account",
-      "Realm": "gcpe",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },

--- a/services/net/syndication/appsettings.Development.json
+++ b/services/net/syndication/appsettings.Development.json
@@ -12,9 +12,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "http://host.docker.internal:40001",
+      "Authority": "http://host.docker.internal:40001/auth/realms/tno",
       "Audience": "tno-service-account",
-      "Realm": "tno",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },

--- a/services/net/syndication/appsettings.Staging.json
+++ b/services/net/syndication/appsettings.Staging.json
@@ -12,9 +12,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "https://dev.oidc.gov.bc.ca",
+      "Authority": "https://dev.oidc.gov.bc.ca/auth/realms/gcpe",
       "Audience": "tno-service-account",
-      "Realm": "gcpe",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },

--- a/services/net/syndication/appsettings.json
+++ b/services/net/syndication/appsettings.json
@@ -15,9 +15,8 @@
   },
   "Auth": {
     "Keycloak": {
-      "Authority": "https://oidc.gov.bc.ca",
+      "Authority": "https://oidc.gov.bc.ca/auth/realms/gcpe",
       "Audience": "tno-service-account",
-      "Realm": "gcpe",
       "Secret": "{DO NOT STORE SECRET HERE}"
     }
   },


### PR DESCRIPTION
Added the audience configuration for the service account in keycloak so that validation works.

> Please note that this will require another refresh of your keycloak service and database.  `make renew`