### PR TITLE
TNO-646 Fix published on

### DIFF
--- a/app/editor/src/features/admin/ingests/IngestSettings.tsx
+++ b/app/editor/src/features/admin/ingests/IngestSettings.tsx
@@ -80,6 +80,16 @@ export const IngestSettings: React.FC<IIngestSettingsProps> = () => {
               }}
               required
             />
+            <Show
+              visible={values.sourceConnection?.connectionType === ConnectionTypeName.LocalVolume}
+            >
+              <FormikText
+                label="Path"
+                name="_.path"
+                value={values.sourceConnection?.configuration.path}
+                disabled
+              />
+            </Show>
             <Show visible={values.sourceConnection?.connectionType === ConnectionTypeName.SSH}>
               <FormikText
                 label="Hostname"
@@ -110,7 +120,7 @@ export const IngestSettings: React.FC<IIngestSettingsProps> = () => {
               <Row>
                 <Col flex="1 1 0">
                   <FormikText
-                    label="Connection Path to Files"
+                    label="Volume Path"
                     name="_.path"
                     value={values.sourceConnection?.configuration.path}
                     disabled
@@ -140,6 +150,18 @@ export const IngestSettings: React.FC<IIngestSettingsProps> = () => {
               }}
               required
             />
+            <Show
+              visible={
+                values.destinationConnection?.connectionType === ConnectionTypeName.LocalVolume
+              }
+            >
+              <FormikText
+                label="Path"
+                name="_.path"
+                value={values.destinationConnection?.configuration.path}
+                disabled
+              />
+            </Show>
             <p>
               Select if content should be posted to Kafka. If the service doesn't generate content
               it doesn't need to capture.

