### PR TITLE
TNO-430: Hidden expand button on combined view

### DIFF
--- a/app/editor/src/components/form/formpage/FormPage.tsx
+++ b/app/editor/src/components/form/formpage/FormPage.tsx
@@ -3,6 +3,9 @@ import { InputHTMLAttributes } from 'react';
 import * as styled from './styled';
 
 export interface IFormPageProps extends InputHTMLAttributes<HTMLDivElement> {
+  /** bypass the default min width */
+  bypassMinWidth?: boolean;
+  /** include contents of form page */
   children: React.ReactNode;
 }
 /** Provides a consistent white background "page" used throughout the application */

--- a/app/editor/src/components/form/formpage/styled/FormPage.tsx
+++ b/app/editor/src/components/form/formpage/styled/FormPage.tsx
@@ -5,7 +5,7 @@ import { IFormPageProps } from '../FormPage';
 export const FormPage = styled.div<IFormPageProps>`
   background-color: white;
   min-height: 100%;
-  min-width: 1200px;
+  min-width: ${(props) => !props.bypassMinWidth && '1200px'};
   padding: 0.5em 2em 0 2em;
   margin: 0px auto;
 `;

--- a/app/editor/src/features/content/form/CondensedContentForm.tsx
+++ b/app/editor/src/features/content/form/CondensedContentForm.tsx
@@ -148,7 +148,7 @@ export const CondensedContentForm: React.FC<ICondensedContentFormProps> = ({
 
   return (
     <styled.ContentForm>
-      <FormPage className="condensed">
+      <FormPage bypassMinWidth className="condensed">
         <Area>
           <FormikForm
             onSubmit={handleSubmit}


### PR DESCRIPTION
Add way to bypass `min-width` on the `FormPage` component, this also returns the combined view to the proper styling