### PR TITLE
TNO-519: Clip warnings

### DIFF
--- a/app/editor/src/features/content/form/ContentClipForm.tsx
+++ b/app/editor/src/features/content/form/ContentClipForm.tsx
@@ -196,20 +196,22 @@ export const ContentClipForm: React.FC<IContentClipFormProps> = ({
         <Col className="video">
           <Row>
             <video ref={videoRef} controls>
-              <source type="audio/m4a" />
-              <source type="audio/flac" />
-              <source type="audio/mp3" />
-              <source type="audio/mp4" />
-              <source type="audio/wav" />
-              <source type="audio/wma" />
-              <source type="audio/aac" />
-              <source type="video/wmv" />
-              <source type="video/mov" />
-              <source type="video/mpeg" />
-              <source type="video/mpg" />
-              <source type="video/avi" />
-              <source type="video/mp4" />
-              <source type="video/gif" />
+              <source src={streamUrl} type="audio/m4a" />
+              <source src={streamUrl} type="audio/flac" />
+              <source src={streamUrl} type="audio/mp3" />
+              <source src={streamUrl} type="audio/mp4" />
+              <source src={streamUrl} type="audio/wav" />
+              <source src={streamUrl} type="audio/wma" />
+              <source src={streamUrl} type="audio/aac" />
+              <source src={streamUrl} type="video/wmv" />
+              <source src={streamUrl} type="video/mov" />
+              <source src={streamUrl} type="video/mpeg" />
+              <source src={streamUrl} type="video/mpg" />
+              <source src={streamUrl} type="video/avi" />
+              <source src={streamUrl} type="video/mp4" />
+              <source src={streamUrl} type="video/gif" />
+              <source src={streamUrl} type="video/ogg" />
+              <source src={streamUrl} type="video/webm" />
               HTML5 Video is required for this example
             </video>
           </Row>


### PR DESCRIPTION
- `.webm` and `.ogg` added as additions for further Firefox support (warnings seemed to be FF specific)
- `src` attribute added to `<source />` tag to address compiler warnings