### PR TITLE
TNO-386 Add Purge Service

### DIFF
--- a/openshift/kustomize/cron/base/config-map.yaml
+++ b/openshift/kustomize/cron/base/config-map.yaml
@@ -1,0 +1,62 @@
+---
+# Configuration settings
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: purge-service
+  namespace: default
+  annotations:
+    description: CronJob purge-service delete script.
+  labels:
+    name: purge-service
+    part-of: tno
+    version: 1.0.0
+    component: purge-service
+    managed-by: kustomize
+    created-by: jeremy.foster
+data:
+  entrypoint.sh: |-
+    #!/bin/sh
+
+    # *********************************************************************************
+    # Delete folders that are older than the specified number of days.
+    # Folder convention requires folders to be named with the date (i.e. yyyy-mm-dd).
+    # arg1: Folder path to purge (i.e. /data/capture)
+    # arg2: Number of days to keep in storage (i.e 2 = Delete everything two days old)
+    # *********************************************************************************
+    purge_folders () {
+      echo "************************************"
+      echo "Purging $1"
+
+      for d in $1/*/*/ ; do
+        [ -L "${d%/}" ] && continue
+
+        DELETE=1
+
+        # Loop through each day to determine if the folder should be deleted.
+        i=0
+        while [ $i -lt $2 ]; do
+          DAY=$(date -D %s -d $(( $(date +%s) - (24*60*60*$i))) +"%Y-%m-%d")
+          MATCH=$(echo $d | grep -iE "^${1}/.*/${DAY}/$" | wc -l)
+
+          # Find a match, mark for keep.
+          if [ $MATCH -eq 1 ]; then
+            DELETE=0
+          fi
+          i=$(( $i + 1 ))
+        done
+
+        if [ $DELETE -eq 1 ]; then
+          echo "Delete - $d"
+          rm -rf $d
+        else
+          echo "Keep - $d"
+        fi
+
+      done
+
+      echo "************************************"
+    }
+
+    purge_folders "/data/capture" 2
+    purge_folders "/data/clip" 2

--- a/openshift/kustomize/cron/base/cron-job.yaml
+++ b/openshift/kustomize/cron/base/cron-job.yaml
@@ -1,0 +1,50 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: purge-service
+  namespace: default
+  annotations:
+    description: CronJob service to delete files from PVC
+  labels:
+    name: purge-service
+    part-of: tno
+    version: 1.0.0
+    component: purge-service
+    managed-by: kustomize
+    created-by: jeremy.foster
+spec:
+  schedule: "0 0 * * *" # Midnight
+  # schedule: "* * * * *" # Immediately
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          volumes:
+            - name: entrypoint
+              configMap:
+                defaultMode: 0700
+                name: purge-service
+            - name: av-storage
+              persistentVolumeClaim:
+                claimName: av-storage
+          containers:
+            - name: purge-service
+              image: busybox:1.35.0
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 20m
+                  memory: 120Mi
+                limits:
+                  cpu: 50m
+                  memory: 200Mi
+              volumeMounts:
+                - name: entrypoint
+                  mountPath: /bin/entrypoint.sh
+                  readonly: true
+                  subPath: entrypoint.sh
+                - name: av-storage
+                  mountPath: /data
+              command:
+                - /bin/entrypoint.sh

--- a/openshift/kustomize/cron/base/kustomization.yaml
+++ b/openshift/kustomize/cron/base/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - config-map.yaml
+  - cron-job.yaml

--- a/openshift/kustomize/cron/overlays/dev/kustomization.yaml
+++ b/openshift/kustomize/cron/overlays/dev/kustomization.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-dev
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: CronJob
+      name: purge-service
+    patch: |-
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/containers/0/resources/requests/cpu
+        value: 20m
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/containers/0/resources/requests/memory
+        value: 120Mi
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/containers/0/resources/limits/cpu
+        value: 50m
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/containers/0/resources/limits/memory
+        value: 200Mi

--- a/openshift/kustomize/cron/overlays/prod/kustomization.yaml
+++ b/openshift/kustomize/cron/overlays/prod/kustomization.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-prod
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: CronJob
+      name: purge-service
+    patch: |-
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/containers/0/resources/requests/cpu
+        value: 20m
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/containers/0/resources/requests/memory
+        value: 120Mi
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/containers/0/resources/limits/cpu
+        value: 50m
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/containers/0/resources/limits/memory
+        value: 200Mi

--- a/openshift/kustomize/cron/overlays/test/kustomization.yaml
+++ b/openshift/kustomize/cron/overlays/test/kustomization.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-test
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: CronJob
+      name: purge-service
+    patch: |-
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/containers/0/resources/requests/cpu
+        value: 20m
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/containers/0/resources/requests/memory
+        value: 120Mi
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/containers/0/resources/limits/cpu
+        value: 50m
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/containers/0/resources/limits/memory
+        value: 200Mi


### PR DESCRIPTION
We now have a simple Purge Service that uses a CronJob to delete folders (based on convention) that are older than two days.

The CronJob is configured to run nightly and executes a shell script file.

![image](https://user-images.githubusercontent.com/3180256/176306776-793731c7-e873-45c1-b7ba-7ca845f65b0b.png)
