### PR TITLE
TNO-392 Ingest Fixes

### DIFF
--- a/api/net/Dockerfile
+++ b/api/net/Dockerfile
@@ -21,7 +21,7 @@ RUN dotnet publish "TNO.API.csproj" -c "$BUILD_CONFIGURATION" -o /app/publish
 FROM base AS final
 
 RUN apt-get update && apt-get -y upgrade
-RUN apt -y install curl libc6-dev libgdiplus
+RUN apt -y install curl libc6-dev libgdiplus ffmpeg
 
 WORKDIR /app
 COPY --from=publish /app/publish .

--- a/app/editor/src/features/admin/sources/connections/AudioClip.tsx
+++ b/app/editor/src/features/admin/sources/connections/AudioClip.tsx
@@ -35,7 +35,7 @@ export const AudioClip: React.FC = (props) => {
         label="File Name"
         name="connection.fileName"
         tooltip="File name and output format"
-        placeholder="{schedule name}.mp3"
+        placeholder="{schedule.Name}.mp3"
       />
       <FormikText
         label="Copy Arguments"
@@ -70,15 +70,22 @@ export const AudioClip: React.FC = (props) => {
           setFieldValue('connection.throwOnMissingFile', e.currentTarget.checked);
         }}
       />
-      <p>Do not turn on "Import Content" until you have successfully ingested content.</p>
-      <FormikCheckbox
-        label="Import Content"
-        name="connection.import"
-        tooltip="Whether ingested content should be imported"
-        onChange={(e) => {
-          setFieldValue('connection.import', e.currentTarget.checked);
-        }}
-      />
+      {!!values.contentTypeId && (
+        <>
+          <p>
+            Only import content if you have already successfully ingested content for the configured
+            Kafka Topic.
+          </p>
+          <FormikCheckbox
+            label="Import Content"
+            name="connection.import"
+            tooltip="Whether ingested content should be imported"
+            onChange={(e) => {
+              setFieldValue('connection.import', e.currentTarget.checked);
+            }}
+          />
+        </>
+      )}
     </styled.MediaType>
   );
 };

--- a/app/editor/src/features/admin/sources/connections/Video.tsx
+++ b/app/editor/src/features/admin/sources/connections/Video.tsx
@@ -1,25 +1,39 @@
-import { FormikText } from 'components/formik';
+import { FormikSelect } from 'components/formik';
 import { useFormikContext } from 'formik';
 import { IDataSourceModel } from 'hooks/api-editor';
 import React from 'react';
 
+import { VideoClip, VideoStream, VideoTuner } from '.';
+import { ServiceTypes } from './constants';
 import * as styled from './styled';
 
 export const Video: React.FC = (props) => {
   const { values } = useFormikContext<IDataSourceModel>();
 
+  const ConnectionSettings = () => {
+    switch (values.connection.serviceType) {
+      case 'stream':
+        return <VideoStream />;
+      case 'clip':
+        return <VideoClip />;
+      case 'tuner':
+        return <VideoTuner />;
+      default:
+        return null;
+    }
+  };
+
+  const serviceType = ServiceTypes.find((t) => t.value === values.connection.serviceType);
+
   return (
     <styled.MediaType>
-      <FormikText
-        label="Volume Range"
-        name="connection.volumeRange"
-        value={values.connection.volumeRange}
+      <FormikSelect
+        label="Service Type"
+        name="connection.serviceType"
+        options={ServiceTypes}
+        value={serviceType}
       />
-      <FormikText
-        label="Frame Rate"
-        name="connection.frameRate"
-        value={values.connection.frameRate}
-      />
+      {ConnectionSettings()}
     </styled.MediaType>
   );
 };

--- a/app/editor/src/features/admin/sources/connections/VideoClip.tsx
+++ b/app/editor/src/features/admin/sources/connections/VideoClip.tsx
@@ -4,18 +4,20 @@ import { IDataSourceModel } from 'hooks/api-editor';
 import React from 'react';
 import ReactTooltip from 'react-tooltip';
 
-import { Languages, TimeZones } from './constants';
+import { TimeZones } from './constants';
 import * as styled from './styled';
 
