### PR TITLE
Mapping paper names to source configuration

### DIFF
--- a/services/net/filemonitor/models/Fields.cs
+++ b/services/net/filemonitor/models/Fields.cs
@@ -6,94 +6,99 @@ namespace TNO.Services.FileMonitor;
 public static class Fields
 {
     /// <summary>
-    /// Key to the "papername" connection string value.
+    /// Key to the "papername" configuration string value.
     /// </summary>
     public const string Papername = "papername";
 
     /// <summary>
-    /// Key to the "headline" connection string value.
+    /// Key to the "headline" configuration string value.
     /// </summary>
     public const string Headline = "headline";
 
     /// <summary>
-    /// Key to the "summary" connection string value.
+    /// Key to the "summary" configuration string value.
     /// </summary>
     public const string Summary = "summary";
 
     /// <summary>
-    /// Key to the "story" connection string value.
+    /// Key to the "story" configuration string value.
     /// </summary>
     public const string Story = "story";
 
     /// <summary>
-    /// Key to the "author" connection string value.
+    /// Key to the "author" configuration string value.
     /// </summary>
     public const string Author = "author";
 
     /// <summary>
-    /// Key to the "date" connection string value.
+    /// Key to the "date" configuration string value.
     /// </summary>
     public const string Date = "date";
 
     /// <summary>
-    /// Key to the "lang" connection string value.
+    /// Key to the "lang" configuration string value.
     /// </summary>
     public const string Lang = "lang";
 
     /// <summary>
-    /// Key to the "section" connection string value.
+    /// Key to the "section" configuration string value.
     /// </summary>
     public const string Section = "section";
 
     /// <summary>
-    /// Key to the "id" connection string value.
+    /// Key to the "id" configuration string value.
     /// </summary>
     public const string Id = "id";
 
     /// <summary>
-    /// Key to the "tags" connection string value.
+    /// Key to the "tags" configuration string value.
     /// </summary>
     public const string Tags = "tags";
 
     /// <summary>
-    /// Key to the "page" connection string value.
+    /// Key to the "page" configuration string value.
     /// </summary>
     public const string Page = "page";
 
     /// <summary>
-    /// Key to the "item" connection string value.
+    /// Key to the "item" configuration string value.
     /// </summary>
     public const string Item = "item";
 
     /// <summary>
-    /// Key to the "dateFmt" connection string value.
+    /// Key to the "dateFmt" configuration string value.
     /// </summary>
     public const string DateFmt = "dateFmt";
 
     /// <summary>
-    /// Key to the "escapeContent" connection string value.
+    /// Key to the "escapeContent" configuration string value.
     /// </summary>
     public const string EscapeContent = "escapeContent";
 
     /// <summary>
-    /// Key to the "addParent" connection string value.
+    /// Key to the "addParent" configuration string value.
     /// </summary>
     public const string AddParent = "addParent";
 
     /// <summary>
-    /// Key to the "fileFormat" connection string value.
+    /// Key to the "fileFormat" configuration string value.
     /// </summary>
     public const string FileFormat = "fileFormat";
 
     /// <summary>
-    /// Key to the "importDir" connection string value.
+    /// Key to the "importDir" configuration string value.
     /// </summary>
     public const string ImportDir = "importDir";
 
     /// <summary>
-    /// Key to the "selfPublished" connection string value.
+    /// Key to the "selfPublished" configuration string value.
     /// </summary>
     public const string SelfPublished = "selfPublished";
+
+    /// <summary>
+    /// Key to the "sources" configuration string value.
+    /// </summary>
+    public const string Sources = "sources";
 
     /// <summary>
     /// FMS story delimiter string.


### PR DESCRIPTION
To complete this task I had to:

- Add ingest records for BCNG, MELT and STAR
- Add source records for BCNG and MELT
- Add schedules for GLOBE, BCNG, MELT and STAR
- Map the ingest records to the source records

The resulting ingest records are shown below. These will likely need updating (due to missed paper names) when I have a larger data set to work with after data is being retrieved from the SFTP server. The paper names configured are gathered from:

- Information provided by Scott.
- Online research.
- Existing test data.

One small issue: The filemonitor service currently ingests media_type "Paper" (id = 5). This has a content_type of 1, which I believe maps to the product id 1 (Daily Print). Some of the publications being ingested are daily, others are weekly and others are published less frequently. This doesn't appear to be captured using the current schema (unless I'm missing something).

