### PR TITLE
Fix logging invalid characters

### DIFF
--- a/api/net/appsettings.json
+++ b/api/net/appsettings.json
@@ -1,6 +1,9 @@
 {
   "BaseUrl": "/",
   "Logging": {
+    "Console": {
+      "DisableColors": true
+    },
     "LogLevel": {
       "Default": "Warning",
       "Microsoft": "Error",

--- a/services/net/capture/appsettings.json
+++ b/services/net/capture/appsettings.json
@@ -1,6 +1,9 @@
 {
   "BaseUrl": "/",
   "Logging": {
+    "Console": {
+      "DisableColors": true
+    },
     "LogLevel": {
       "Default": "Warning",
       "Microsoft": "Error",

--- a/services/net/clip/appsettings.json
+++ b/services/net/clip/appsettings.json
@@ -1,6 +1,9 @@
 {
   "BaseUrl": "/",
   "Logging": {
+    "Console": {
+      "DisableColors": true
+    },
     "LogLevel": {
       "Default": "Warning",
       "Microsoft": "Error",

--- a/services/net/content/appsettings.json
+++ b/services/net/content/appsettings.json
@@ -1,6 +1,9 @@
 {
   "BaseUrl": "/",
   "Logging": {
+    "Console": {
+      "DisableColors": true
+    },
     "LogLevel": {
       "Default": "Warning",
       "Microsoft": "Error",

--- a/services/net/image/appsettings.json
+++ b/services/net/image/appsettings.json
@@ -1,6 +1,9 @@
 {
   "BaseUrl": "/",
   "Logging": {
+    "Console": {
+      "DisableColors": true
+    },
     "LogLevel": {
       "Default": "Warning",
       "Microsoft": "Error",

--- a/services/net/indexing/appsettings.json
+++ b/services/net/indexing/appsettings.json
@@ -1,6 +1,9 @@
 {
   "BaseUrl": "/",
   "Logging": {
+    "Console": {
+      "DisableColors": true
+    },
     "LogLevel": {
       "Default": "Warning",
       "Microsoft": "Error",

--- a/services/net/nlp/appsettings.json
+++ b/services/net/nlp/appsettings.json
@@ -1,6 +1,9 @@
 {
   "BaseUrl": "/",
   "Logging": {
+    "Console": {
+      "DisableColors": true
+    },
     "LogLevel": {
       "Default": "Warning",
       "Microsoft": "Error",

--- a/services/net/syndication/appsettings.json
+++ b/services/net/syndication/appsettings.json
@@ -1,6 +1,9 @@
 {
   "BaseUrl": "/",
   "Logging": {
+    "Console": {
+      "DisableColors": true
+    },
     "LogLevel": {
       "Default": "Warning",
       "Microsoft": "Error",

--- a/services/net/transcription/appsettings.json
+++ b/services/net/transcription/appsettings.json
@@ -1,6 +1,9 @@
 {
   "BaseUrl": "/",
   "Logging": {
+    "Console": {
+      "DisableColors": true
+    },
     "LogLevel": {
       "Default": "Warning",
       "Microsoft": "Error",


### PR DESCRIPTION
All of our .NET container logs had invalid characters.  It appears this may be the result of console messages that contain colour information.  I'm turning colour off and testing.