### PR TITLE
Fix content form layout

### DIFF
--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -460,7 +460,7 @@ export const ContentForm: React.FC<IContentFormProps> = ({ contentType: initCont
                 <Row>
                   <Show visible={isSnippetForm(contentType)}>
                     <Tabs
-                      className={`tabs ${size === 1 ? 'small' : 'large'}`}
+                      className={`${combined ? 'fit' : 'expand'} ${size === 1 ? 'small' : 'large'}`}
                       tabs={
                         <>
                           <Tab

--- a/app/editor/src/features/content/form/styled/ContentForm.tsx
+++ b/app/editor/src/features/content/form/styled/ContentForm.tsx
@@ -39,9 +39,11 @@ export const ContentForm = styled.div`
     display: none;
   }
 
-  .tab-container {
-    height: calc(100vh - 580px);
-    overflow-y: auto;
+  .tabs.fit {
+    .tab-container {
+      height: calc(100vh - 580px);
+      overflow-y: auto;
+    }
   }
 
   .tabs.small {


### PR DESCRIPTION
The Content Form layout should expand and have vertical scrolling when it is on its own page.  When it is part of the combined page it should fit the page.

![image](https://user-images.githubusercontent.com/3180256/194368022-350f2f21-a0aa-43c9-8345-1b63a067ca32.png)