INSERT INTO public.ingest ("name",topic,description,is_enabled,source_id,media_type_id,product_id,source_connection_id,destination_connection_id,"configuration",retry_limit,schedule_type,created_by_id,created_by,created_on,updated_by_id,updated_by,updated_on,"version") VALUES
	 ('Blacks Newsgroup','BCNG','',true,248,5,1,4,1,'{
	"timeZone":"Pacific Standard Time",
	"language":"en-CA",
	"post":true,
	"import":true,
	"importDir":"/bcng",
	"papername":"papername",
	"headline":"headline",
	"summary":"summary",
	"story":"story",
	"author":"author",
	"date":"date",
	"id":"id",
	"item":"bcng",
	"page":"page",
	"section":"category",
	"dateFmt":"MM-dd-yyyy",
	"escapeContent":true,
	"addParent":true,
	"selfPublished":false,
	"sources":"Maple Ridge-Pitt Meadows News=MRN&100 Mile House Free Press=100MILE&Arrow Lakes News=ARROWLAKE&Ashcroft Cache Creek Journal=ASHJOUR&Barriere Star Journal=BARRSTARR&Boundary Creek Times=BCT&Burns Lake Lakes District News=BLLDN&Caledonia Courier=CC&Castlegar News=CN&Clearwater Times=CT&Coast Mountain News=CMN&Cranbrook Townsman=CDT&Creston Valley Advance=CVA&Sicamouse Eagle Valley News=SEVN&Fernie Free Press=TFP&Golden Star=GS&Grand Forks Gazette=GFG&Houston Today=HT&Invermere Valley Echo=IVE&Kamloops This Week=KTW&Kelowna Capital News=KCN&Keremeos Review=KR&Kimberley Bulletin=KDB&Kitimat Northern Sentinel=KS&Kootenay News Advertiser=KNA&Lake Country Calendar=LCC&Salmon Arm Lakeshore News=SALN&Merritt Herald=MH&Nelson Star=NS&North Delta Reporter=NDR&Prince Rupert Northern View=NV&Penticton Western News=PW&Prince George Free Press=PGFP&Quesnel Cariboo Observer=QCO&Revelstoke Review=RTR&Rossland News=RN&Salmon Arm Observer=SAO&Similkameen Spotlight=SIMSP&Smithers Interior News=SIN&Summerland Review=SR&Terrace Standard=TSTD&Trail Daily Times=TDT&Comox Valley Echo=CVE&Vanderhoof Omineca Express=VOE&Vernon Morning Star=VMS&Williams Lake Tribune=WLT&Abbotsford News=ABBNEWS&Agassiz-Harrison Observer=AGASSIZ&Aldergrove Star=ALDERSTAR&Bowen Island Undercurrent=BIU&Chilliwack Times=CTIMES&Cloverdale Reporter=CRR&Hope Standard=HS&Langley Times=LT&Langley Advance Times=LA&Mission City Record=MCR&North Shore Outlook=NSO&Peace Arch News=PAN&Richmond Review=RR&Surrey Now-Leader=SURN&Alberni Valley News=AVN&Campbell River Mirror=CRM&Comox Valley Record=CCVR&Cowichan News Leader Pictorial=CNLP&Cowichan Valley Citizen=CVC&Goldstream News Gazette=GG&Gulf Islands Driftwood=GID&Ladysmith Chronicle=LC&Lake Cowichan Gazette=LCG&Monday Magazine=MM&The Daily News (Nanaimo)=NANAIMO&Nanaimo News Bulletin=NNB&North Island Gazette=NIG&Oak Bay News=OBN&Parksville Qualicum Beach News=PQN&Peninsula News Review=PNR&Saanich News=SN&Sooke News Mirror=SNM&Tofino-Ucluelet Westerly News=TUWN&Victoria News=VN&Vancouver Island Free Daily=VIFD&The Free Press=TFP&Chemainus Valley Courier=CHVC&Agassiz Observer=AGASSIZ&Maple Ridge News=MRN&Chilliwack Progress=CP&The Northern View=NV"
}',3,1,'00000000-0000-0000-0000-000000000000','','2022-09-22 08:29:05.11146-07','f3487a90-b793-4e60-b32c-2945591289aa','admin','2022-09-23 08:15:33.410994-07',3),
	 ('Globe and Mail','GLOBE','',true,95,5,1,4,1,'{
      "timeZone": "Pacific Standard Time",
      "language": "en-CA",
      "post": true,
      "import": true,
      "importDir": "/gandm",
      "papername":"pubdata!name",
      "headline":"hl1",
      "summary":"hl1",
      "story":"body.content",
      "author":"byline",
      "date":"pubdata!date.publication",
      "id":"pubdata!id",
      "section":"pubdata!position.section",
      "page":"pubdata!position.sequence",
      "item":"nitf","dateFmt":"yyyyMMdd",
      "selfPublished": true
}',3,1,'00000000-0000-0000-0000-000000000000','','2022-09-22 08:29:05.11146-07','f3487a90-b793-4e60-b32c-2945591289aa','admin','2022-09-22 09:09:03.600201-07',2),
	 ('StartMetro','STAR','',true,221,5,1,4,1,'{
	"timeZone": "Pacific Standard Time",
	"language": "en-CA",
	"post": true,
	"import": true,
	"importDir":"/star",
	"papername": "pubdata!name",
	"headline": "hl1",
	"summary": "hl1",
	"story": "body.content",
	"author": "byline",
	"date": "pubdata!date.publication",
	"id": "doc-id!id-string",
	"section": "pubdata!position.section",
	"page": "pubdata!position.sequence",
	"item": "nitf",
	"dateFmt": "yyyyMMdd",
	"escape-content": false,
	"add-parent": false,
	"selfPublished": true
}',3,1,'00000000-0000-0000-0000-000000000000','','2022-09-22 08:29:05.11146-07','f3487a90-b793-4e60-b32c-2945591289aa','admin','2022-09-23 13:57:02.141677-07',3),
	 ('Meltwater','MELT','',true,249,5,1,4,1,'{
	"timeZone":"Pacific Standard Time",
	"language":"en-CA",
	"post":true,
	"import":true,
	"importDir":"/meltwater",
	"papername": "!@PAPER=",
	"headline": "!@HEAD=",
	"summary": "!@ABSTRACT=",
	"story": "!@TEXT=",
	"author": "!@BYLINE=",
	"date": "!@DATE=",
	"lang": "!@LANG=",
	"section": "!@SECTION=",
	"id": "!@IDNUMBER=",
	"tags": "!@LKW=",
	"page": "!@PAGE=",
	"item": "**START-IO-STORY**",
	"dateFmt": "yyyyMMdd",
	"fileFormat": "fms",
	"sources":"Vancouver Sun=SUN&The Province=PROVINCE&Times Colonist (Victoria)=TC&National Post=POST&Kelowna Daily Courier=KELOWNA&Delta Optimist=DO&North Shore News=NSN&Burnaby Now=BNOW&New West Record=NWR&Richmond News=RNEWS&Alaska Highway News=AHN&Squamish Chief=SC&Merritt Herald=MH&Tri-City News=TCN&Coast Reporter=CORE&Dawson Creek Mirror=DCMR&Kamloops This Week=KTW&Peachland View=PV&Prince George Citizen=PGC&Oliver Chronicle=APOC"
}',3,1,'00000000-0000-0000-0000-000000000000','','2022-09-22 08:29:05.11146-07','f3487a90-b793-4e60-b32c-2945591289aa','admin','2022-09-23 13:14:18.970923-07',4);
