### PR TITLE
TNO-378 Fix syndication feed dates

### DIFF
--- a/api/net/appsettings.Development.json
+++ b/api/net/appsettings.Development.json
@@ -1,10 +1,9 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Debug",
-      "Microsoft": "Information",
-      "Microsoft.AspNetCore": "Warning",
-      "System": "Warning"
+      "Default": "Warning",
+      "Microsoft": "Warning",
+      "TNO": "Debug"
     }
   },
   "Keycloak": {

--- a/api/net/appsettings.Staging.json
+++ b/api/net/appsettings.Staging.json
@@ -3,8 +3,7 @@
     "LogLevel": {
       "Default": "Warning",
       "Microsoft": "Warning",
-      "Microsoft.AspNetCore": "Warning",
-      "System": "Warning"
+      "TNO": "Information"
     }
   },
   "Keycloak": {

--- a/api/net/appsettings.json
+++ b/api/net/appsettings.json
@@ -3,7 +3,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Warning",
-      "Microsoft.AspNetCore": "Error"
+      "Microsoft": "Error",
+      "TNO": "Information"
     }
   },
   "AllowedHosts": "*",

--- a/libs/net/core/Extensions/StringExtensions.cs
+++ b/libs/net/core/Extensions/StringExtensions.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace TNO.Core.Extensions;
 
@@ -7,6 +9,10 @@ namespace TNO.Core.Extensions;
 /// </summary>
 public static class StringExtensions
 {
+    #region Variables
+    private static readonly Regex TimeZone = new("[A-Z]{3}$");
+    #endregion
+
     /// <summary>
     /// Extracts the first letter of each word from the text and returns the value.
     /// </summary>
@@ -115,5 +121,56 @@ public static class StringExtensions
         if (value?.StartsWith(remove) == true) result = result?[(remove.Length - 1)..];
         if (result?.EndsWith(remove) == true) result = result?[..^remove.Length];
         return result;
+    }
+
+    /// <summary>
+    /// Try to parse the string 'value' as a DateTime with the default system format first, then the formats provided.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="cultureInfo"></param>
+    /// <param name="dateTimeStyles"></param>
+    /// <param name="formats"></param>
+    /// <returns></returns>
+    public static bool TryParseDateTimeExact(this string? value, CultureInfo cultureInfo, DateTimeStyles dateTimeStyles, out DateTime result, params string[] formats)
+    {
+        if (!String.IsNullOrWhiteSpace(value))
+        {
+            if (DateTime.TryParse(value, out DateTime date))
+            {
+                result = date;
+                return true;
+            }
+
+            // If the 'value' has a timezone it will need to be converted into an offset.
+            // This isn't a good solution but will work for now.
+            var match = TimeZone.Match(value);
+            if (match.Success && match.Value != "GMT")
+            {
+                var abbr = match.Value;
+                var timezone = abbr switch
+                {
+                    "EST" => TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time"),
+                    "CST" => TimeZoneInfo.FindSystemTimeZoneById("Central Standard Time"),
+                    "PST" => TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"),
+                    "NST" => TimeZoneInfo.FindSystemTimeZoneById("Newfoundland Standard Time"),
+                    "AST" => TimeZoneInfo.FindSystemTimeZoneById("Atlantic Standard Time"),
+                    "MST" => TimeZoneInfo.FindSystemTimeZoneById("Mountain Standard Time"),
+                    _ => TimeZoneInfo.Utc
+                };
+                value = value.Replace(abbr, $"{timezone.BaseUtcOffset.Hours}");
+            }
+
+            foreach (var format in formats)
+            {
+                if (DateTime.TryParseExact(value, format, cultureInfo, dateTimeStyles, out DateTime dateExact))
+                {
+                    result = dateExact;
+                    return true;
+                }
+            }
+        }
+
+        result = DateTime.MinValue;
+        return false;
     }
 }

--- a/libs/net/services/Config/ServiceOptions.cs
+++ b/libs/net/services/Config/ServiceOptions.cs
@@ -27,6 +27,6 @@ public class ServiceOptions
     /// <summary>
     /// get/set - The service timezone.
     /// </summary>
-    public string TimeZone { get; set; } = "Pacific Standard Time";
+    public string TimeZone { get; set; } = "UTC";
     #endregion
 }

--- a/services/net/capture/appsettings.json
+++ b/services/net/capture/appsettings.json
@@ -12,7 +12,7 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
     "MediaTypes": ["Talk Radio"],
-    "TimeZone": "Pacific Standard Time",
+    "TimeZone": "UTC",
     "OutputPath": "/data/capture",
     "Command": "ffmpeg"
   },

--- a/services/net/clip/appsettings.json
+++ b/services/net/clip/appsettings.json
@@ -12,7 +12,7 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
     "MediaTypes": ["Talk Radio"],
-    "TimeZone": "Pacific Standard Time",
+    "TimeZone": "UTC",
     "CapturePath": "/data/capture",
     "OutputPath": "/data/clip",
     "Command": "ffmpeg"

--- a/services/net/command/appsettings.json
+++ b/services/net/command/appsettings.json
@@ -12,7 +12,7 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
     "MediaTypes": ["Talk Radio"],
