### PR TITLE
TNO-315: React 18 Warning

### DIFF
--- a/app/editor/src/features/login/UserInfo.tsx
+++ b/app/editor/src/features/login/UserInfo.tsx
@@ -26,7 +26,8 @@ export const UserInfo: React.FC<IUserInfoProps> = ({ children }) => {
       appStore.storeUserInfo();
       setInit(true);
     }
-  }, [app, appStore, keycloak.authenticated, init]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [appStore, keycloak.authenticated, init]);
 
   return <>{children}</>;
 };

--- a/app/editor/src/index.tsx
+++ b/app/editor/src/index.tsx
@@ -1,7 +1,7 @@
 import './index.scss';
 
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { store } from 'store';
 import { ThemeProvider } from 'styled-components';
@@ -11,21 +11,21 @@ import App from './App';
 import css from './css/_variables.module.scss';
 import * as serviceWorker from './serviceWorker';
 
+/** TODO: Enable React.StrictMode when keycloak fix is released. */
 const Index = () => {
   return (
-    <React.StrictMode>
-      <ThemeProvider theme={{ css }}>
-        <Provider store={store}>
-          <SummonProvider>
-            <App />
-          </SummonProvider>
-        </Provider>
-      </ThemeProvider>
-    </React.StrictMode>
+    <ThemeProvider theme={{ css }}>
+      <Provider store={store}>
+        <SummonProvider>
+          <App />
+        </SummonProvider>
+      </Provider>
+    </ThemeProvider>
   );
 };
 
-ReactDOM.render(<Index />, document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById('root')!);
+root.render(<Index />);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.


### PR DESCRIPTION
`StrictMode` creates an infinite loop with `Keycloak`, to get the benefits of React 18 we can temporarily remove `StrictMode` until a fix is pushed for this. Not sure which one is more beneficial for us.

I also tried moving StrictMode to a different location, which seemed to work; however, an error toast was constantly appearing saying "Data may have changed, please refresh to confirm".

Also after the change `UserInfo` was causing an infinite loop with the app dependency. 