### PR TITLE
TNO-520: Breadcrumb trail for clips

### DIFF
--- a/app/editor/src/components/breadcrumb/Breadcrumb.tsx
+++ b/app/editor/src/components/breadcrumb/Breadcrumb.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-import * as styled from './styled';
+import * as styled from '../../features/content/form/styled';
 export interface IBreadcrumbProps {
   /** the current path being viewed in the clip explorer */
   path: string;

--- a/app/editor/src/components/breadcrumb/index.ts
+++ b/app/editor/src/components/breadcrumb/index.ts
@@ -1,0 +1,1 @@
+export * from './Breadcrumb';

--- a/app/editor/src/components/breadcrumb/styled/Breadcrumb.tsx
+++ b/app/editor/src/components/breadcrumb/styled/Breadcrumb.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+import { Row } from 'tno-core';
+
+export const Breadcrumb = styled(Row)`
+  .clickeable {
+    color: ${(props) => props.theme.css.primaryLightColor};
+    cursor: pointer;
+    :after {
+      content: '\u00A0>\u00A0';
+      color: ${(props) => props.theme.css.textColor};
+      font-weight: bold;
+    }
+  }
+  .current {
+    cursor: default;
+  }
+`;

--- a/app/editor/src/components/breadcrumb/styled/index.ts
+++ b/app/editor/src/components/breadcrumb/styled/index.ts
@@ -1,0 +1,1 @@
+export * from './Breadcrumb';

--- a/app/editor/src/features/content/form/Breadcrumb.tsx
+++ b/app/editor/src/features/content/form/Breadcrumb.tsx
@@ -13,7 +13,7 @@ export interface IBreadcrumbProps {
  *  search params to the current directory
  */
 export const Breadcrumb: React.FC<IBreadcrumbProps> = ({ path, setPath }) => {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [, setSearchParams] = useSearchParams();
   /** split path into array in order to display breadcrumb as individual items */
   let splitPath = path.split('/').filter((s) => !!s);
   const checkPath = (index: number, item: string) => {

--- a/app/editor/src/features/content/form/Breadcrumb.tsx
+++ b/app/editor/src/features/content/form/Breadcrumb.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import * as styled from './styled';
+export interface IBreadcrumbProps {
+  /** the current path being viewed in the clip explorer */
+  path: string;
+  /** set path of the parent component */
+  setPath: (path: string) => void;
+}
+
+/** component used to navigate state controlled path directory, also updates the
+ *  search params to the current directory
+ */
+export const Breadcrumb: React.FC<IBreadcrumbProps> = ({ path, setPath }) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  /** split path into array in order to display breadcrumb as individual items */
+  let splitPath = path.split('/').filter((s) => !!s);
+  const checkPath = (index: number, item: string) => {
+    if (index === 0) setPath(`${item}`);
+    /** last item not clickeable */
+    if (index !== splitPath.length - 1) setPath(splitPath.slice(0, index + 1).join('/'));
+  };
+  useEffect(() => {
+    setSearchParams({ path: path });
+  }, [path, setSearchParams]);
+  return (
+    <styled.Breadcrumb>
+      {splitPath.map((i: string, index: number) => (
+        <p
+          className={index !== splitPath.length - 1 ? 'clickeable' : 'current'}
+          onClick={() => checkPath(index, i)}
+        >
+          {i}
+        </p>
+      ))}
+    </styled.Breadcrumb>
+  );
+};

--- a/app/editor/src/features/content/form/ContentClipForm.tsx
+++ b/app/editor/src/features/content/form/ContentClipForm.tsx
@@ -1,3 +1,4 @@
+import { Breadcrumb } from 'components/breadcrumb';
 import { Modal } from 'components/modal';
 import { useFormikContext } from 'formik';
 import { IFileReferenceModel, IFolderModel, IItemModel } from 'hooks/api-editor';
@@ -8,7 +9,6 @@ import { useContent, useStorage } from 'store/hooks';
 import { Button, ButtonVariant, Col, Row, Text } from 'tno-core';
 
 import { defaultFolder } from '../../storage/constants';
-import { Breadcrumb } from './Breadcrumb';
 import { ClipDirectoryTable } from './ClipDirectoryTable';
 import { IContentForm } from './interfaces';
 import * as styled from './styled';

--- a/app/editor/src/features/content/form/ContentClipForm.tsx
+++ b/app/editor/src/features/content/form/ContentClipForm.tsx
@@ -8,6 +8,7 @@ import { useContent, useStorage } from 'store/hooks';
 import { Button, ButtonVariant, Col, Row, Text } from 'tno-core';
 
 import { defaultFolder } from '../../storage/constants';
+import { Breadcrumb } from './Breadcrumb';
 import { ClipDirectoryTable } from './ClipDirectoryTable';
 import { IContentForm } from './interfaces';
 import * as styled from './styled';
@@ -166,18 +167,10 @@ export const ContentClipForm: React.FC<IContentClipFormProps> = ({
     }
   };
 
-  const navigateUp = () => {
-    var path = folder.path.split('/').filter((v) => !!v);
-    if (path.length <= 1) setPath('/');
-    else setPath(path.slice(0, -1).join('/'));
-  };
-
   return (
     <styled.ContentClipForm>
       <div>
-        <Button className="navigate-up" onClick={() => navigateUp()} name="navigateUp">
-          Directory: {folder.path}
-        </Button>
+        <Breadcrumb path={folder.path} setPath={setPath} />
       </div>
       <Row>
         <Col flex="1 1 100%">

--- a/app/editor/src/features/content/form/styled/Breadcrumb.tsx
+++ b/app/editor/src/features/content/form/styled/Breadcrumb.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+import { Row } from 'tno-core';
+
+export const Breadcrumb = styled(Row)`
+  .clickeable {
+    color: ${(props) => props.theme.css.primaryLightColor};
+    cursor: pointer;
+    :after {
+      content: '\u00A0>\u00A0';
+      color: ${(props) => props.theme.css.textColor};
+      font-weight: bold;
+    }
+  }
+  .current {
+    cursor: default;
+  }
+`;

--- a/app/editor/src/features/content/form/styled/index.ts
+++ b/app/editor/src/features/content/form/styled/index.ts
@@ -1,3 +1,4 @@
+export * from './Breadcrumb';
 export * from './ClipDirectoryTable';
 export * from './ContentClipForm';
 export * from './ContentForm';


### PR DESCRIPTION
Having some bugs with the query params after latest changes, removed for now as breadcrumb functionality works. Query params will update but do not control state currently. Will create ticket to capture this.

Also ended up just making our own component, seemed to fit better for our scenario. 

![breadcrumb](https://user-images.githubusercontent.com/15724124/188214196-3ff4dc23-232e-4010-9f8d-566b2b165f87.gif)
