### PR TITLE
TNO-639 Fix syndication content without body

### DIFF
--- a/services/net/content/ContentManager.cs
+++ b/services/net/content/ContentManager.cs
@@ -253,7 +253,7 @@ public class ContentManager : ServiceManager<ContentOptions>
                     Uid = model.Uid,
                     Page = "", // TODO: Provide default page from Data Source config settings.
                     Summary = String.IsNullOrWhiteSpace(model.Summary) ? "[TBD]" : model.Summary,
-                    Body = model.Body,
+                    Body = !String.IsNullOrWhiteSpace(model.Body) ? model.Body : model.ContentType == ContentType.Snippet ? "" : model.Summary,
                     SourceUrl = model.Link,
                     PublishedOn = model.PublishedOn,
                 };

--- a/services/net/nlp/NLPManager.cs
+++ b/services/net/nlp/NLPManager.cs
@@ -237,7 +237,7 @@ public class NLPManager : ServiceManager<NLPOptions>
     /// <returns></returns>
     private async Task UpdateContentAsync(ContentModel content)
     {
-        this.Logger.LogInformation("Transcription requested.  Content ID: {Id}", content.Id);
+        this.Logger.LogInformation("NLP requested.  Content ID: {Id}", content.Id);
 
         var labels = await RequestNlpAsync(content); // TODO: Extract language from data source.
 


### PR DESCRIPTION
Syndication content without a body regrettably results in the summary not being displayed because we only show the summary or the body (depending on the content type).  We never show both for syndication content.

I've updated the Content Service to check the content type and then use the summary if the body is empty.