### PR TITLE
TNO-427: Tooltip not disappearing on dropdown

### DIFF
--- a/app/editor/src/components/form/select/Select.tsx
+++ b/app/editor/src/components/form/select/Select.tsx
@@ -1,6 +1,7 @@
 import React, { Ref } from 'react';
 import { ActionMeta, GroupBase, Props } from 'react-select';
 import ReactSelect from 'react-select/dist/declarations/src/Select';
+import ReactTooltip from 'react-tooltip';
 import { FieldSize } from 'tno-core';
 import { Row } from 'tno-core/dist/components/flex';
 
@@ -51,6 +52,8 @@ export interface ISelectProps<OptionType> extends SelectProps {
   ref?: Ref<ReactSelect<OptionType, boolean, GroupBase<OptionType>>>;
 }
 
+type TooltipRef = { tooltipRef: null } | null;
+
 /**
  * Select component provides a bootstrapped styled button element.
  * @param param0 Select element attributes.
@@ -79,7 +82,7 @@ export const Select = <OptionType extends IOptionItem>({
 }: ISelectProps<OptionType>) => {
   const selectRef = React.useRef(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
-
+  const tip = React.useRef(null);
   return (
     <styled.Select className="frm-in">
       {label && (
@@ -93,8 +96,13 @@ export const Select = <OptionType extends IOptionItem>({
             onClear?.();
           }
         }}
-        data-for="main-tooltip"
+        data-for="select-tooltip"
         data-tip={tooltip}
+        onClick={() => {
+          const current: TooltipRef = tip.current;
+          current!.tooltipRef = null;
+          ReactTooltip.hide();
+        }}
       >
         <styled.SelectField
           ref={selectRef}
@@ -147,6 +155,7 @@ export const Select = <OptionType extends IOptionItem>({
         />
       )}
       {error && <p role="alert">{error}</p>}
+      <ReactTooltip ref={tip} id="select-tooltip" effect="float" type="light" place="top" />
     </styled.Select>
   );
 };


### PR DESCRIPTION
I had tried a handful of different libraries with the same issue, as well as trying to find a better solution for "globally" handled tooltips. Was not able to make progress there.

This is a bit of a hacky fix; however, allows us to keep our tooltips the way they are throughout the application. I believe we can also get rid of the rebuild statements if we restructure where the tooltip is being rendered; but that may be outside of this ticket.

![tooltip](https://user-images.githubusercontent.com/15724124/190336331-293836f0-281f-4449-b543-c3b44102a351.gif)
