### PR TITLE
TNO-356 Fix Clip Service

### DIFF
--- a/libs/net/services/Actions/IngestAction.cs
+++ b/libs/net/services/Actions/IngestAction.cs
@@ -34,7 +34,7 @@ public abstract class IngestAction<TOptions> : ServiceAction<TOptions>, IIngestA
     /// <param name="manager"></param>
     /// <param name="name"></param>
     /// <param name="cancellationToken"></param>
-    public abstract Task PerformActionAsync(IDataSourceIngestManager manager, string? name = null, CancellationToken cancellationToken = default);
+    public abstract Task PerformActionAsync<T>(IDataSourceIngestManager manager, string? name = null, T? data = null, CancellationToken cancellationToken = default) where T : class;
 
     /// <summary>
     /// Perform the action for the specified data source.
@@ -43,9 +43,9 @@ public abstract class IngestAction<TOptions> : ServiceAction<TOptions>, IIngestA
     /// <param name="manager"></param>
     /// <param name="name"></param>
     /// <param name="cancellationToken"></param>
-    public override Task PerformActionAsync(IServiceActionManager manager, string? name = null, CancellationToken cancellationToken = default)
+    public override Task PerformActionAsync<T>(IServiceActionManager manager, string? name = null, T? data = null, CancellationToken cancellationToken = default) where T : class
     {
-        return PerformActionAsync((IDataSourceIngestManager)manager, name, cancellationToken);
+        return PerformActionAsync((IDataSourceIngestManager)manager, name, data, cancellationToken);
     }
     #endregion
 }

--- a/libs/net/services/Actions/Managers/ServiceActionManager`.cs
+++ b/libs/net/services/Actions/Managers/ServiceActionManager`.cs
@@ -99,7 +99,20 @@ public abstract class ServiceActionManager<TOptions> : IServiceActionManager
     protected virtual async Task PerformActionAsync(string? name = null)
     {
         // Perform configured action.
-        await _action.PerformActionAsync(this, name);
+        await PerformActionAsync<object>(name, null);
+    }
+
+    /// <summary>
+    /// Call the configured action.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="data"></param>
+    /// <returns></returns>
+    protected virtual async Task PerformActionAsync<T>(string? name = null, T? data = null)
+        where T : class
+    {
+        // Perform configured action.
+        await _action.PerformActionAsync(this, name, data);
     }
 
     /// <summary>

--- a/libs/net/services/Actions/ServiceAction.cs
+++ b/libs/net/services/Actions/ServiceAction.cs
@@ -44,7 +44,8 @@ public abstract class ServiceAction<TOptions> : IServiceAction<TOptions>
     /// </summary>
     /// <param name="manager"></param>
     /// <param name="name"></param>
+    /// <param name="data"></param>
     /// <param name="cancellationToken"></param>
-    public abstract Task PerformActionAsync(IServiceActionManager manager, string? name = null, CancellationToken cancellationToken = default);
+    public abstract Task PerformActionAsync<T>(IServiceActionManager manager, string? name = null, T? data = null, CancellationToken cancellationToken = default) where T : class;
     #endregion
 }

--- a/libs/net/services/Interfaces/IIngestAction`.cs
+++ b/libs/net/services/Interfaces/IIngestAction`.cs
@@ -17,7 +17,8 @@ public interface IIngestAction<TOptions> : IServiceAction<TOptions>
     /// </summary>
     /// <param name="dataSource"></param>
     /// <param name="name"></param>
+    /// <param name="data"></param>
     /// <param name="cancellationToken"></param>
-    public Task PerformActionAsync(IDataSourceIngestManager dataSource, string? name = null, CancellationToken cancellationToken = default);
+    public Task PerformActionAsync<T>(IDataSourceIngestManager dataSource, string? name = null, T? data = null, CancellationToken cancellationToken = default) where T : class;
     #endregion
 }

--- a/libs/net/services/Interfaces/IServiceAction`.cs
+++ b/libs/net/services/Interfaces/IServiceAction`.cs
@@ -17,7 +17,8 @@ public interface IServiceAction<TOptions>
     /// </summary>
     /// <param name="manager"></param>
     /// <param name="name"></param>
+    /// <param name="data"></param>
     /// <param name="cancellationToken"></param>
-    public Task PerformActionAsync(IServiceActionManager manager, string? name = null, CancellationToken cancellationToken = default);
+    public Task PerformActionAsync<T>(IServiceActionManager manager, string? name = null, T? data = null, CancellationToken cancellationToken = default) where T : class;
     #endregion
 }

