### PR TITLE
Fix data source bug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,6 +38,40 @@
       // Use IntelliSense to find out which attributes exist for C# debugging
       // Use hover for the description of the existing attributes
       // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+      "name": "Run Capture Service",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build-capture",
+      // If you have changed target frameworks, make sure to update the program path.
+      "program": "${workspaceFolder}/services/net/capture/bin/Debug/net6.0/TNO.Services.Capture.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/services/net/capture",
+      // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+      "console": "internalConsole",
+      "stopAtEntry": false,
+      "envFile": "${workspaceFolder}/services/net/capture/.env"
+    },
+    {
+      // Use IntelliSense to find out which attributes exist for C# debugging
+      // Use hover for the description of the existing attributes
+      // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+      "name": "Run Clip Service",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build-clip",
+      // If you have changed target frameworks, make sure to update the program path.
+      "program": "${workspaceFolder}/services/net/clip/bin/Debug/net6.0/TNO.Services.Clip.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/services/net/clip",
+      // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+      "console": "internalConsole",
+      "stopAtEntry": false,
+      "envFile": "${workspaceFolder}/services/net/clip/.env"
+    },
+    {
+      // Use IntelliSense to find out which attributes exist for C# debugging
+      // Use hover for the description of the existing attributes
+      // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
       "name": "Run Content Service",
       "type": "coreclr",
       "request": "launch",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -74,6 +74,78 @@
       "problemMatcher": "$msCompile"
     },
     {
+      "label": "build-capture",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/services/net/capture/TNO.Services.Capture.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish-capture",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/services/net/capture/TNO.Services.Capture.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch-capture",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "--project",
+        "${workspaceFolder}/services/net/capture/TNO.Services.Capture.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "build-clip",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/services/net/clip/TNO.Services.Clip.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish-clip",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/services/net/clip/TNO.Services.Clip.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch-clip",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "--project",
+        "${workspaceFolder}/services/net/clip/TNO.Services.Clip.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
       "label": "build-content",
       "command": "dotnet",
       "type": "process",

--- a/api/net/Areas/Services/Controllers/DataSourceController.cs
+++ b/api/net/Areas/Services/Controllers/DataSourceController.cs
@@ -73,7 +73,7 @@ public class DataSourceController : ControllerBase
     [SwaggerOperation(Tags = new[] { "DataSource" })]
     public IActionResult FindByMediaType(string mediaTypeName)
     {
-        var result = _serviceDataSource.FindByMediaType(mediaTypeName);
+        var result = _serviceDataSource.FindByMediaType(mediaTypeName, true);
         return new JsonResult(result.Select(ds => new DataSourceModel(ds, _serializerOptions)));
     }
 

--- a/libs/net/dal/Services/DataSourceService.cs
+++ b/libs/net/dal/Services/DataSourceService.cs
@@ -32,7 +32,7 @@ public class DataSourceService : BaseService<DataSource, int>, IDataSourceServic
     #region Methods
     /// <summary>
     /// Find and return all the data sources.
-    /// Removes connection information with possible secrets.
+    /// Removes connection information with possible secrets by default.
     /// </summary>
     /// <param name="includeConnection">Whether or not to include connection information</param>
     /// <returns></returns>
@@ -49,6 +49,7 @@ public class DataSourceService : BaseService<DataSource, int>, IDataSourceServic
             .ThenBy(ds => ds.Name)
             .ToArray();
 
+        /// TODO: Only allow admin to include connection information.
         return includeConnection ? result : result
             .Select(ds =>
             {
@@ -112,13 +113,14 @@ public class DataSourceService : BaseService<DataSource, int>, IDataSourceServic
 
     /// <summary>
     /// Find and return all data sources that match the specified 'mediaTypeName'.
-    /// Removes connection information with possible secrets.
+    /// Removes connection information with possible secrets by default.
     /// </summary>
-    /// <param name="mediaTypeName"></param>
+    /// <param name="mediaTypeName">Name of media type</param>
+    /// <param name="includeConnection">Whether or not to include connection information</param>
     /// <returns></returns>
-    public IEnumerable<DataSource> FindByMediaType(string mediaTypeName)
+    public IEnumerable<DataSource> FindByMediaType(string mediaTypeName, bool includeConnection)
     {
-        return this.Context.DataSources
+        var result = this.Context.DataSources
             .AsNoTracking()
             .Include(ds => ds.ContentType)
             .Include(ds => ds.DataLocation)
@@ -129,7 +131,11 @@ public class DataSourceService : BaseService<DataSource, int>, IDataSourceServic
             .Include(ds => ds.MetricsManyToMany).ThenInclude(cc => cc.SourceMetric)
             .Include(ds => ds.SchedulesManyToMany).ThenInclude(ct => ct.Schedule)
             .Where(ds => ds.MediaType!.Name.ToLower() == mediaTypeName.ToLower())
-            .ToArray().Select(ds =>
+            .ToArray();
+
+        /// TODO: Only allow admin to include connection information.
+        return includeConnection ? result : result
+            .Select(ds =>
             {
                 ds.Connection = "{}";
                 return ds;

--- a/libs/net/dal/Services/Interfaces/IDataSourceService.cs
+++ b/libs/net/dal/Services/Interfaces/IDataSourceService.cs
@@ -10,6 +10,6 @@ public interface IDataSourceService : IBaseService<DataSource, int>
     IEnumerable<DataSource> FindAll(bool includeConnection = false);
     IPaged<DataSource> Find(DataSourceFilter filter);
     DataSource? FindByCode(string code);
-    IEnumerable<DataSource> FindByMediaType(string mediaTypeName);
+    IEnumerable<DataSource> FindByMediaType(string mediaTypeName, bool includeConnection = false);
     DataSource Update(DataSource entity, bool updateChildren = false);
 }

--- a/libs/net/kafka/KafkaListener`.cs
+++ b/libs/net/kafka/KafkaListener`.cs
@@ -141,6 +141,8 @@ public class KafkaListener<TKey, TValue> : IKafkaListener<TKey, TValue>, IDispos
             if (!this.IsReady) throw new InvalidOperationException("Consumer is not ready for consuming, it must be opened first.");
 
             this.IsConsuming = true;
+            _logger.LogDebug("Waiting to receive message from Kafka topics:'{topic}'", String.Join(", ", this.Consumer.Subscription));
+
             // I don't understand why Kafka didn't use an async+await pattern here, but this function blocks until it receives a message.
             result = this.Consumer.Consume(cancellationToken);
 

--- a/services/net/capture/CaptureAction.cs
+++ b/services/net/capture/CaptureAction.cs
@@ -45,7 +45,6 @@ public class CaptureAction : CommandAction<CaptureOptions>
     #region Methods
     /// <summary>
     /// Perform the ingestion service action.
-    ///
     /// </summary>
     /// <param name="manager"></param>
     /// <param name="name"></param>


### PR DESCRIPTION
I introduced a bug when I removed data source connection information from the service endpoints.  Our ingest services require the connection information to determine if they should run.  It's not ideal including the connection information in the generic endpoints as it can contain secrets.  To secure these endpoints we'll need to add claim based authorization in another PR.

I've also added the Capture and Clip Services to the root launch file so we can run them outside of a devcontainer.