### PR TITLE
TNO-374: Get rid of duplicate data sources

### DIFF
--- a/libs/net/dal/Services/DataSourceService.cs
+++ b/libs/net/dal/Services/DataSourceService.cs
@@ -27,6 +27,7 @@ public class DataSourceService : BaseService<DataSource, int>, IDataSourceServic
             .Include(ds => ds.DataLocation)
             .Include(ds => ds.MediaType)
             .Include(ds => ds.License)
+            .Where(ds => ds.ContentTypeId != 0)
             .OrderBy(ds => ds.Code).ThenBy(ds => ds.Name).ToArray();
     }
 


### PR DESCRIPTION
As discussed, most likely a temp fix as there will most likely be data sources that don't generate content that should be in this list.

Do we want to control this at the back end of find all, or would it be better to filter from the frontend? Wondering mainly because of the admin section as we would still want to be able to edit these I am assuming.