-    "TimeZone": "Pacific Standard Time"
+    "TimeZone": "UTC"
   },
   "Auth": {
     "Keycloak": {

--- a/services/net/content/appsettings.json
+++ b/services/net/content/appsettings.json
@@ -11,7 +11,7 @@
   "Service": {
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
-    "TimeZone": "Pacific Standard Time"
+    "TimeZone": "UTC"
   },
   "Auth": {
     "Keycloak": {

--- a/services/net/nlp/appsettings.json
+++ b/services/net/nlp/appsettings.json
@@ -11,7 +11,7 @@
   "Service": {
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080/api",
-    "TimeZone": "Pacific Standard Time"
+    "TimeZone": "UTC"
   },
   "Auth": {
     "Keycloak": {

--- a/services/net/syndication/SyndicationAction.cs
+++ b/services/net/syndication/SyndicationAction.cs
@@ -203,13 +203,16 @@ public class SyndicationAction : IngestAction<SyndicationOptions>
 
         try
         {
-            var xmlr = XmlReader.Create(new StringReader(data));
-            return SyndicationFeed.Load(xmlr);
+            // Reformat dates because timezone abbreviations don't work...
 
-            // var feed = SyndicationFeed.Load(xmlr);
-            // var rss = new Rss20FeedFormatter();
-            // rss.ReadFrom(xmlr);
-            // var feed = rss.Feed;
+            var xmlr = XmlReader.Create(new StringReader(data));
+            var feed = SyndicationFeed.Load(xmlr);
+
+            // Need to manually test if `pubDate` is valid.  Microsoft didn't bother providing a way to work with valid dates...
+            // Essentially timezone values are context sensitive.
+            var pubDate = feed.Items.FirstOrDefault()?.PublishDate;
+
+            return feed;
         }
         catch (Exception ex)
         {

--- a/services/net/syndication/Xml/Rss/RssChannel.cs
+++ b/services/net/syndication/Xml/Rss/RssChannel.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Serialization;
+using TNO.Core.Extensions;
 
 namespace TNO.Services.Syndication.Xml;
 
@@ -180,8 +181,9 @@ public class RssChannel
         var docs = element.Element("docs")?.Value;
         if (Uri.TryCreate(docs, UriKind.Absolute, out Uri? docsUri)) this.Documentation = docsUri;
 
-        if (DateTime.TryParse(element.Element("pubDate")?.Value, out DateTime pubDate)) this.PublishedOn = pubDate;
-        if (DateTime.TryParse(element.Element("lastBuildDate")?.Value, out DateTime lastBuildDate)) this.LastBuildDate = lastBuildDate;
+        if (element.Element("pubDate")?.Value.TryParseDateTimeExact(CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out DateTime pubDate, RssFeed.PUB_DATE_FORMATS) == true) this.PublishedOn = pubDate;
+        if (element.Element("lastBuildDate")?.Value.TryParseDateTimeExact(CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out DateTime lastBuildDate, RssFeed.PUB_DATE_FORMATS) == true) this.LastBuildDate = lastBuildDate;
+
         if (Int32.TryParse(element.Element("ttl")?.Value, out int ttl)) this.TimeToLive = ttl;
 
         this.Categories = RssCategory.LoadAll(element, enforceSpec);

--- a/services/net/syndication/Xml/Rss/RssFeed.cs
+++ b/services/net/syndication/Xml/Rss/RssFeed.cs
@@ -14,6 +14,19 @@ namespace TNO.Services.Syndication.Xml;
 public class RssFeed
 {
     #region Variables
+    /// <summary>
+    /// Published Date formats used to parse date values.
+    /// .NET has an issue with parsing valid dates because it doesn't know how to apply the timezone.
+    /// </summary>
+    public readonly static string[] PUB_DATE_FORMATS = new[]
+    {
+        "ddd, dd MMM yyyy HH:mm:ss z",
+        "ddd, d MMM yyyy HH:mm:ss z",
+        "ddd, d MMM yyyy HH:mm:ss ZZZ",
+        "ddd dd MMM yyyy HH:mm:ss z",
+        "ddd d MMM yyyy HH:mm:ss z",
+        "ddd d MMM yyyy HH:mm:ss ZZZ"
+    };
     #endregion
 
     #region Properties

--- a/services/net/syndication/Xml/Rss/RssItem.cs
+++ b/services/net/syndication/Xml/Rss/RssItem.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.ServiceModel.Syndication;
 using System.Xml;
 using System.Xml.Linq;
@@ -111,7 +112,7 @@ public class RssItem
         this.Categories = RssCategory.LoadAll(element, enforceSpec);
         this.Source = RssSource.Load(element, enforceSpec);
 
-        if (DateTime.TryParse(element.Element("pubDate")?.Value, out DateTime pubDate)) this.PublishedOn = pubDate;
+        if (element.Element("pubDate")?.Value.TryParseDateTimeExact(CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out DateTime pubDate, RssFeed.PUB_DATE_FORMATS) == true) this.PublishedOn = pubDate;
     }
     #endregion
 

--- a/services/net/syndication/appsettings.json
+++ b/services/net/syndication/appsettings.json
@@ -12,7 +12,7 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
     "MediaTypes": ["Syndication"],
-    "TimeZone": "Pacific Standard Time"
+    "TimeZone": "UTC"
   },
   "Auth": {
     "Keycloak": {


### PR DESCRIPTION
There are two date time bugs.

- Many feeds have an invalid time-zone abbreviation.  Which results in the syndication feed failing.  I've created a simple string parser to determine a possible time-zone offset for the abbreviation.
- The services compare the local system datetime to the `DataSource.LastRanOn` datetime, but it would result in an incorrect comparison.  I don't know if I've fixed this, but it now defaults to UTC.  I'll need to test the Capture and Clip services at some point.