### PR TITLE
TNO-637 Fix content body bugs

### DIFF
--- a/app/editor/src/features/content/form/ContentSummaryForm.tsx
+++ b/app/editor/src/features/content/form/ContentSummaryForm.tsx
@@ -195,11 +195,11 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
               />
               <TimeInput
                 name="publishedOnTime"
+                label="Time"
                 disabled={!values.publishedOn}
                 placeholder={
                   !!values.publishedOn ? moment(values.publishedOn).format('HH:mm:ss') : 'HH:MM:SS'
                 }
-                label="Time"
                 onChange={(e) => setPublishedOnTime(e.target.value)}
               />
               <Show visible={contentType === ContentTypeName.Snippet}>
@@ -210,9 +210,9 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
           <Show visible={contentType === ContentTypeName.Snippet}>
             <Col className="licenses">
               <RadioGroup
+                name="expireOptions"
                 label="License"
                 spaceUnderRadio
-                name="expireOptions"
                 options={licenseOptions}
                 value={licenseOptions.find((e) => e.value === values?.licenseId)}
                 onChange={(e) => setFieldValue('licenseId', Number(e.target.value))}
@@ -222,34 +222,44 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
         </Row>
         <Row>
           <Col flex="1 1 0">
-            <FormikTextArea
-              name="summary"
-              label="Summary"
-              required
-              onBlur={(e) => {
-                const value = e.currentTarget.value;
-                if (!!value) {
-                  const values = value.match(tagMatch)?.toString()?.split(', ') ?? [];
-                  const tags = extractTags(values);
-                  setFieldValue('tags', tags);
-                }
-              }}
-            />
+            <Show visible={contentType === ContentTypeName.Snippet}>
+              <FormikTextArea
+                name="summary"
+                label="Summary"
+                required
+                onBlur={(e) => {
+                  const value = e.currentTarget.value;
+                  if (!!value) {
+                    const values = value.match(tagMatch)?.toString()?.split(', ') ?? [];
+                    const tags = extractTags(values);
+                    setFieldValue('tags', tags);
+                  }
+                }}
+              />
+            </Show>
+            <Show visible={contentType !== ContentTypeName.Snippet}>
+              <FormikTextArea
+                name="body"
+                label="Story"
+                required
+                onBlur={(e) => {
+                  const value = e.currentTarget.value;
+                  if (!!value) {
+                    const values = value.match(tagMatch)?.toString()?.split(', ') ?? [];
+                    const tags = extractTags(values);
+                    setFieldValue('tags', tags);
+                  }
+                }}
+              />
+            </Show>
           </Col>
         </Row>
-        <Show visible={contentType !== ContentTypeName.Snippet}>
-          <Row>
-            <Col flex="1 1 0">
-              <FormikTextArea name="body" label="Story" />
-            </Col>
-          </Row>
-        </Show>
         <Row>
           <FormikText
-            disabled
-            width={combined ? FieldSize.Big : FieldSize.Large}
             name="tags"
             label="Tags"
+            disabled
+            width={combined ? FieldSize.Big : FieldSize.Large}
             value={values.tags.map((t) => t.id).join(', ')}
           />
           <Button

--- a/app/editor/src/features/content/form/ContentTranscriptForm.tsx
+++ b/app/editor/src/features/content/form/ContentTranscriptForm.tsx
@@ -1,50 +1,18 @@
 import { FormikTextArea } from 'components/formik';
 import { useFormikContext } from 'formik';
-import { useContent } from 'store/hooks';
-import { Button, ButtonVariant, Show } from 'tno-core';
 
 import { IContentForm } from './interfaces';
 import * as styled from './styled';
