### PR TITLE
TNO-618 Update DB Migration

### DIFF
--- a/libs/net/dal/Migrations/Initial/Up/PostUp/02-Ingest.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/02-Ingest.sql
@@ -354,7 +354,7 @@ INSERT INTO public.ingest (
   , 'CBCV' -- topic
   , talkRadioId -- product_id
   , '{ "serviceType":"stream",
-      "url": "https://cbcradiolive.akamaized.net/hls/live/2041051/ES_R1PVI/master.m3u8",
+      "url": "http://cbcmp3.ic.llnwd.net/stream/cbcmp3_cbc_r1_vcr",
       "timeZone":"Pacific Standard Time",
       "language": "en-CA",
       "post": false,

--- a/openshift/kustomize/README.md
+++ b/openshift/kustomize/README.md
@@ -20,3 +20,12 @@ oc kustomize ./overlays/dev | oc create -f -
 | ------------------------------------------------------- | --------------------------------------------------------- |
 | [CrunchyDB HA Cluster](./postgres/crunchy/README.md)    | High availability PostgreSQL database cluster.            |
 | [CrunchyDB HA Monitoring](./postgres/monitor/README.md) | High availability PostgreSQL database cluster monitoring. |
+
+## Setup Environment
+
+To setup each environment start with the Kafka installation.
+This will create a service-account in the environment that is required.
+
+```bash
+oc kustomize kafka/zookeeper/overlays/test | oc create -f -
+```

--- a/openshift/kustomize/elastic/overlays/test/kustomization.yaml
+++ b/openshift/kustomize/elastic/overlays/test/kustomization.yaml
@@ -15,6 +15,13 @@ patches:
         path: /spec/host
         value: tno-test.apps.silver.devops.gov.bc.ca
   - target:
+      kind: Route
+      name: elastic-dejavu
+    patch: |-
+      - op: replace
+        path: /spec/host
+        value: tno-test-elastic.apps.silver.devops.gov.bc.ca
+  - target:
       kind: StatefulSet
       name: elastic
     patch: |-


### PR DESCRIPTION
Minor tweak to the Initial DB migration script what configures the ingest for the radio stream.  It'll now use the mp3 endpoint instead of the m3u8 one.  This is because Openshift continues to have network issues on the m3u8 route.

Minor updates for DevOps Infrastructure as Code.