### PR TITLE
Fix Kafka Producers

### DIFF
--- a/app/editor/src/features/admin/ingests/configurations/Audio.tsx
+++ b/app/editor/src/features/admin/ingests/configurations/Audio.tsx
@@ -9,7 +9,7 @@ import { ServiceTypes } from './constants';
 import * as styled from './styled';
 
 export const Audio: React.FC = (props) => {
-  const { values } = useFormikContext<IIngestModel>();
+  const { values, setFieldValue } = useFormikContext<IIngestModel>();
 
   const serviceType = ServiceTypes.find((t) => t.value === values.configuration.serviceType);
 
@@ -20,6 +20,12 @@ export const Audio: React.FC = (props) => {
         name="configuration.serviceType"
         options={ServiceTypes}
         value={serviceType}
+        onChange={(newValue: any) => {
+          // If an audio ingest, set the configuration other args.
+          if (values.id === 0 && !values.configuration.otherArgs && newValue.value === 'stream') {
+            setFieldValue('configuration.otherArgs', '-acodec mp3 -ab 257k');
+          }
+        }}
       />
       <Show visible={values.configuration.serviceType === 'stream'}>
         <AudioStream />

--- a/app/editor/src/features/admin/ingests/configurations/AudioStream.tsx
+++ b/app/editor/src/features/admin/ingests/configurations/AudioStream.tsx
@@ -58,6 +58,7 @@ export const AudioStream: React.FC = (props) => {
         label="Other Arguments"
         name="configuration.otherArgs"
         tooltip="Any other arguments to pass to the command"
+        placeholder="-acodec mp3 -ab 257k"
       />
     </styled.IngestType>
   );


### PR DESCRIPTION
Our ingest services update a `Content Reference` to reduce the possibilities of duplicates.  However, a race condition is occurring where the ingest service is posting content to Kafka and the `Content Service` has already imported it before the ingest service has even finished updating the `Content Reference`.

To resolve this ingest service `Kafka Producers` will make an additional request to the `Content Reference` to determine if it has already been imported.

Additionally I have added default "Other Arguments" for `ffmpeg` when the ingest is configured for an audio stream.