### PR TITLE
TNO-577: Allow access from iOS

### DIFF
--- a/app/editor/src/features/content/form/ContentSummaryForm.tsx
+++ b/app/editor/src/features/content/form/ContentSummaryForm.tsx
@@ -20,7 +20,7 @@ import * as styled from './styled';
 import { TimeLogTable } from './TimeLogTable';
 import { getTotalTime } from './utils';
 
-const tagMatch = /(?<=\[).+?(?=\])/g;
+const tagMatch = /(?!\[).+?(?=\])/g;
 export interface IContentSummaryFormProps {
   setContent: (content: IContentForm) => void;
   content: IContentForm;


### PR DESCRIPTION
Very underwhelming fix....

Positive lookbehind `(?<= )` causing a failure to load on iOS Safari

See: https://caniuse.com/js-regexp-lookbehind