-import { toModel } from './utils';
 
 /**
  * The component to be displayed when the transcript tab is selected from the content form.
  * @returns the ContentTranscriptForm
  */
 export const ContentTranscriptForm: React.FC = () => {
-  const [, { transcribe, nlp }] = useContent();
-  const { values, isSubmitting } = useFormikContext<IContentForm>();
-
-  const handleTranscribe = async (values: IContentForm) => {
-    await transcribe(toModel(values));
-  };
-
-  const handleNLP = async (values: IContentForm) => {
-    await nlp(toModel(values));
-  };
+  const { values } = useFormikContext<IContentForm>();
 
   return (
     <styled.ContentTranscriptForm>
-      <Show visible={!!values.id}>
-        <Button
-          onClick={() => handleTranscribe(values)}
-          variant={ButtonVariant.action}
-          disabled={
-            isSubmitting ||
-            !values.fileReferences.length ||
-            (values.fileReferences.length > 0 && !values.fileReferences[0].isUploaded)
-          }
-        >
-          Transcribe
-        </Button>
-        <Button
-          onClick={() => handleNLP(values)}
-          variant={ButtonVariant.action}
-          disabled={isSubmitting}
-        >
-          NLP
-        </Button>
-      </Show>
       <FormikTextArea name="body" label="Transcript" value={values.body} />
     </styled.ContentTranscriptForm>
   );

--- a/app/editor/src/features/content/list-view/ContentListView.tsx
+++ b/app/editor/src/features/content/list-view/ContentListView.tsx
@@ -22,7 +22,7 @@ export const ContentListView: React.FC = () => {
   const combined = useCombinedView();
   useTooltips();
 
-  const [contentType, setContentType] = React.useState<ContentTypeName>(ContentTypeName.Snippet);
+  const [contentType, setContentType] = React.useState(ContentTypeName.Snippet);
   const [loading, setLoading] = React.useState(false);
   const [activeId, setActiveId] = React.useState<number>(parseInt(id ?? '0'));
 
@@ -135,31 +135,6 @@ export const ContentListView: React.FC = () => {
                 variant={ButtonVariant.secondary}
               >
                 Create Print Content
-              </Button>
-              <div>Send to</div>
-              <Button
-                name="create"
-                variant={ButtonVariant.secondary}
-                disabled
-                tooltip="Under Construction"
-              >
-                Front Pages
-              </Button>
-              <Button
-                name="create"
-                variant={ButtonVariant.secondary}
-                disabled
-                tooltip="Under Construction"
-              >
-                Top Stories
-              </Button>
-              <Button
-                name="create"
-                variant={ButtonVariant.secondary}
-                disabled
-                tooltip="Under Construction"
-              >
-                Commentary
               </Button>
             </Row>
           </Col>

--- a/app/editor/src/features/content/validation/ContentFormSchema.ts
+++ b/app/editor/src/features/content/validation/ContentFormSchema.ts
@@ -1,3 +1,4 @@
+import { ContentTypeName } from 'hooks';
 import { date, number, object, string } from 'yup';
 
 export const ContentFormSchema = object().shape({
@@ -7,7 +8,15 @@ export const ContentFormSchema = object().shape({
   productId: number().required('Product designation is a required field.'),
   publishedOn: date().required('Published On is a required field.'),
   // TODO: Summary should not be empty.
-  summary: string().required('Summary is a required field.'),
+  // summary: string().required('Summary is a required field.'),
+  summary: string().when('contentType', {
+    is: ContentTypeName.Snippet,
+    then: string().trim().required('Summary is a required field.'),
+  }),
+  body: string().when('contentType', {
+    is: (value: ContentTypeName) => value !== ContentTypeName.Snippet,
+    then: string().trim().required('Summary is a required field.'),
+  }),
   // TODO: Headline should not be empty.
   headline: string().required('Headline is a required field.'),
   tone: number().required('Tone is a required field.'),

--- a/services/net/content/ContentManager.cs
+++ b/services/net/content/ContentManager.cs
@@ -247,10 +247,10 @@ public class ContentManager : ServiceManager<ContentOptions>
                     OtherSeries = null, // TODO: Provide default series from Data Source config settings.
                     OwnerId = source?.OwnerId,
                     Headline = String.IsNullOrWhiteSpace(model.Title) ? "[TBD]" : model.Title,
-                    Uid = result.Message.Value.Uid,
+                    Uid = model.Uid,
                     Page = "", // TODO: Provide default page from Data Source config settings.
                     Summary = String.IsNullOrWhiteSpace(model.Summary) ? "[TBD]" : model.Summary,
-                    Body = "",
+                    Body = model.Body,
                     SourceUrl = model.Link,
                     PublishedOn = model.PublishedOn,
                 };


### PR DESCRIPTION
A number of bug fixes related to syndication content, the content form, and requesting transcripts and NLP.

- Syndication Ingest Service: Will now correctly update the story body
- Composite View: Will now correctly update the form based on the loaded content type
- Content Form: Summary is only visible for snippets
- Content Form: Transcription and Clips tab are only visible for snippets
- Content Form: Request Transcript button is only visible for snippets
- Content Form: Request NLP button is only visible if the story body has text
- Content Form: Request Transcript will now first save 
- Content Form: Request NLP will now first save

> Note that currently there is no way to edit the summary of a story imported by the syndication service.  Probably the summary value should just be blank.

![image](https://user-images.githubusercontent.com/3180256/192618740-5e0fa596-a7e5-43bc-84eb-3ba349183ecf.png)
