### PR TITLE
Fix Kafka consumer

### DIFF
--- a/libs/net/kafka/KafkaListener`.cs
+++ b/libs/net/kafka/KafkaListener`.cs
@@ -210,12 +210,13 @@ public class KafkaListener<TKey, TValue> : IKafkaListener<TKey, TValue>, IDispos
     /// </summary>
     public void Stop()
     {
+        this.Consumer.Close();
+
         if (this.IsConsuming && this.IsReady)
         {
             _logger.LogInformation("Consumer is stopping");
             this.IsConsuming = false;
             this.IsReady = false;
-            this.Consumer.Close();
             OnStop?.Invoke(this, new EventArgs());
         }
     }


### PR DESCRIPTION
Another fix to how errors are handled with Kafka consumer services.  Currently an issue occurs when unexpected errors occur and the thread is cancelled.  The Kafka consumer library is trying to dispose before being closed.