### PR TITLE
TNO-121 Fix DB migration script

### DIFF
--- a/libs/net/dal/Migrations/Initial/Up/PostUp/01-Schedule.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/01-Schedule.sql
@@ -94,7 +94,7 @@ INSERT INTO public.schedule (
   , CURRENT_TIMESTAMP -- version
   , '0'
 ), (
-  'CBCV - 01' -- name
+  'CBCV - 02' -- name
   , '' -- description
   , true -- is_enabled
   , 3 -- schedule_type

--- a/libs/net/dal/Migrations/Initial/Up/PostUp/03-IngestSchedule.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/03-IngestSchedule.sql
@@ -31,7 +31,7 @@ INSERT INTO public.ingest_schedule (
   , CURRENT_TIMESTAMP
 ), (
   (SELECT id FROM public.ingest WHERE name = 'CBC Victoria - Stream')  -- ingest_id
-  , (SELECT id FROM public.schedule WHERE name = 'CBC Victoria - Stream') -- schedule_id
+  , (SELECT id FROM public.schedule WHERE name = 'CBCV - 01') -- schedule_id
   , DEFAULT_USER_ID
   , ''
   , CURRENT_TIMESTAMP
@@ -40,7 +40,7 @@ INSERT INTO public.ingest_schedule (
   , CURRENT_TIMESTAMP
 ), (
   (SELECT id FROM public.ingest WHERE name = 'CBC Victoria - Clips')  -- ingest_id
-  , (SELECT id FROM public.schedule WHERE name = 'CBC Victoria - Clips')  -- schedule_id
+  , (SELECT id FROM public.schedule WHERE name = 'CBCV - 02')  -- schedule_id
   , DEFAULT_USER_ID
   , ''
   , CURRENT_TIMESTAMP


### PR DESCRIPTION
The initial DB migration scripts had an issue I introduced when I changed the name of some of the schedules.