### PR TITLE
TNO-445 Fix Kafka consumers

### DIFF
--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -555,7 +555,7 @@ export const ContentForm: React.FC<IContentFormProps> = ({ contentType: initCont
                             !props.values.fileReferences[0].isUploaded)
                         }
                       >
-                        Request Transcribe
+                        Request Transcript
                       </Button>
                     </Show>
                     <Show visible={!!props.values.id && props.values.body.length > 0}>

--- a/openshift/kustomize/README.md
+++ b/openshift/kustomize/README.md
@@ -8,6 +8,12 @@ For Windows installation. Open a command prompt as an administrator.
 
 `choco install Kustomize`
 
+## Kustomize Command
+
+```bash
+oc kustomize ./overlays/dev | oc create -f -
+```
+
 ## Solution Installation
 
 | Service                                                 | Description                                               |

--- a/openshift/kustomize/services/transcription/base/config-map.yaml
+++ b/openshift/kustomize/services/transcription/base/config-map.yaml
@@ -19,5 +19,5 @@ data:
   KAFKA_CLIENT_ID: Transcription
   MAX_FAIL_LIMIT: "5"
   TOPICS: transcribe
-  FILE_PATH: /data/clip
+  VOLUME_PATH: /data
   NOTIFICATION_TOPIC: ""

--- a/openshift/kustomize/services/transcription/base/deploy.yaml
+++ b/openshift/kustomize/services/transcription/base/deploy.yaml
@@ -37,9 +37,9 @@ spec:
         component: transcription-service
     spec:
       volumes:
-        - name: av-storage
+        - name: file-storage
           persistentVolumeClaim:
-            claimName: av-storage
+            claimName: file-storage
       containers:
         - name: transcription-service
           image: ""
@@ -48,7 +48,7 @@ spec:
             - containerPort: 8080
               protocol: TCP
           volumeMounts:
-            - name: av-storage
+            - name: file-storage
               mountPath: /data
           resources:
             requests:
@@ -143,11 +143,11 @@ spec:
                 configMapKeyRef:
                   name: transcription-service
                   key: TOPICS
-            - name: Service__FilePath
+            - name: Service__VolumePath
               valueFrom:
                 configMapKeyRef:
                   name: transcription-service
-                  key: FILE_PATH
+                  key: VOLUME_PATH
             - name: Service__NotificationTopic
               valueFrom:
                 configMapKeyRef:

