### PR TITLE
Fix kafka consumers

### DIFF
--- a/libs/net/kafka/KafkaListener`.cs
+++ b/libs/net/kafka/KafkaListener`.cs
@@ -160,6 +160,7 @@ public class KafkaListener<TKey, TValue> : IKafkaListener<TKey, TValue>, IDispos
 
                 if (!this.IsPaused)
                 {
+                    _logger.LogDebug("Pausing consumption: {topics}", String.Join(", ", this.Consumer.Subscription ?? new List<string>()));
                     // TODO: Pausing is only required if the action takes too long.  This current implementation isn't efficient.
                     this.Consumer.Pause(this.Consumer.Assignment);
                     this.IsPaused = true;
@@ -185,6 +186,10 @@ public class KafkaListener<TKey, TValue> : IKafkaListener<TKey, TValue>, IDispos
                     _currentResult = null;
                 }
             }
+            else
+            {
+                _logger.LogError("Unexpected consumer with no message");
+            }
         }
         catch (Exception ex)
         {
@@ -198,8 +203,9 @@ public class KafkaListener<TKey, TValue> : IKafkaListener<TKey, TValue>, IDispos
             if (proceed == ConsumerAction.Stop) this.Stop();
             else if (this.IsPaused && proceed == ConsumerAction.Proceed)
             {
-                this.Consumer?.Resume(this.Consumer.Assignment);
+                _logger.LogDebug("Resuming consumption: {topics}", String.Join(", ", this.Consumer!.Subscription ?? new List<string>()));
                 this.IsPaused = false;
+                this.Consumer?.Resume(this.Consumer.Assignment);
             }
         }
     }

--- a/services/net/content/ContentManager.cs
+++ b/services/net/content/ContentManager.cs
@@ -149,8 +149,11 @@ public class ContentManager : ServiceManager<ContentOptions>
     {
         if (_consumer == null || _notRunning.Contains(_consumer.Status))
         {
+            // Make sure the prior task is cancelled before creating a new one.
+            if (_cancelToken?.IsCancellationRequested == false)
+                _cancelToken?.Cancel();
             _cancelToken = new CancellationTokenSource();
-            _consumer = ConsumerHandlerAsync();
+            _consumer = Task.Run(ConsumerHandlerAsync, _cancelToken.Token);
         }
     }
 

--- a/services/net/indexing/IndexingManager.cs
+++ b/services/net/indexing/IndexingManager.cs
@@ -148,8 +148,11 @@ public class IndexingManager : ServiceManager<IndexingOptions>
     {
         if (_consumer == null || _notRunning.Contains(_consumer.Status))
         {
+            // Make sure the prior task is cancelled before creating a new one.
+            if (_cancelToken?.IsCancellationRequested == false)
+                _cancelToken?.Cancel();
             _cancelToken = new CancellationTokenSource();
-            _consumer = ConsumerHandlerAsync();
+            _consumer = Task.Run(ConsumerHandlerAsync, _cancelToken.Token);
         }
     }
 

--- a/services/net/nlp/NLPManager.cs
+++ b/services/net/nlp/NLPManager.cs
@@ -125,8 +125,11 @@ public class NLPManager : ServiceManager<NLPOptions>
     {
         if (_consumer == null || _notRunning.Contains(_consumer.Status))
         {
+            // Make sure the prior task is cancelled before creating a new one.
+            if (_cancelToken?.IsCancellationRequested == false)
+                _cancelToken?.Cancel();
             _cancelToken = new CancellationTokenSource();
-            _consumer = ConsumerHandlerAsync();
+            _consumer = Task.Run(ConsumerHandlerAsync, _cancelToken.Token);
         }
     }
 

--- a/services/net/transcription/TranscriptionManager.cs
+++ b/services/net/transcription/TranscriptionManager.cs
@@ -110,14 +110,17 @@ public class TranscriptionManager : ServiceManager<TranscriptionOptions>
 
     /// <summary>
     /// Creates a new cancellation token.
-    /// Create a new thread if the prior one isn't running anymore.
+    /// Create a new Task if the prior one isn't running anymore.
     /// </summary>
     private void ConsumeMessages()
     {
         if (_consumer == null || _notRunning.Contains(_consumer.Status))
         {
+            // Make sure the prior task is cancelled before creating a new one.
+            if (_cancelToken?.IsCancellationRequested == false)
+                _cancelToken?.Cancel();
             _cancelToken = new CancellationTokenSource();
-            _consumer = ConsumerHandlerAsync();
+            _consumer = Task.Run(ConsumerHandlerAsync, _cancelToken.Token);
         }
     }
 


### PR DESCRIPTION
The Kafka consumers were not correctly awaiting the completion of the handle message task.  This was originally resulting in the creation of new threads any time a long async process ran.  My last fix introduced a different bug, which was it no longer ran asynchronously.  

This fix appears to correct the prior issues.