### PR TITLE
TNO-610 Fix clip service

### DIFF
--- a/services/net/clip/ClipAction.cs
+++ b/services/net/clip/ClipAction.cs
@@ -478,7 +478,9 @@ public class ClipAction : CommandAction<ClipOptions>
     private static string GetCopy(IngestModel ingest)
     {
         var value = ingest.GetConfigurationValue("copy");
-        return String.IsNullOrWhiteSpace(value) ? " -c:v copy -c:a copy" : $" {value}";
+        // Attempting to use this copy command is much faster, but it corrupts the output file...
+        // return String.IsNullOrWhiteSpace(value) ? " -c:v copy -c:a copy" : $" {value}";
+        return String.IsNullOrWhiteSpace(value) ? "" : $" {value}";
     }
     #endregion
 }


### PR DESCRIPTION
For some reason on Openshift the command we were using to create a clip was resulting in a corrupt output file.  This was caused by the `-c:v copy -c:a copy` arguments.  These arguments are to speed up the process dramatically, but they result in a failure, so not much value.