### PR TITLE
Fix Capture Service

### DIFF
--- a/services/net/command/CommandProcess.cs
+++ b/services/net/command/CommandProcess.cs
@@ -1,0 +1,40 @@
+namespace TNO.Services.Command;
+
+/// <summary>
+/// CommandProcess class, provides a way to store a process and related information.
+/// </summary>
+public class CommandProcess : ICommandProcess
+{
+    #region Properties
+    /// <summary>
+    /// get/set - The process for this command.
+    /// </summary>
+    public System.Diagnostics.Process Process { get; set; }
+
+    /// <summary>
+    /// get/set - When the process was created.
+    /// </summary>
+    public DateTime CreatedOn { get; set; }
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    /// Creates a new instance of a CommandProcess object, initializes with specified paraemters.
+    /// </summary>
+    /// <param name="process"></param>
+    public CommandProcess(System.Diagnostics.Process process) : this(process, DateTime.Now)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of a CommandProcess object, initializes with specified paraemters.
+    /// </summary>
+    /// <param name="process"></param>
+    /// <param name="createdOn"></param>
+    public CommandProcess(System.Diagnostics.Process process, DateTime createdOn)
+    {
+        this.Process = process;
+        this.CreatedOn = createdOn;
+    }
+    #endregion
+}

--- a/services/net/command/ICommandProcess.cs
+++ b/services/net/command/ICommandProcess.cs
@@ -1,0 +1,19 @@
+namespace TNO.Services.Command;
+
+/// <summary>
+/// ICommandProcess interface, provides a way to store a process and related information.
+/// </summary>
+public interface ICommandProcess
+{
+    #region Properties
+    /// <summary>
+    /// get/set - The process for this command.
+    /// </summary>
+    public System.Diagnostics.Process Process { get; set; }
+
+    /// <summary>
+    /// get/set - When the process was created.
+    /// </summary>
+    public DateTime CreatedOn { get; set; }
+    #endregion
+}


### PR DESCRIPTION
Ingest services using the Command Service were not cleaning up when a premature exit occurred on the process.  For example when `ffmpeg` received a 404 it would exit, however the Capture and Clip Service would keep a reference to the process that ran.  This process then would continue to be reused even when it should no longer be used.

Now an exit will remove the referenced process so that a new process can be created.