### PR TITLE
Fix Kafka Consumer Services

### DIFF
--- a/libs/net/core/Exceptions/HttpClientRequestException.cs
+++ b/libs/net/core/Exceptions/HttpClientRequestException.cs
@@ -46,7 +46,7 @@ namespace TNO.Core.Exceptions
         /// </summary>
         /// <param name="response"></param>
         /// <returns></returns>
-        public HttpClientRequestException(HttpResponseMessage response) : base($"HTTP Request '{response?.RequestMessage?.RequestUri}' failed", null, response?.StatusCode)
+        public HttpClientRequestException(HttpResponseMessage response) : base($"HTTP Request {response?.StatusCode}:'{response?.RequestMessage?.RequestUri}' failed", null, response?.StatusCode)
         {
             this.Response = response ?? throw new ArgumentNullException(nameof(response)); // NOSONAR
             var body = response.Content.ReadAsStringAsync().Result;
@@ -70,7 +70,7 @@ namespace TNO.Core.Exceptions
         /// </summary>
         /// <param name="response"></param>
         /// <returns></returns>
-        public HttpClientRequestException(HttpResponseMessage response, Exception innerException) : base($"HTTP Request '{response?.RequestMessage?.RequestUri}' failed", innerException, response?.StatusCode)
+        public HttpClientRequestException(HttpResponseMessage response, Exception innerException) : base($"HTTP Request {response?.StatusCode}:'{response?.RequestMessage?.RequestUri}' failed", innerException, response?.StatusCode)
         {
             this.Response = response ?? throw new ArgumentNullException(nameof(response)); // NOSONAR
             var body = response.Content.ReadAsStringAsync().Result;

--- a/openshift/kustomize/api/build/base/build.yaml
+++ b/openshift/kustomize/api/build/base/build.yaml
@@ -55,5 +55,5 @@ spec:
       cpu: 250m
       memory: 250Mi
     limits:
-      cpu: 2000m
+      cpu: 1500m
       memory: 2Gi

--- a/openshift/kustomize/app/editor/build/base/build.yaml
+++ b/openshift/kustomize/app/editor/build/base/build.yaml
@@ -55,5 +55,5 @@ spec:
       cpu: 250m
       memory: 500Mi
     limits:
-      cpu: 2000m
+      cpu: 1500m
       memory: 3Gi

--- a/openshift/kustomize/db-migration/build/base/build.yaml
+++ b/openshift/kustomize/db-migration/build/base/build.yaml
@@ -52,5 +52,5 @@ spec:
       name: db-migration:latest
   resources:
     limits:
-      cpu: 1000m
+      cpu: 1500m
       memory: 500Mi

--- a/openshift/templates/tekton/pipelines/complete.yaml
+++ b/openshift/templates/tekton/pipelines/complete.yaml
@@ -141,6 +141,8 @@ objects:
               value: $(params.IMAGE_TAG)
 
         - name: build-api
+          runAfter:
+            - build-db-migration
           taskRef:
             name: oc-build
             kind: Task
@@ -153,6 +155,8 @@ objects:
               value: $(params.IMAGE_TAG)
 
         - name: build-app
+          runAfter:
+            - build-api
           taskRef:
             name: oc-build
             kind: Task

--- a/services/net/indexing/IndexingManager.cs
+++ b/services/net/indexing/IndexingManager.cs
@@ -113,13 +113,7 @@ public class IndexingManager : ServiceManager<IndexingOptions>
                     {
                         if (!this.Consumer.IsReady) this.Consumer.Open();
                         this.Consumer.Subscribe(topics);
-
-                        // Create a new thread if the prior one isn't running anymore.
-                        if (_consumer == null || _notRunning.Contains(_consumer.Status))
-                        {
-                            _cancelToken = new CancellationTokenSource();
-                            _consumer = Task.Factory.StartNew(() => ConsumerHandler(), _cancelToken.Token);
-                        }
+                        ConsumeMessages();
                     }
                     else if (topics.Length == 0)
                     {
@@ -139,6 +133,19 @@ public class IndexingManager : ServiceManager<IndexingOptions>
             this.Logger.LogDebug("Service sleeping for {delay:n0} ms", delay);
             // await Thread.Sleep(new TimeSpan(0, 0, 0, delay));
             await Task.Delay(delay);
+        }
+    }
+
+    /// <summary>
+    /// Creates a new cancellation token.
+    /// Create a new thread if the prior one isn't running anymore.
+    /// </summary>
+    private void ConsumeMessages()
+    {
+        if (_consumer == null || _notRunning.Contains(_consumer.Status))
+        {
+            _cancelToken = new CancellationTokenSource();
+            _consumer = Task.Factory.StartNew(() => ConsumerHandler(), _cancelToken.Token);
         }
     }
 

--- a/services/net/nlp/NLPManager.cs
+++ b/services/net/nlp/NLPManager.cs
@@ -87,13 +87,7 @@ public class NLPManager : ServiceManager<NLPOptions>
                     {
                         if (!this.Consumer.IsReady) this.Consumer.Open();
                         this.Consumer.Subscribe(topics);
-
-                        // Create a new thread if the prior one isn't running anymore.
-                        if (_consumer == null || _notRunning.Contains(_consumer.Status))
-                        {
-                            _cancelToken = new CancellationTokenSource();
-                            _consumer = Task.Factory.StartNew(() => ConsumerHandler(), _cancelToken.Token);
-                        }
+                        ConsumeMessages();
                     }
                     else if (topics.Length == 0)
                     {
@@ -110,6 +104,19 @@ public class NLPManager : ServiceManager<NLPOptions>
             // The delay ensures we don't have a run away thread.
             this.Logger.LogDebug("Service sleeping for {delay} ms", delay);
             await Task.Delay(delay);
+        }
+    }
+
+    /// <summary>
+    /// Creates a new cancellation token.
+    /// Create a new thread if the prior one isn't running anymore.
+    /// </summary>
+    private void ConsumeMessages()
+    {
+        if (_consumer == null || _notRunning.Contains(_consumer.Status))
+        {
+            _cancelToken = new CancellationTokenSource();
+            _consumer = Task.Factory.StartNew(() => ConsumerHandler(), _cancelToken.Token);
         }
     }
 

