### PR TITLE
Text area styling

### DIFF
--- a/app/editor/src/components/form/textarea/TextArea.tsx
+++ b/app/editor/src/components/form/textarea/TextArea.tsx
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Error } from 'components/form';
 import { InputHTMLAttributes } from 'react';
 import React from 'react';
-import { FieldSize, TextVariant } from 'tno-core';
+import { FieldSize, Show, TextVariant } from 'tno-core';
 
 import * as styled from './styled';
 
@@ -50,14 +50,16 @@ export const TextArea: React.FC<ITextAreaProps> = ({
 }) => {
   return (
     <styled.TextArea className="frm-in">
-      {label && (
-        <div title={tooltip}>
-          <label className={rest.required ? 'required' : ''} htmlFor={id ?? `txa-${name}`}>
-            {label}
-          </label>
-          {tooltip && <FontAwesomeIcon icon={faInfoCircle} />}
-        </div>
-      )}
+      <Show visible={!!label}>
+        <label
+          title={tooltip}
+          className={rest.required ? 'required' : ''}
+          htmlFor={id ?? `txa-${name}`}
+        >
+          {label}
+          {tooltip && <FontAwesomeIcon title={tooltip} icon={faInfoCircle} />}
+        </label>
+      </Show>
       <styled.TextAreaField
         id={id}
         name={name}

--- a/app/editor/src/components/form/textarea/styled/TextArea.ts
+++ b/app/editor/src/components/form/textarea/styled/TextArea.ts
@@ -4,6 +4,12 @@ import { Col } from 'tno-core/dist/components/flex';
 export const TextArea = styled(Col)`
   padding-right: 0.5em;
 
+  label {
+    svg {
+      margin-left: 0.25em;
+    }
+  }
+
   .required:after {
     content: ' *';
     color: ${(props) => props.theme.css.dangerColor};


### PR DESCRIPTION
Text area now appears under label like before:
![image](https://user-images.githubusercontent.com/15724124/193652056-5f8e4649-4382-4afc-b36f-735706b76a16.png)
![image](https://user-images.githubusercontent.com/15724124/193652108-5c067bba-4f41-4bd4-9b44-9293d363f244.png)
