### PR TITLE
TNO-425: Fix the add a tag error

### DIFF
--- a/app/editor/src/features/admin/actions/ActionForm.tsx
+++ b/app/editor/src/features/admin/actions/ActionForm.tsx
@@ -22,7 +22,7 @@ export const ActionForm: React.FC = () => {
   const { id } = useParams();
   const navigate = useNavigate();
   const actionId = Number(id);
-  const [action, setAction] = React.useState<IActionModel>((state as any)?.series ?? defaultAction);
+  const [action, setAction] = React.useState<IActionModel>((state as any)?.action ?? defaultAction);
 
   const { toggle, isShowing } = useModal();
 

--- a/app/editor/src/features/admin/categories/CategoryForm.tsx
+++ b/app/editor/src/features/admin/categories/CategoryForm.tsx
@@ -22,7 +22,7 @@ export const CategoryForm: React.FC = () => {
   const navigate = useNavigate();
   const categoryId = Number(id);
   const [category, setCategory] = React.useState<ICategoryModel>(
-    (state as any)?.series ?? defaultCategory,
+    (state as any)?.category ?? defaultCategory,
   );
 
   const { toggle, isShowing } = useModal();
@@ -137,7 +137,7 @@ export const CategoryForm: React.FC = () => {
                 try {
                   await api.deleteCategory(category);
                   toast.success(`${category.name} has successfully been deleted.`);
-                  navigate('/admin/media/types');
+                  navigate('/admin/categories');
                 } finally {
                   toggle();
                 }

--- a/app/editor/src/features/admin/tags/TagListFilter.tsx
+++ b/app/editor/src/features/admin/tags/TagListFilter.tsx
@@ -16,7 +16,7 @@ export const TagListFilter: React.FC<IAdminFilterProps> = ({ setGlobalFilter }) 
         <IconButton
           iconType="plus"
           label={`Add new tag`}
-          onClick={() => navigate(`/admin/tags/0`)}
+          onClick={() => navigate(`/admin/tags/NEW`)}
         />
       </Row>
       <Row className="filter-bar" justifyContent="center">


### PR DESCRIPTION
As tags behave slightly differently than admin areas with a string id, there was some incorrect behaviour when creating a new one. 

i.e) `useEffect` loop firing when it is not supposed to because `undefined !== 0`

Can now create a new tag as expected, form will submit the name value as the id. Also fixed some copy paste errors I ran into.