-export const AudioStream: React.FC = (props) => {
+export const VideoClip: React.FC = (props) => {
   const { values, setFieldValue } = useFormikContext<IDataSourceModel>();
 
   React.useEffect(() => {
     ReactTooltip.rebuild();
+    if (!values.connection.fileName) {
+      setFieldValue('connection.fileName', '{schedule.Name}.mp4');
+    }
   });
 
   const timeZone = TimeZones.find((t) => t.value === values.connection.timeZone);
-  const language = Languages.find((t) => t.value === values.connection.language);
 
   return (
     <styled.MediaType>
@@ -27,22 +29,27 @@ export const AudioStream: React.FC = (props) => {
         defaultValue={timeZone}
       />
       <FormikText
-        label="Stream URL"
-        name="connection.url"
-        tooltip="URL to the source stream"
-        required
-      />
-      <FormikText
         label="Format"
         name="connection.format"
-        tooltip="Format of the stream"
-        placeholder="mp3"
+        tooltip="Format of the clip"
+        placeholder="mp4"
       />
       <FormikText
         label="File Name"
         name="connection.fileName"
         tooltip="File name and output format"
-        placeholder="{schedule.Name}.mp3"
+        placeholder="{schedule.Name}.mp4"
+      />
+      <FormikText
+        label="Copy Arguments"
+        name="connection.copy"
+        tooltip="Copy command arguments"
+        placeholder="-c:v copy -c:a copy"
+      />
+      <FormikText
+        label="Frame Rate"
+        name="connection.frameRate"
+        value={values.connection.frameRate}
       />
       <FormikText
         label="Volume"
@@ -55,11 +62,21 @@ export const AudioStream: React.FC = (props) => {
         name="connection.otherArgs"
         tooltip="Any other arguments to pass to the command"
       />
-      <FormikSelect
-        label="Language"
-        name="connection.language"
-        options={Languages}
-        defaultValue={language}
+      <FormikCheckbox
+        label="Retry prior schedules"
+        name="connection.keepChecking"
+        tooltip="Always check if earlier schedules have successfully generated clips (This is not performant)"
+        onChange={(e) => {
+          setFieldValue('connection.keepChecking', e.currentTarget.checked);
+        }}
+      />
+      <FormikCheckbox
+        label="Throw error on missing files"
+        name="connection.throwOnMissingFile"
+        tooltip="The service will throw an error if the capture file is not found or is missing data"
+        onChange={(e) => {
+          setFieldValue('connection.throwOnMissingFile', e.currentTarget.checked);
+        }}
       />
       {!!values.contentTypeId && (
         <>

--- a/app/editor/src/features/admin/sources/connections/VideoStream.tsx
+++ b/app/editor/src/features/admin/sources/connections/VideoStream.tsx
@@ -7,11 +7,14 @@ import ReactTooltip from 'react-tooltip';
 import { Languages, TimeZones } from './constants';
 import * as styled from './styled';
 
-export const AudioStream: React.FC = (props) => {
+export const VideoStream: React.FC = (props) => {
   const { values, setFieldValue } = useFormikContext<IDataSourceModel>();
 
   React.useEffect(() => {
     ReactTooltip.rebuild();
+    if (!values.connection.fileName) {
+      setFieldValue('connection.fileName', '{schedule.Name}.mp4');
+    }
   });
 
   const timeZone = TimeZones.find((t) => t.value === values.connection.timeZone);
@@ -36,13 +39,18 @@ export const AudioStream: React.FC = (props) => {
         label="Format"
         name="connection.format"
         tooltip="Format of the stream"
-        placeholder="mp3"
+        placeholder="mp4"
       />
       <FormikText
         label="File Name"
         name="connection.fileName"
         tooltip="File name and output format"
-        placeholder="{schedule.Name}.mp3"
+        placeholder="{schedule.Name}.mp4"
+      />
+      <FormikText
+        label="Frame Rate"
+        name="connection.frameRate"
+        value={values.connection.frameRate}
       />
       <FormikText
         label="Volume"

--- a/app/editor/src/features/admin/sources/connections/VideoTuner.tsx
+++ b/app/editor/src/features/admin/sources/connections/VideoTuner.tsx
@@ -1,0 +1,28 @@
+import { FormikSelect, FormikText } from 'components/formik';
+import { useFormikContext } from 'formik';
+import { IDataSourceModel } from 'hooks/api-editor';
+import React from 'react';
+
+import { TimeZones } from './constants';
+import * as styled from './styled';
+
+export const VideoTuner: React.FC = (props) => {
+  const { values } = useFormikContext<IDataSourceModel>();
+
+  return (
+    <styled.MediaType>
+      <FormikSelect label="Timezone" name="connection.timeZone" options={TimeZones} required />
+      <FormikText
+        label="Volume"
+        name="connection.volume"
+        tooltip="Volume in percent or dB (1 = 100%)"
+        placeholder="1"
+      />
+      <FormikText
+        label="Frequency"
+        name="connection.frequency"
+        value={values.connection.frequency}
+      />
+    </styled.MediaType>
+  );
+};

--- a/app/editor/src/features/admin/sources/connections/index.ts
+++ b/app/editor/src/features/admin/sources/connections/index.ts
@@ -7,3 +7,6 @@ export * from './Connection';
 export * from './Newspaper';
 export * from './Syndication';
 export * from './Video';
+export * from './VideoClip';
+export * from './VideoStream';
+export * from './VideoTuner';

--- a/app/editor/src/features/admin/sources/services/ServiceIngestSettings.tsx
+++ b/app/editor/src/features/admin/sources/services/ServiceIngestSettings.tsx
@@ -18,8 +18,6 @@ export const ServiceIngestSettings: React.FC<IServiceIngestSettingsProps> = () =
   const { values, setFieldValue } = useFormikContext<IDataSourceModel>();
   const [lookups] = useLookup();
 
-  // TODO: Need a more selective condition to determine if this section should be visible.
-  const showImportContent = values.connection.serviceType !== 'stream';
   const users = [
     new OptionItem('None', 0),
     ...lookups.users.map((u) => new OptionItem(u.username, u.id)),
@@ -81,23 +79,23 @@ export const ServiceIngestSettings: React.FC<IServiceIngestSettingsProps> = () =
             options={dataLocations}
             required
           />
-          {showImportContent && (
+          <FormikSelect
+            label="Generated Content Type"
+            name="contentTypeId"
+            tooltip="The type of content that is created when ingesting"
+            options={contentTypes}
+            onChange={handleContentTypeChange}
+            required={values.connection.serviceType === 'clip'}
+          />
+          <FormikSelect
+            label="Owner"
+            name="ownerId"
+            tooltip="The default user who will own ingested content"
+            options={users}
+            onChange={handleOwnerChange}
+          />
+          {values.contentTypeId !== 0 && (
             <>
-              <FormikSelect
-                label="Generated Content Type"
-                name="contentTypeId"
-                tooltip="The type of content that is created when ingesting"
-                options={contentTypes}
-                onChange={handleContentTypeChange}
-                required={values.connection.serviceType === 'clip'}
-              />
-              <FormikSelect
-                label="Owner"
-                name="ownerId"
-                tooltip="The default user who will own ingested content"
-                options={users}
-                onChange={handleOwnerChange}
-              />
               <FormikText label="Kafka Topic" name="topic" required={!!values.contentTypeId} />
               <div>
                 <p>

--- a/libs/net/dal/Models/ContentFileReference.cs
+++ b/libs/net/dal/Models/ContentFileReference.cs
@@ -111,7 +111,7 @@ public class ContentFileReference : IReadonlyFileReference
     /// <summary>
     /// Creates a new instance of a ContentFileReference, initializes with specified parameters.
     /// Use this to create a new FileReference.
-    /// Only use this contructor when the 'content' already exists in the database.
+    /// Only use this constructor when the 'content' already exists in the database.
     /// </summary>
     /// <param name="content"></param>
     /// <param name="file"></param>
@@ -147,7 +147,7 @@ public class ContentFileReference : IReadonlyFileReference
     /// <summary>
     /// Creates a new instance of a ContentFileReference, initializes with specified parameters.
     /// Use this to update an existing FileReference.
-    /// Only use this contructor when the 'content' already exists in the database.
+    /// Only use this constructor when the 'content' already exists in the database.
     /// </summary>
     /// <param name="fileReference"></param>
     /// <param name="file"></param>

--- a/libs/net/models/Extensions/ScheduleModelExtensions.cs
+++ b/libs/net/models/Extensions/ScheduleModelExtensions.cs
@@ -12,7 +12,7 @@ public static class ScheduleModelExtensions
     /// </summary>
     /// <param name="schedule"></param>
     /// <returns></returns>
-    public static TimeSpan CalcDuraction(this ScheduleModel schedule)
+    public static TimeSpan CalcDuration(this ScheduleModel schedule)
     {
         if (schedule.StartAt == null || schedule.StopAt == null) return new TimeSpan();
         var startAt = schedule.StartAt.Value;

--- a/libs/net/services/Actions/Managers/DataSourceIngestManager`.cs
+++ b/libs/net/services/Actions/Managers/DataSourceIngestManager`.cs
@@ -58,7 +58,7 @@ public class DataSourceIngestManager<TOptions> : ServiceActionManager<TOptions>,
         if (dataSource != null)
             this.DataSource = dataSource;
 
-        return VerifyDataSource() && this.DataSource.DataSourceSchedules.Where(s => s.Schedule != null).Any(s => VerifySchedule(GetSourceDateTime(DateTime.UtcNow), s.Schedule!));
+        return VerifyDataSource() && this.DataSource.DataSourceSchedules.Where(s => s.Schedule != null).Any(s => VerifySchedule(s.Schedule!));
     }
 
     /// <summary>
@@ -66,7 +66,7 @@ public class DataSourceIngestManager<TOptions> : ServiceActionManager<TOptions>,
     /// </summary>
     /// <param name="date"></param>
     /// <returns></returns>
-    protected virtual DateTime GetSourceDateTime(DateTime date)
+    public virtual DateTime GetSourceDateTime(DateTime date)
     {
         return date.ToTimeZone(GetTimeZone());
     }
@@ -108,6 +108,17 @@ public class DataSourceIngestManager<TOptions> : ServiceActionManager<TOptions>,
     public virtual bool VerifyDataSource()
     {
         return true;
+    }
+
+    /// <summary>
+    /// Determine if the schedule allows for the process to run at the specified 'date'.
+    /// Make certain the date is valid for the source timezone.
+    /// </summary>
+    /// <param name="schedule"></param>
+    /// <returns></returns>
+    public virtual bool VerifySchedule(ScheduleModel schedule)
+    {
+        return VerifySchedule(GetSourceDateTime(DateTime.UtcNow), schedule);
     }
 
     /// <summary>

--- a/libs/net/services/Interfaces/IDataSourceIngestManager.cs
+++ b/libs/net/services/Interfaces/IDataSourceIngestManager.cs
@@ -30,6 +30,14 @@ public interface IDataSourceIngestManager : IServiceActionManager
     /// Determine if the schedule allows for the process to run at the specified 'date'.
     /// Make certain the date is valid for the source timezone.
     /// </summary>
+    /// <param name="schedule"></param>
+    /// <returns></returns>
+    public bool VerifySchedule(ScheduleModel schedule);
+
+    /// <summary>
+    /// Determine if the schedule allows for the process to run at the specified 'date'.
+    /// Make certain the date is valid for the source timezone.
+    /// </summary>
     /// <param name="date"></param>
     /// <param name="schedule"></param>
     /// <returns></returns>

--- a/services/net/.devcontainer/Dockerfile
+++ b/services/net/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends procps curl ffmpeg
+    && apt-get -y install --no-install-recommends procps curl ffmpeg libc6-dev libgdiplus
 
 RUN su vscode -c "dotnet tool install --global dotnet-ef"
 # RUN dotnet tool update --global dotnet-ef

--- a/services/net/capture/CaptureDataSourceManager.cs
+++ b/services/net/capture/CaptureDataSourceManager.cs
@@ -33,7 +33,7 @@ public class CaptureDataSourceManager : CommandDataSourceManager<CaptureOptions>
     public override bool VerifyDataSource()
     {
         var url = this.DataSource.GetConnectionValue("url");
-        return !String.IsNullOrWhiteSpace(url);
+        return !String.IsNullOrWhiteSpace(url) && this.DataSource.IsEnabled;
     }
     #endregion
 }

--- a/services/net/capture/Config/CaptureOptions.cs
+++ b/services/net/capture/Config/CaptureOptions.cs
@@ -9,11 +9,6 @@ public class CaptureOptions : CommandOptions
 {
     #region Properties
     /// <summary>
-    /// get/set - The command to execute (i.e. ffmpeg).
-    /// </summary>
-    public string Command { get; set; } = "ffmpeg";
-
-    /// <summary>
     /// get/set - The path to store files.
     /// </summary>
     public string OutputPath { get; set; } = "";

--- a/services/net/capture/Dockerfile
+++ b/services/net/capture/Dockerfile
@@ -24,7 +24,7 @@ RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build
 FROM mcr.microsoft.com/dotnet/sdk:6.0 as deploy
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends procps curl ffmpeg
+    && apt-get -y install --no-install-recommends procps curl ffmpeg libc6-dev libgdiplus
 
 WORKDIR /app
 COPY --from=build /build .

--- a/services/net/capture/appsettings.json
+++ b/services/net/capture/appsettings.json
@@ -14,7 +14,7 @@
     "TimeZone": "UTC",
     "OutputPath": "/data/capture",
     "Command": "ffmpeg",
-    "MediaTypes": "Talk Radio"
+    "MediaTypes": "Talk Radio, Television"
   },
   "Auth": {
     "Keycloak": {

--- a/services/net/clip/Config/ClipOptions.cs
+++ b/services/net/clip/Config/ClipOptions.cs
@@ -9,11 +9,6 @@ public class ClipOptions : CommandOptions
 {
     #region Properties
     /// <summary>
-    /// get/set - The command to execute (i.e. ffmpeg).
-    /// </summary>
-    public string Command { get; set; } = "ffmpeg";
-
-    /// <summary>
     /// get/set - The path to captured files.
     /// </summary>
     public string CapturePath { get; set; } = "";

--- a/services/net/clip/Dockerfile
+++ b/services/net/clip/Dockerfile
@@ -24,7 +24,7 @@ RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build
 FROM mcr.microsoft.com/dotnet/sdk:6.0 as deploy
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends procps curl ffmpeg
+    && apt-get -y install --no-install-recommends procps curl ffmpeg libc6-dev libgdiplus
 
 WORKDIR /app
 COPY --from=build /build .

--- a/services/net/clip/appsettings.json
+++ b/services/net/clip/appsettings.json
@@ -15,7 +15,7 @@
     "CapturePath": "/data/capture",
     "OutputPath": "/data/clip",
     "Command": "ffmpeg",
-    "MediaTypes": "Talk Radio"
+    "MediaTypes": "Talk Radio, Television"
   },
   "Auth": {
     "Keycloak": {

--- a/services/net/command/CommandProcess.cs
+++ b/services/net/command/CommandProcess.cs
@@ -15,6 +15,11 @@ public class CommandProcess : ICommandProcess
     /// get/set - When the process was created.
     /// </summary>
     public DateTime CreatedOn { get; set; }
+
+    /// <summary>
+    /// get - Data included in the command process.
+    /// </summary>
+    public Dictionary<string, object> Data { get; } = new Dictionary<string, object>();
     #endregion
 
     #region Constructors
@@ -30,11 +35,33 @@ public class CommandProcess : ICommandProcess
     /// Creates a new instance of a CommandProcess object, initializes with specified paraemters.
     /// </summary>
     /// <param name="process"></param>
+    /// <param name="data"></param>
+    public CommandProcess(System.Diagnostics.Process process, KeyValuePair<string, object> data) : this(process, DateTime.Now, data)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of a CommandProcess object, initializes with specified paraemters.
+    /// </summary>
+    /// <param name="process"></param>
     /// <param name="createdOn"></param>
     public CommandProcess(System.Diagnostics.Process process, DateTime createdOn)
     {
         this.Process = process;
         this.CreatedOn = createdOn;
+    }
+
+    /// <summary>
+    /// Creates a new instance of a CommandProcess object, initializes with specified paraemters.
+    /// </summary>
+    /// <param name="process"></param>
+    /// <param name="createdOn"></param>
+    /// <param name="data"></param>
+    public CommandProcess(System.Diagnostics.Process process, DateTime createdOn, KeyValuePair<string, object> data)
+    {
+        this.Process = process;
+        this.CreatedOn = createdOn;
+        this.Data.Add(data.Key, data.Value);
     }
     #endregion
 }

--- a/services/net/command/Config/CommandOptions.cs
+++ b/services/net/command/Config/CommandOptions.cs
@@ -8,5 +8,9 @@ namespace TNO.Services.Command.Config;
 public class CommandOptions : IngestServiceOptions
 {
     #region Properties
+    /// <summary>
+    /// get/set - The command to execute (i.e. ffmpeg).
+    /// </summary>
+    public string Command { get; set; } = "";
     #endregion
 }

--- a/services/net/command/Dockerfile
+++ b/services/net/command/Dockerfile
@@ -21,7 +21,7 @@ RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build
 FROM mcr.microsoft.com/dotnet/sdk:6.0 as deploy
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends procps curl ffmpeg
+    && apt-get -y install --no-install-recommends procps curl ffmpeg libc6-dev libgdiplus
 
 WORKDIR /app
 COPY --from=build /build .

--- a/services/net/command/ICommandProcess.cs
+++ b/services/net/command/ICommandProcess.cs
@@ -15,5 +15,10 @@ public interface ICommandProcess
     /// get/set - When the process was created.
     /// </summary>
     public DateTime CreatedOn { get; set; }
+
+    /// <summary>
+    /// get - Data included in the command process.
+    /// </summary>
+    public Dictionary<string, object> Data { get; }
     #endregion
 }

--- a/services/net/content/Config/ContentOptions.cs
+++ b/services/net/content/Config/ContentOptions.cs
@@ -15,6 +15,11 @@ public class ContentOptions : ServiceOptions
     public string Topics { get; set; } = "";
 
     /// <summary>
+    /// get/set - The path to capture files.
+    /// </summary>
+    public string CapturePath { get; set; } = "";
+
+    /// <summary>
     /// get/set - The path to clip files.
     /// </summary>
     public string ClipPath { get; set; } = "";

--- a/services/net/content/appsettings.json
+++ b/services/net/content/appsettings.json
@@ -12,6 +12,7 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
     "TimeZone": "UTC",
+    "CapturePath": "/data/capture",
     "ClipPath": "/data/clip"
   },
   "Auth": {


### PR DESCRIPTION
While testing video capture and clip I discovered that the current architecture wouldn't work.  The original design was to have the Capture Service capture the stream and write to a file throughout the day.  Then the Clip Service would clip subsets from the active stream capture.  This works for audio, but not video regrettably.

The `ffmpeg` tool when capturing a video stream must fully complete the capture and close the file correctly before the file is usable.  This means if the process ends abruptly the file will be corrupt and will not play.  The Clips Service also cannot create a usable clip from the unfinished stream.

The Capture Service can now use the `Advanced Schedule`, which allows capturing smaller streams, which when complete will generate a clip.  While this doesn't solve corrupted file issues, it does allow us to create clips.

We'll need to look into fixing corrupted files at a later date.  All attempts so far haven't been unsuccessful.  It's not a bug with the current architecture or implementation, as it's simply a limitation of capturing a video stream.  There may be a better way to do it with `ffmpeg`, but currently I am unaware of any other way.

We can reduce risk of corrupted files and missing content simply by running multiple pods, and/or creating additional data sources that capture the full day stream.

> Had bad luck with rebase and conflicts this time.  I don't know what happened, but I've had to redo a lot of changes.  I hope I haven't forgotten or missed something...  I'll have to retest again tomorrow.