--- a/services/net/transcription/TranscriptionManager.cs
+++ b/services/net/transcription/TranscriptionManager.cs
@@ -78,13 +78,7 @@ public class TranscriptionManager : ServiceManager<TranscriptionOptions>
                     {
                         if (!this.Consumer.IsReady) this.Consumer.Open();
                         this.Consumer.Subscribe(topics);
-
-                        // Create a new thread if the prior one isn't running anymore.
-                        if (_consumer == null || _notRunning.Contains(_consumer.Status))
-                        {
-                            _cancelToken = new CancellationTokenSource();
-                            _consumer = Task.Factory.StartNew(() => ConsumerHandler(), _cancelToken.Token);
-                        }
+                        ConsumeMessages();
                     }
                     else if (topics.Length == 0)
                     {
@@ -101,6 +95,19 @@ public class TranscriptionManager : ServiceManager<TranscriptionOptions>
             // The delay ensures we don't have a run away thread.
             this.Logger.LogDebug("Service sleeping for {delay} ms", delay);
             await Task.Delay(delay);
+        }
+    }
+
+    /// <summary>
+    /// Creates a new cancellation token.
+    /// Create a new thread if the prior one isn't running anymore.
+    /// </summary>
+    private void ConsumeMessages()
+    {
+        if (_consumer == null || _notRunning.Contains(_consumer.Status))
+        {
+            _cancelToken = new CancellationTokenSource();
+            _consumer = Task.Factory.StartNew(() => ConsumerHandler(), _cancelToken.Token);
         }
     }
 


### PR DESCRIPTION
Fixing issue with Kafka consumer services that stop consuming messages after an unexpected failure.  Normally that failure occurs within an HTTP request to the API.  Also added additional logging information for HTTP errors.

Updated the pipeline to build one thing at a time.  When attempting to do them all at once we run out of resources and the pipeline gets stuck.  Sequential however results in build times of over 30 minutes...

- Content Service
- Transcription Service
- Indexing Service
- NLP Service