### PR TITLE
TNO-405: Time log table displaying wrong month

### DIFF
--- a/app/editor/src/features/content/form/constants/timeLogColumns.tsx
+++ b/app/editor/src/features/content/form/constants/timeLogColumns.tsx
@@ -36,7 +36,9 @@ export const timeLogColumns = (
     Cell: ({ value }: any) => {
       const date = new Date(value);
       return (
-        <div className="center">{`${date.getMonth()}/${date.getDate()}/${date.getFullYear()}`}</div>
+        <div className="center">{`${
+          date.getMonth() + 1
+        }/${date.getDate()}/${date.getFullYear()}`}</div>
       );
     },
   },


### PR DESCRIPTION
`date.getMonth()` is 0 indexed so we have to add +1 for desired output 