--- a/services/net/capture/CaptureAction.cs
+++ b/services/net/capture/CaptureAction.cs
@@ -181,7 +181,7 @@ public class CaptureAction : CommandAction<CaptureOptions>
     private ContentReferenceModel CreateContentReference(IngestModel ingest, ScheduleModel schedule)
     {
         var today = GetLocalDateTime(ingest, DateTime.UtcNow);
-        var publishedOn = new DateTime(today.Year, today.Month, today.Day, 0, 0, 0, DateTimeKind.Local) + schedule.StartAt;
+        var publishedOn = new DateTime(today.Year, today.Month, today.Day, 0, 0, 0, today.Kind) + schedule.StartAt;
         return new ContentReferenceModel()
         {
             Source = ingest.Source?.Code ?? throw new InvalidOperationException($"Ingest '{ingest.Name}' is missing source code."),

--- a/services/net/clip/ClipAction.cs
+++ b/services/net/clip/ClipAction.cs
@@ -155,7 +155,7 @@ public class ClipAction : CommandAction<ClipOptions>
     private ContentReferenceModel CreateContentReference(IngestModel ingest, ScheduleModel schedule)
     {
         var today = GetLocalDateTime(ingest, DateTime.UtcNow);
-        var publishedOn = new DateTime(today.Year, today.Month, today.Day, 0, 0, 0, DateTimeKind.Local) + schedule.StartAt;
+        var publishedOn = new DateTime(today.Year, today.Month, today.Day, 0, 0, 0, today.Kind) + schedule.StartAt;
         return new ContentReferenceModel()
         {
             Source = ingest.Source?.Code ?? throw new InvalidOperationException($"Ingest '{ingest.Name}' missing source code."),

--- a/services/net/content/ContentManager.cs
+++ b/services/net/content/ContentManager.cs
@@ -150,7 +150,7 @@ public class ContentManager : ServiceManager<ContentOptions>
         if (_consumer == null || _notRunning.Contains(_consumer.Status))
         {
             _cancelToken = new CancellationTokenSource();
-            _consumer = Task.Run(ConsumerHandlerAsync, _cancelToken.Token);
+            _consumer = ConsumerHandlerAsync();
         }
     }
 
@@ -163,7 +163,7 @@ public class ContentManager : ServiceManager<ContentOptions>
         while (this.State.Status == ServiceStatus.Running &&
             _cancelToken?.IsCancellationRequested == false)
         {
-            await this.Consumer.ConsumeAsync(HandleMessageAsync);
+            await this.Consumer.ConsumeAsync(HandleMessageAsync, _cancelToken.Token);
         }
 
         // The service is stopping or has stopped, consume should stop too.

--- a/services/net/indexing/IndexingManager.cs
+++ b/services/net/indexing/IndexingManager.cs
@@ -149,7 +149,7 @@ public class IndexingManager : ServiceManager<IndexingOptions>
         if (_consumer == null || _notRunning.Contains(_consumer.Status))
         {
             _cancelToken = new CancellationTokenSource();
-            _consumer = Task.Factory.StartNew(() => ConsumerHandler(), _cancelToken.Token);
+            _consumer = ConsumerHandlerAsync();
         }
     }
 
@@ -157,12 +157,12 @@ public class IndexingManager : ServiceManager<IndexingOptions>
     /// Keep consuming messages from Kafka until the service stops running.
     /// </summary>
     /// <returns></returns>
-    private async Task ConsumerHandler()
+    private async Task ConsumerHandlerAsync()
     {
         while (this.State.Status == ServiceStatus.Running &&
             _cancelToken?.IsCancellationRequested == false)
         {
-            await this.Consumer.ConsumeAsync(HandleMessageAsync);
+            await this.Consumer.ConsumeAsync(HandleMessageAsync, _cancelToken.Token);
         }
 
         // The service is stopping or has stopped, consume should stop too.

--- a/services/net/transcription/TranscriptionManager.cs
+++ b/services/net/transcription/TranscriptionManager.cs
@@ -117,7 +117,7 @@ public class TranscriptionManager : ServiceManager<TranscriptionOptions>
         if (_consumer == null || _notRunning.Contains(_consumer.Status))
         {
             _cancelToken = new CancellationTokenSource();
-            _consumer = Task.Factory.StartNew(() => ConsumerHandler(), _cancelToken.Token);
+            _consumer = ConsumerHandlerAsync();
         }
     }
 
@@ -125,12 +125,12 @@ public class TranscriptionManager : ServiceManager<TranscriptionOptions>
     /// Keep consuming messages from Kafka until the service stops running.
     /// </summary>
     /// <returns></returns>
-    private async Task ConsumerHandler()
+    private async Task ConsumerHandlerAsync()
     {
         while (this.State.Status == ServiceStatus.Running &&
             _cancelToken?.IsCancellationRequested == false)
         {
-            await this.Consumer.ConsumeAsync(HandleMessageAsync);
+            await this.Consumer.ConsumeAsync(HandleMessageAsync, _cancelToken.Token);
         }
 
         // The service is stopping or has stopped, consume should stop too.
@@ -181,39 +181,41 @@ public class TranscriptionManager : ServiceManager<TranscriptionOptions>
     /// <returns></returns>
     private async Task<ConsumerAction> HandleMessageAsync(ConsumeResult<string, TranscriptRequest> result)
     {
-        try
+        // The service has stopped, so to should consuming messages.
+        if (this.State.Status != ServiceStatus.Running)
         {
-            // The service has stopped, so to should consuming messages.
-            if (this.State.Status != ServiceStatus.Running)
-            {
-                this.Consumer.Stop();
-                this.State.Stop();
-            }
-
-            var content = await _api.FindContentByIdAsync(result.Message.Value.ContentId);
-            if (content != null)
-            {
-                // TODO: Handle multi-threading so that more than one transcription can be performed at a time.
-                await UpdateTranscriptionAsync(content);
-            }
-            else
-            {
-                // Identify requests for transcription for content that does not exist.
-                this.Logger.LogWarning("Content does not exist for this message. Key: {Key}, Content ID: {ContentId}", result.Message.Key, result.Message.Value.ContentId);
-            }
-
-            // Successful run clears any errors.
-            this.State.ResetFailures();
-            _retries = 0;
-            return ConsumerAction.Proceed;
+            this.Consumer.Stop();
+            this.State.Stop();
+            return ConsumerAction.Stop;
         }
-        catch (HttpClientRequestException ex)
+        else
         {
-            this.Logger.LogError(ex, "HTTP exception while consuming. {response}", ex.Data["body"] ?? "");
+            try
+            {
+                var content = await _api.FindContentByIdAsync(result.Message.Value.ContentId);
+                if (content != null)
+                {
+                    // TODO: Handle multi-threading so that more than one transcription can be performed at a time.
+                    await UpdateTranscriptionAsync(content);
+                }
+                else
+                {
+                    // Identify requests for transcription for content that does not exist.
+                    this.Logger.LogWarning("Content does not exist for this message. Key: {Key}, Content ID: {ContentId}", result.Message.Key, result.Message.Value.ContentId);
+                }
+
+                // Successful run clears any errors.
+                this.State.ResetFailures();
+                _retries = 0;
+                return ConsumerAction.Proceed;
+            }
+            catch (HttpClientRequestException ex)
+            {
+                this.Logger.LogError(ex, "HTTP exception while consuming. {response}", ex.Data["body"] ?? "");
+            }
+
+            return _options.RetryLimit > _retries++ ? ConsumerAction.Retry : ConsumerAction.Stop;
         }
-
-
-        return _options.RetryLimit > _retries++ ? ConsumerAction.Retry : ConsumerAction.Stop;
     }
 
     /// <summary>
@@ -242,7 +244,7 @@ public class TranscriptionManager : ServiceManager<TranscriptionOptions>
             if (result != null && !String.IsNullOrWhiteSpace(transcript))
             {
                 // The transcription may have been edited during this process and now those changes will be lost.
-                if (original != result.Body) this.Logger.LogWarning("Transcription will be overwritten.  Content ID: {Id}", content.Id);
+                if (String.CompareOrdinal(original, result.Body) != 0) this.Logger.LogWarning("Transcription will be overwritten.  Content ID: {Id}", content.Id);
 
                 result.Body = transcript;
                 await _api.UpdateContentAsync(result); // TODO: This can result in an editor getting a optimistic concurrency error.
@@ -302,7 +304,7 @@ public class TranscriptionManager : ServiceManager<TranscriptionOptions>
             if (e.Reason == CancellationReason.Error)
             {
                 sb.AppendLine("*** SPEECH TRANSCRIPTION ERROR ***");
-                this.Logger.LogError("Speech transcription failed", e.ErrorDetails);
+                this.Logger.LogError("Speech transcription error. {details}", e.ErrorDetails);
                 this.State.RecordFailure();
             }
             sem.Release();


### PR DESCRIPTION
The Kafka consumer services were using a `Task.Factory.StartNew(...)`, but the tasks it created would not await and continued to run to completion (even though they were still running!).  The fix creates the thread in a simpler way and appears to correctly await until the process completes before attempting to create a new thread.

Also updated the Infrastructure as Code to resolve transcription service configuration issues in Openshift.