--- a/services/net/capture/CaptureAction.cs
+++ b/services/net/capture/CaptureAction.cs
@@ -37,9 +37,10 @@ public class CaptureAction : CommandAction<CaptureOptions>
     /// </summary>
     /// <param name="manager"></param>
     /// <param name="name"></param>
+    /// <param name="data"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public override async Task PerformActionAsync(IDataSourceIngestManager manager, string? name = null, CancellationToken cancellationToken = default)
+    public override async Task PerformActionAsync<T>(IDataSourceIngestManager manager, string? name = null, T? data = null, CancellationToken cancellationToken = default) where T : class
     {
         this.Logger.LogDebug("Performing ingestion service action for data source '{Code}'", manager.DataSource.Code);
 

--- a/services/net/clip/ClipDataSourceManager.cs
+++ b/services/net/clip/ClipDataSourceManager.cs
@@ -52,18 +52,18 @@ public class ClipDataSourceManager : CommandDataSourceManager<ClipOptions>
 
                 await PostRunAsync();
             }
-            catch (MissingFileException ex)
+            catch (Exception ex)
             {
-                var throwOnMissingFile = this.DataSource.GetConnectionValue<bool>("throwOnMissingFile");
-                if (throwOnMissingFile)
+                if ((ex is MissingFileException || (ex is AggregateException && ex.InnerException is MissingFileException)) &&
+                    !this.DataSource.GetConnectionValue<bool>("throwOnMissingFile"))
+                {
+                    _logger.LogWarning(ex, "File missing for clip service");
+                }
+                else
+                {
+                    this.IsRunning = false;
                     throw;
-
-                _logger.LogWarning(ex, "File missing for clip service");
-            }
-            catch
-            {
-                this.IsRunning = false;
-                throw;
+                }
             }
         }
     }

--- a/services/net/command/CommandAction`.cs
+++ b/services/net/command/CommandAction`.cs
@@ -41,9 +41,10 @@ public abstract class CommandAction<TOptions> : IngestAction<TOptions>
     /// </summary>
     /// <param name="manager"></param>
     /// <param name="name"></param>
+    /// <param name="data"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public override async Task PerformActionAsync(IDataSourceIngestManager manager, string? name = null, CancellationToken cancellationToken = default)
+    public override async Task PerformActionAsync<T>(IDataSourceIngestManager manager, string? name = null, T? data = null, CancellationToken cancellationToken = default) where T : class
     {
         this.Logger.LogDebug("Performing ingestion service action for data source '{Code}'", manager.DataSource.Code);
 

--- a/services/net/nlp/NLPAction.cs
+++ b/services/net/nlp/NLPAction.cs
@@ -43,9 +43,10 @@ public class NLPAction : ServiceAction<NLPOptions>
     /// </summary>
     /// <param name="manager"></param>
     /// <param name="name"></param>
+    /// <param name="data"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public override Task PerformActionAsync(IServiceActionManager manager, string? name = null, CancellationToken cancellationToken = default)
+    public override Task PerformActionAsync<T>(IServiceActionManager manager, string? name = null, T? data = null, CancellationToken cancellationToken = default) where T : class
     {
         _logger.LogDebug("Performing NLP service action for ...");
 

--- a/services/net/syndication/SyndicationAction.cs
+++ b/services/net/syndication/SyndicationAction.cs
@@ -53,9 +53,10 @@ public class SyndicationAction : IngestAction<SyndicationOptions>
     /// </summary>
     /// <param name="manager"></param>
     /// <param name="name"></param>
+    /// <param name="data"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public override async Task PerformActionAsync(IDataSourceIngestManager manager, string? name = null, CancellationToken cancellationToken = default)
+    public override async Task PerformActionAsync<T>(IDataSourceIngestManager manager, string? name = null, T? data = null, CancellationToken cancellationToken = default) where T : class
     {
         _logger.LogDebug("Performing ingestion service action for data source '{Code}'", manager.DataSource.Code);
         var url = GetUrl(manager.DataSource);


### PR DESCRIPTION
The Clip Service would shutdown as a result of scheduled run failures.  The failure was expected (the Capture file was missing), however based on configuration the service should continue to run other schedules without erroring out.

This update wraps the schedule runs with `try+catch` and correctly handles the failures based on config.