### PR TITLE
Minor clip styling

### DIFF
--- a/app/editor/src/features/content/form/ContentClipForm.tsx
+++ b/app/editor/src/features/content/form/ContentClipForm.tsx
@@ -194,28 +194,26 @@ export const ContentClipForm: React.FC<IContentClipFormProps> = ({
         </Col>
       </Row>
       <div className={!streamUrl ? 'hidden' : ''}>
-        <Row>
-          <Col className="video" alignItems="stretch">
-            <video ref={videoRef} controls>
-              <source type="audio/m4a" />
-              <source type="audio/flac" />
-              <source type="audio/mp3" />
-              <source type="audio/mp4" />
-              <source type="audio/wav" />
-              <source type="audio/wma" />
-              <source type="audio/aac" />
-              <source type="video/wmv" />
-              <source type="video/mov" />
-              <source type="video/mpeg" />
-              <source type="video/mpg" />
-              <source type="video/avi" />
-              <source type="video/mp4" />
-              <source type="video/gif" />
-              HTML5 Video is required for this example
-            </video>
-          </Col>
+        <Row className="video" justifyContent="center">
+          <video ref={videoRef} controls>
+            <source type="audio/m4a" />
+            <source type="audio/flac" />
+            <source type="audio/mp3" />
+            <source type="audio/mp4" />
+            <source type="audio/wav" />
+            <source type="audio/wma" />
+            <source type="audio/aac" />
+            <source type="video/wmv" />
+            <source type="video/mov" />
+            <source type="video/mpeg" />
+            <source type="video/mpg" />
+            <source type="video/avi" />
+            <source type="video/mp4" />
+            <source type="video/gif" />
+            HTML5 Video is required for this example
+          </video>
         </Row>
-        <Row className="video-buttons">
+        <Row className="video-buttons" justifyContent="center">
           <Col>
             <p className="start-end">Start: {start}</p>
             <Button

--- a/app/editor/src/features/content/form/constants/clipDirectoryColumns.tsx
+++ b/app/editor/src/features/content/form/constants/clipDirectoryColumns.tsx
@@ -8,7 +8,7 @@ import {
   FaRegFolder,
   FaTrash,
 } from 'react-icons/fa';
-import { Column } from 'react-table';
+import { Column, UseSortByColumnOptions } from 'react-table';
 import { Col, Row } from 'tno-core';
 
 /** columns located within file for state manipulation */
@@ -18,11 +18,12 @@ export const clipDirectoryColumns = (
   onDownload: Function,
   onAttach: Function,
   values: IItemModel,
-): Column<IItemModel>[] => [
+): Column<IItemModel>[] & UseSortByColumnOptions<IItemModel> => [
   {
     id: 'isDirectory',
     Header: () => <div className="list-icon"></div>,
     accessor: 'isDirectory',
+    disableSortBy: true,
     Cell: ({ row, value }) => (
       <div>
         <div className={row.values.isDirectory ? 'hidden' : 'center'}>
@@ -40,6 +41,7 @@ export const clipDirectoryColumns = (
     Header: () => <div className="center">Filename</div>,
     accessor: 'name',
     Cell: ({ value }) => <div className="ft-row">{value}</div>,
+    width: 125,
   },
   {
     id: 'size',

--- a/app/editor/src/features/content/form/styled/ContentClipForm.tsx
+++ b/app/editor/src/features/content/form/styled/ContentClipForm.tsx
@@ -31,10 +31,6 @@ export const ContentClipForm = styled.div`
     }
   }
 
-  .video {
-    width: 100%;
-  }
-
   .video-buttons {
     margin-top: 20px;
   }
@@ -77,13 +73,9 @@ export const ContentClipForm = styled.div`
     color: red;
   }
 
-  .video {
-    min-height: max-content;
-  }
-
   video {
-    height: calc(100% - 0.5em);
-    width: auto;
+    height: 270px;
+    width: 480px;
   }
 
   .header {


### PR DESCRIPTION
Minor styling tweaks to the clip tab on the content form. Just decided to quickly tweak them as I was working on warnings in this area. 

PR Includes:

- removal of sort icon above icons
- video centered and does not expand screen
- horizontal scroll removed 
- slight dom cleanup

![image](https://user-images.githubusercontent.com/15724124/188575793-dd36d4da-5e56-4ecf-af0b-3a057a5317de.png)

Zoomed at 100% on 1920x1080:
![image](https://user-images.githubusercontent.com/15724124/188576522-051a4a9e-5761-4e08-b9d1-7efc25d6084c.png)