--- a/app/editor/src/features/admin/ingests/configurations/Newspaper.tsx
+++ b/app/editor/src/features/admin/ingests/configurations/Newspaper.tsx
@@ -24,6 +24,18 @@ export const Newspaper: React.FC = (props) => {
           <FormikCheckbox label="Escape Content" name="configuration.escapeContent" />
           <FormikCheckbox label="Add Parent" name="configuration.addParent" />
         </Col>
+        <Col flex="1 1 0"></Col>
+      </Row>
+      <Row>
+        <Col flex="1 1 0">
+          <FormikSelect
+            label="Timezone"
+            name="configuration.timeZone"
+            tooltip="Timezone of the source"
+            options={TimeZones}
+            defaultValue={timeZone}
+          />
+        </Col>
         <Col flex="1 1 0">
           <FormikText
             label="Date Offset"
@@ -37,11 +49,12 @@ export const Newspaper: React.FC = (props) => {
       <Row>
         <Col flex="1 1 0">
           <FormikSelect
-            label="Timezone"
-            name="configuration.timeZone"
-            tooltip="Timezone of the source"
-            options={TimeZones}
-            defaultValue={timeZone}
+            label="File Type"
+            name="configuration.fileFormat"
+            tooltip="The file extension (xml, fms)"
+            options={FileTypes}
+            defaultValue={fileType}
+            required
           />
         </Col>
         <Col flex="1 1 0">
@@ -56,13 +69,10 @@ export const Newspaper: React.FC = (props) => {
       </Row>
       <Row>
         <Col flex="1 1 0">
-          <FormikSelect
-            label="File Type"
-            name="configuration.fileFormat"
-            tooltip="The file extension (xml, fms)"
-            options={FileTypes}
-            defaultValue={fileType}
-            required
+          <FormikText
+            label="Path to Files"
+            name="configuration.path"
+            value={values.configuration.path}
           />
         </Col>
         <Col flex="1 1 0">

--- a/app/editor/src/features/content/form/ContentSummaryForm.tsx
+++ b/app/editor/src/features/content/form/ContentSummaryForm.tsx
@@ -9,6 +9,8 @@ import { ContentTypeName, IUserModel } from 'hooks/api-editor';
 import { useModal } from 'hooks/modal';
 import moment from 'moment';
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
 import { useContent, useLookup } from 'store/hooks';
 import { Button, ButtonVariant, Col, FieldSize, Row, Show, useKeycloakWrapper } from 'tno-core';
 import { getSortableOptions } from 'utils';
@@ -44,6 +46,7 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
   const { isShowing, toggle } = useModal();
   const [, { download }] = useContent();
   const combined = useCombinedView();
+  const navigate = useNavigate();
 
   const [categoryOptions, setCategoryOptions] = React.useState<IOptionItem[]>([]);
   const [seriesOptions, setSeriesOptions] = React.useState<IOptionItem[]>([]);
@@ -63,6 +66,16 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
     : undefined;
   const [streamUrl, setStreamUrl] = React.useState<string>('');
   const videoRef = React.useRef<HTMLVideoElement>(null);
+
+  React.useEffect(() => {
+    // This should never occur, but if keycloak is not configured correctly, or the local storage is missing their account it can.
+    if (!userId) {
+      toast.error(
+        'Your user account is missing.  Try refreshing your page.  If the issue persists contact support.',
+      );
+      navigate('/error');
+    }
+  }, [navigate, userId]);
 
   React.useEffect(() => {
     setEffort(getTotalTime(values.timeTrackings));
@@ -182,7 +195,7 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
               }
               value={
                 !!values.publishedOn
-                  ? moment(values.publishedOn).format('MMMM D, yyyy HH:mm:ss')
+                  ? moment(values.publishedOn).format('MMM D, yyyy HH:mm:ss')
                   : ''
               }
               onChange={(date: any) => {
@@ -332,7 +345,7 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
             setFieldValue('timeTrackings', [
               ...values.timeTrackings,
               {
-                userId: userId ?? 0,
+                userId: userId,
                 activity: !!values.id ? 'Updated' : 'Created',
                 effort: (values as any).prep,
                 createdOn: new Date(),

--- a/app/editor/src/features/router/AppRouter.tsx
+++ b/app/editor/src/features/router/AppRouter.tsx
@@ -9,7 +9,7 @@ import { ContentTypeName } from 'hooks';
 import React from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { useApp } from 'store/hooks';
-import { Claim, NotFound } from 'tno-core';
+import { Claim, InternalServerError, NotFound } from 'tno-core';
 
 import { PrivateRoute } from '.';
 
@@ -91,6 +91,7 @@ export const AppRouter: React.FC<IAppRouter> = ({ name }) => {
           path="reports/*"
           element={<PrivateRoute claims={Claim.administrator} element={<ReportsRouter />} />}
         />
+        <Route path="error" element={<InternalServerError />} />
         <Route path="*" element={<NotFound />} />
       </Route>
     </Routes>

--- a/libs/net/core/Extensions/DateTimeExtensions.cs
+++ b/libs/net/core/Extensions/DateTimeExtensions.cs
@@ -14,6 +14,6 @@ public static class DateTimeExtensions
     public static DateTime ToTimeZone(this DateTime date, string timeZoneId)
     {
         var timezone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
-        return new DateTime(TimeZoneInfo.ConvertTime(date, timezone).Ticks, DateTimeKind.Local);
+        return TimeZoneInfo.ConvertTime(date, timezone);
     }
 }

--- a/libs/net/dal/Migrations/Initial/Up/PostUp/00-Connection.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/00-Connection.sql
@@ -91,7 +91,7 @@ INSERT INTO public.connection (
   , 'Meltwater and Blacks News Group upload files to this location.' -- description
   , true -- is_enabled
   , 7 -- connection_type - SSH
-  , '{"path":"/dsk98/processed/","username":"ckayfish","hostname":"scharnhorst.tno.gov.bc.ca","keyFileName":"id_rsa"}' -- configuration
+  , '{"path":"/dsk98","username":"ckayfish","hostname":"scharnhorst.tno.gov.bc.ca","keyFileName":"id_rsa"}' -- configuration
   , true -- is_read_only
   , 0 -- sort_order
   , DEFAULT_USER_ID

--- a/libs/net/dal/Migrations/Initial/Up/PostUp/02-Ingest.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/02-Ingest.sql
@@ -312,6 +312,7 @@ INSERT INTO public.ingest (
       "language": "en-CA",
       "post": true,
       "import": true,
+      "path": "processed",
       "papername": "pubdata!name",
       "headline": "hl1",
       "summary": "hl1",
@@ -345,6 +346,7 @@ INSERT INTO public.ingest (
       "language": "en-CA",
       "post": true,
       "import": true,
+      "path": "processed",
       "papername": "pubdata!name",
       "headline": "hl1",
       "summary": "hl1",
@@ -380,6 +382,7 @@ INSERT INTO public.ingest (
       "language": "en-CA",
       "post": true,
       "import": true,
+      "path": "processed",
       "papername": "papername",
       "headline": "headline",
       "summary": "summary",
@@ -416,6 +419,7 @@ INSERT INTO public.ingest (
       "language": "en-CA",
       "post": true,
       "import": true,
+      "path": "processed",
       "papername": "!@PAPER=",
       "headline": "!@HEAD=",
       "summary": "!@ABSTRACT=",
@@ -454,7 +458,7 @@ INSERT INTO public.ingest (
   , (SELECT id FROM public.source WHERE code = 'GLOBE') -- source_id
   , 'GLOBE' -- topic
   , frontPageId -- product_id
-  , '{ "path": "/dsk98/binaryroot",
+  , '{ "path": "binaryroot",
       "fileName": "sv-GLB",
       "post": true,
       "import": true }' -- configuration

--- a/libs/net/services/Actions/IngestAction.cs
+++ b/libs/net/services/Actions/IngestAction.cs
@@ -2,9 +2,12 @@ using System.Net;
 using Confluent.Kafka;
 using Microsoft.Extensions.Options;
 using TNO.API.Areas.Services.Models.ContentReference;
+using TNO.API.Areas.Services.Models.Ingest;
 using TNO.Core.Exceptions;
+using TNO.Core.Extensions;
 using TNO.Entities;
 using TNO.Kafka.Models;
+using TNO.Services.Actions.Managers;
 using TNO.Services.Config;
 
 namespace TNO.Services.Actions;
@@ -111,6 +114,52 @@ public abstract class IngestAction<TOptions> : ServiceAction<TOptions>, IIngestA
 
             throw;
         }
+    }
+
+    /// <summary>
+    /// Get the TimeZoneInfo for the specified ingest configuration.
+    /// </summary>
+    /// <param name="ingest"></param>
+    /// <returns></returns>
+    protected TimeZoneInfo GetTimeZone(IngestModel ingest)
+    {
+        return TimeZoneInfo.FindSystemTimeZoneById(IngestActionManager<TOptions>.GetTimeZone(ingest, this.Options.TimeZone));
+    }
+
+    /// <summary>
+    /// Converts the specified date to the ingest timezone.
+    /// </summary>
+    /// <param name="ingest"></param>
+    /// <param name="date"></param>
+    /// <returns></returns>
+    protected DateTime ToTimeZone(DateTime date, IngestModel ingest)
+    {
+        var tz = TimeZoneInfo.FindSystemTimeZoneById(IngestActionManager<TOptions>.GetTimeZone(ingest, this.Options.TimeZone));
+        return TimeZoneInfo.ConvertTimeToUtc(date, tz);
+    }
+
+    /// <summary>
+    /// Convert to timezone and return as local.
+    /// Dates should be stored in the timezone of the data source.
+    /// </summary>
+    /// <param name="ingest"></param>
+    /// <param name="date"></param>
+    /// <returns></returns>
+    protected DateTime GetDateTimeForTimeZone(IngestModel ingest)
+    {
+        return DateTime.Now.ToTimeZone(IngestActionManager<TOptions>.GetTimeZone(ingest, this.Options.TimeZone));
+    }
+
+    /// <summary>
+    /// Convert to timezone and return as local.
+    /// Dates should be stored in the timezone of the data source.
+    /// </summary>
+    /// <param name="ingest"></param>
+    /// <param name="date"></param>
+    /// <returns></returns>
+    protected DateTime GetDateTimeForTimeZone(IngestModel ingest, DateTime date)
+    {
+        return date.ToTimeZone(IngestActionManager<TOptions>.GetTimeZone(ingest, this.Options.TimeZone));
     }
     #endregion
 }

--- a/libs/net/services/Actions/Managers/IngestActionManager`.cs
+++ b/libs/net/services/Actions/Managers/IngestActionManager`.cs
@@ -118,7 +118,7 @@ public class IngestActionManager<TOptions> : ServiceActionManager<TOptions>, IIn
     /// <returns></returns>
     public virtual bool VerifySchedule(ScheduleModel schedule)
     {
-        return VerifySchedule(GetSourceDateTime(DateTime.UtcNow), schedule);
+        return VerifySchedule(GetSourceDateTime(DateTime.Now), schedule);
     }
 
     /// <summary>
@@ -268,7 +268,6 @@ public class IngestActionManager<TOptions> : ServiceActionManager<TOptions>, IIn
     /// <summary>
     /// Get the timezone arguments from the connection settings.
     /// </summary>
-    /// <param name="dataSource"></param>
     /// <returns></returns>
     /// <exception cref="InvalidOperationException"></exception>
     protected string GetTimeZone()
@@ -277,15 +276,24 @@ public class IngestActionManager<TOptions> : ServiceActionManager<TOptions>, IIn
     }
 
     /// <summary>
+    /// Get the TimeZoneInfo for the current ingest configuration settings.
+    /// </summary>
+    /// <returns></returns>
+    public TimeZoneInfo GetTimeZoneInfo()
+    {
+        return TimeZoneInfo.FindSystemTimeZoneById(GetTimeZone());
+    }
+
+    /// <summary>
     /// Get the timezone arguments from the connection settings.
     /// </summary>
-    /// <param name="dataSource"></param>
+    /// <param name="ingest"></param>
     /// <param name="defaultTimeZone"></param>
     /// <returns></returns>
     /// <exception cref="InvalidOperationException"></exception>
-    public static string GetTimeZone(IngestModel dataSource, string defaultTimeZone)
+    public static string GetTimeZone(IngestModel ingest, string defaultTimeZone)
     {
-        var value = dataSource.GetConfigurationValue("timeZone");
+        var value = ingest.GetConfigurationValue("timeZone");
         return String.IsNullOrWhiteSpace(value) ? defaultTimeZone : value;
     }
     #endregion

--- a/services/net/clip/ClipAction.cs
+++ b/services/net/clip/ClipAction.cs
@@ -162,13 +162,15 @@ public class ClipAction : CommandAction<ClipOptions>
     /// <returns></returns>
     private ContentReferenceModel CreateContentReference(IngestModel ingest, ScheduleModel schedule)
     {
-        var today = GetLocalDateTime(ingest, DateTime.UtcNow);
-        var publishedOn = new DateTime(today.Year, today.Month, today.Day, 0, 0, 0, today.Kind) + schedule.StartAt;
+        var today = GetDateTimeForTimeZone(ingest);
+        var publishedOn = new DateTime(today.Year, today.Month, today.Day, 0, 0, 0, today.Kind);
+        if (schedule.StartAt.HasValue)
+            publishedOn = publishedOn.Add(schedule.StartAt.Value);
         return new ContentReferenceModel()
         {
             Source = ingest.Source?.Code ?? throw new InvalidOperationException($"Ingest '{ingest.Name}' missing source code."),
             Uid = $"{schedule.Name}:{schedule.Id}-{publishedOn:yyyy-MM-dd-hh-mm-ss}",
-            PublishedOn = publishedOn?.ToUniversalTime(),
+            PublishedOn = this.ToTimeZone(publishedOn, ingest).ToUniversalTime(),
             Topic = ingest.Topic,
             Status = (int)WorkflowStatus.InProgress
         };
@@ -229,7 +231,7 @@ public class ClipAction : CommandAction<ClipOptions>
     protected override IEnumerable<ScheduleModel> GetSchedules(IngestModel ingest)
     {
         var keepChecking = bool.Parse(ingest.GetConfigurationValue("keepChecking"));
-        var now = GetLocalDateTime(ingest, DateTime.UtcNow).TimeOfDay;
+        var now = GetDateTimeForTimeZone(ingest).TimeOfDay;
         return ingest.IngestSchedules.Where(s =>
             s.Schedule != null &&
             s.Schedule.StopAt != null &&
@@ -303,7 +305,7 @@ public class ClipAction : CommandAction<ClipOptions>
     private async Task<string> GetInputFileAsync(IngestModel ingest, ScheduleModel schedule)
     {
         // TODO: Handle issue where capture failed and has multiple files.
-        var path = Path.Combine(this.Options.VolumePath, ingest.SourceConnection?.GetConfigurationValue("path")?.MakeRelativePath() ?? "", $"{ingest.Source?.Code}/{GetLocalDateTime(ingest, DateTime.Now):yyyy-MM-dd}");
+        var path = Path.Combine(this.Options.VolumePath, ingest.SourceConnection?.GetConfigurationValue("path")?.MakeRelativePath() ?? "", $"{ingest.Source?.Code}/{GetDateTimeForTimeZone(ingest):yyyy-MM-dd}");
         var clipStart = schedule.StartAt;
 
         // Review each file that was captured to determine which one is valid for this clip schedule.
@@ -416,7 +418,7 @@ public class ClipAction : CommandAction<ClipOptions>
     /// <returns></returns>
     protected string GetOutputPath(IngestModel ingest)
     {
-        return Path.Combine(this.Options.VolumePath, ingest.DestinationConnection?.GetConfigurationValue("path")?.MakeRelativePath() ?? "", $"{ingest.Source?.Code}/{GetLocalDateTime(ingest, DateTime.Now):yyyy-MM-dd}");
+        return Path.Combine(this.Options.VolumePath, ingest.DestinationConnection?.GetConfigurationValue("path")?.MakeRelativePath() ?? "", $"{ingest.Source?.Code}/{GetDateTimeForTimeZone(ingest):yyyy-MM-dd}");
     }
 
     /// <summary>

--- a/services/net/command/CommandAction`.cs
+++ b/services/net/command/CommandAction`.cs
@@ -283,18 +283,6 @@ public abstract class CommandAction<TOptions> : IngestAction<TOptions>
     }
 
     /// <summary>
-    /// Convert to timezone and return as local.
-    /// Dates should be stored in the timezone of the data source.
-    /// </summary>
-    /// <param name="ingest"></param>
-    /// <param name="date"></param>
-    /// <returns></returns>
-    protected DateTime GetLocalDateTime(IngestModel ingest, DateTime date)
-    {
-        return date.ToTimeZone(CommandIngestActionManager.GetTimeZone(ingest, this.Options.TimeZone));
-    }
-
-    /// <summary>
     /// Generate the command arguments for this service action.
     /// </summary>
     /// <param name="process"></param>


### PR DESCRIPTION
When a user is missing from the lookups due to either local storage not being up-to-date, or keycloak incorrectly configured it will now redirect to an error page.

Fixed time zone issues with the published on date.  The correct value will be displayed for content created by Capture and Clip Service.

Fixed configuration issues with File and Image Service.

> Will require `make db-refresh` if you want the latest ingest configuration