### PR TITLE
TNO-35 Improve DevOps pipeline

### DIFF
--- a/openshift/kustomize/api/base/deploy.yaml
+++ b/openshift/kustomize/api/base/deploy.yaml
@@ -16,6 +16,7 @@ metadata:
     created-by: jeremy.foster
 spec:
   replicas: 3
+  test: false
   selector:
     part-of: tno
     component: api
@@ -27,6 +28,17 @@ spec:
       timeoutSeconds: 600
       updatePeriodSeconds: 1
     type: Rolling
+  triggers:
+    - type: ConfigChange
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+          - api
+        from:
+          kind: ImageStreamTag
+          namespace: 9b301c-tools
+          name: api:dev
   template:
     metadata:
       name: api
@@ -205,15 +217,3 @@ spec:
       restartPolicy: Always
       securityContext: {}
       terminationGracePeriodSeconds: 30
-  test: false
-  triggers:
-    - type: ConfigChange
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-          - api
-        from:
-          kind: ImageStreamTag
-          namespace: 9b301c-tools
-          name: api:dev

--- a/openshift/kustomize/tekton/base/conditions/has-changed.yaml
+++ b/openshift/kustomize/tekton/base/conditions/has-changed.yaml
@@ -1,0 +1,21 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Condition
+metadata:
+  name: has-changed
+spec:
+  workspaces:
+    - name: source
+  params:
+    - name: PATH
+  check:
+    image: alpine/git:latest
+    script: |
+      changes() {
+        git diff --name-only --diff-filter=AMDR --cached @~..@
+      }
+
+      if changes | grep -q $(params.PATH) {
+        exit 0
+      }
+
+      exit 1

--- a/openshift/kustomize/tekton/base/deploy.yaml
+++ b/openshift/kustomize/tekton/base/deploy.yaml
@@ -3,13 +3,13 @@
 kind: DeploymentConfig
 apiVersion: apps.openshift.io/v1
 metadata:
-  name: debian-git
+  name: git
   namespace: default
   annotations:
     description: Defines how to deploy git
     created-by: jeremy.foster
   labels:
-    name: debian-git
+    name: git
     part-of: tno
     version: 1.0.0
     component: git
@@ -19,15 +19,6 @@ spec:
   test: false
   triggers:
     - type: ConfigChange
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-          - api
-        from:
-          kind: ImageStreamTag
-          namespace: 9b301c-tools
-          name: debian-git:latest
   selector:
     part-of: tno
     component: git
@@ -41,7 +32,7 @@ spec:
     type: Rolling
   template:
     metadata:
-      name: debian-git
+      name: git
       labels:
         part-of: tno
         component: git
@@ -51,8 +42,8 @@ spec:
           persistentVolumeClaim:
             claimName: pipelines
       containers:
-        - name: debian-git
-          image: ""
+        - name: git
+          image: bitnami/git:latest
           imagePullPolicy: Always
           ports:
           volumeMounts:
@@ -63,10 +54,8 @@ spec:
               cpu: 20m
               memory: 50Mi
             limits:
-              cpu: 100m
-              memory: 500Mi
-          env:
-          livenessProbe:
+              cpu: 50m
+              memory: 150Mi
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       securityContext: {}

--- a/openshift/kustomize/tekton/base/pipeline-runs/buildah-main.yaml
+++ b/openshift/kustomize/tekton/base/pipeline-runs/buildah-main.yaml
@@ -1,0 +1,43 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: buildah-main-
+  annotations:
+    description: >-
+      Build an docker image from a GIT repository using an existing BuildConfig.
+      Then deploy to the specified environment.
+    tags: "oc,git,docker,build,deploy"
+  labels:
+    name: buildah-main-pipeline
+    part-of: tno
+    version: 1.0.0
+    component: pipeline
+    managed-by: kustomize
+spec:
+  pipelineRef:
+    name: buildah-main
+  params:
+    - name: GIT_REF
+      value: dev
+    - name: IMAGE_TAG
+      value: latest
+    - name: CONTEXT
+      value: tno
+  serviceAccountName: pipeline
+  timeout: 1h45m0s
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: pipelines
+    - name: conditions
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 50Mi
+          storageClassName: netapp-file-standard
+          volumeMode: Filesystem
+    - name: owasp-settings
+      emptyDir: {}

--- a/openshift/kustomize/tekton/base/pipeline-runs/buildah-services.yaml
+++ b/openshift/kustomize/tekton/base/pipeline-runs/buildah-services.yaml
@@ -1,0 +1,43 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: buildah-services-
+  annotations:
+    description: >-
+      Build an docker image from a GIT repository using an existing BuildConfig.
+      Then deploy to the specified environment.
+    tags: "oc,git,docker,build,deploy"
+  labels:
+    name: buildah-services-pipeline
+    part-of: tno
+    version: 1.0.0
+    component: pipeline
+    managed-by: kustomize
+spec:
+  pipelineRef:
+    name: buildah-services
+  params:
+    - name: GIT_REF
+      value: dev
+    - name: IMAGE_TAG
+      value: latest
+    - name: CONTEXT
+      value: tno
+  serviceAccountName: pipeline
+  timeout: 1h45m0s
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: pipelines
+    - name: conditions
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 50Mi
+          storageClassName: netapp-file-standard
+          volumeMode: Filesystem
+    - name: owasp-settings
+      emptyDir: {}

--- a/openshift/kustomize/tekton/base/pipelines/buildah-main.yaml
+++ b/openshift/kustomize/tekton/base/pipelines/buildah-main.yaml
@@ -1,0 +1,251 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: buildah-main
+  annotations:
+    tekton.dev/displayName: Buildah Pipeline
+    tekton.dev/pipelines.minVersion: 0.17.0
+    tekton.dev/tags: build deploy
+  labels:
+    name: buildah-main
+    part-of: tno
+    version: 1.0.0
+    component: pipeline
+    managed-by: kustomize
+spec:
+  params:
+    - name: GIT_REF
+      description: >-
+        The git revision reference to build.
+      type: string
+      default: dev
+
+    - name: CONTEXT
+      description: >-
+        The root path to the git repo.
+      type: string
+      default: tno
+
+    - name: IMAGE_TAG
+      description: >-
+        The tag given to the built images.
+        Use this to create versioned images.
+      type: string
+      default: latest
+
+    - name: PROJECT_SHORTNAME
+      description: >-
+        The project namespace shortname.
+        The part before the "-" (i.e. 9b301c-dev = 9b301c).
+      type: string
+      default: 9b301c
+
+    - name: DEPLOY_TO
+      description: >-
+        Identify the environment to deploy the solution to [dev,test,prod,tools].
+      type: string
+      default: dev
+
+    - name: EDITOR_URL
+      description: The URL to the web application that will be ZAP scanned.
+      type: string
+      default: https://tno-dev.apps.silver.devops.gov.bc.ca
+
+  workspaces:
+    - name: source
+      description: |
+        Git repo source code.
+    - name: conditions
+      description: |
+        Pipeline configuration file.
+    - name: owasp-settings
+      description: |
+        mounts /zap/wrk to store generated configs and results.
+
+  tasks:
+    - name: wait
+      taskRef:
+        name: pipeline-wait
+        kind: Task
+      params:
+        - name: PIPELINE_NAME
+          value: $(context.pipelineRun.name)
+
+    - name: git
+      taskRef:
+        name: git-conditions
+        kind: Task
+      runAfter:
+        - wait
+      params:
+        - name: GIT_REF
+          value: $(params.GIT_REF)
+        - name: CONTEXT
+          value: $(params.CONTEXT)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: output
+          workspace: conditions
+
+    - name: build-db-migration
+      taskRef:
+        name: build-component
+        kind: Task
+      runAfter:
+        - git
+      params:
+        - name: COMPONENT
+          value: db
+        - name: CONTEXT
+          value: $(params.CONTEXT)/libs/net
+        - name: IMAGE
+          value: db-migration
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: conditions
+          workspace: conditions
+
+    - name: build-editor
+      taskRef:
+        name: build-component
+        kind: Task
+      runAfter:
+        - git
+      params:
+        - name: COMPONENT
+          value: editor
+        - name: CONTEXT
+          value: $(params.CONTEXT)/app/editor
+        - name: IMAGE
+          value: editor
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: conditions
+          workspace: conditions
+
+    - name: build-api
+      taskRef:
+        name: build-component
+        kind: Task
+      runAfter:
+        - git
+      params:
+        - name: COMPONENT
+          value: api
+        - name: CONTEXT
+          value: $(params.CONTEXT)/api/net
+        - name: IMAGE
+          value: api
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: conditions
+          workspace: conditions
+
+    - name: maintenance-on
+      runAfter:
+        - build-db-migration
+        - build-api
+        - build-editor
+      taskRef:
+        name: oc-patch-route
+        kind: Task
+      params:
+        - name: PROJECT
+          value: $(params.PROJECT_SHORTNAME)-$(params.DEPLOY_TO)
+        - name: ROUTE
+          value: editor
+        - name: SERVICE
+          value: nginx
+
+    - name: db-migration
+      runAfter:
+        - maintenance-on
+      taskRef:
+        name: db-migration
+        kind: Task
+      params:
+        - name: MIGRATION_IMAGE
+          value: db-migration
+        - name: DB_SECRET_NAME
+          value: crunchy-pguser-admin
+        - name: API_NAME
+          value: api
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+        - name: DEPLOY_TO
+          value: $(params.DEPLOY_TO)
+
+    - name: deploy-api
+      runAfter:
+        - db-migration
+      taskRef:
+        name: oc-deploy-with-tag
+        kind: Task
+      params:
+        - name: PROJECT_SHORTNAME
+          value: $(params.PROJECT_SHORTNAME)
+        - name: IMAGE
+          value: api
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+        - name: ENV
+          value: $(params.DEPLOY_TO)
+
+    - name: deploy-editor
+      runAfter:
+        - db-migration
+      taskRef:
+        name: oc-deploy-with-tag
+        kind: Task
+      params:
+        - name: PROJECT_SHORTNAME
+          value: $(params.PROJECT_SHORTNAME)
+        - name: IMAGE
+          value: editor
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+        - name: ENV
+          value: $(params.DEPLOY_TO)
+
+    - name: maintenance-off
+      runAfter:
+        - db-migration
+        - deploy-api
+        - deploy-editor
+      taskRef:
+        name: oc-patch-route
+        kind: Task
+      params:
+        - name: PROJECT
+          value: $(params.PROJECT_SHORTNAME)-$(params.DEPLOY_TO)
+        - name: ROUTE
+          value: editor
+        - name: SERVICE
+          value: editor
+
+    - name: owasp-scan
+      taskRef:
+        name: owasp-scanner
+        kind: Task
+      runAfter:
+        - maintenance-off
+      params:
+        - name: TARGET_URL
+          value: $(params.EDITOR_URL)
+        - name: SCAN_TYPE
+          value: quick
+        - name: SCAN_DURATION
+          value: "1"
+      workspaces:
+        - name: owasp-settings
+          workspace: owasp-settings

--- a/openshift/kustomize/tekton/base/pipelines/buildah-services.yaml
+++ b/openshift/kustomize/tekton/base/pipelines/buildah-services.yaml
@@ -1,0 +1,422 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: buildah-services
+  annotations:
+    tekton.dev/displayName: Buildah Pipeline
+    tekton.dev/pipelines.minVersion: 0.17.0
+    tekton.dev/tags: build deploy
+  labels:
+    name: buildah-services
+    part-of: tno
+    version: 1.0.0
+    component: pipeline
+    managed-by: kustomize
+spec:
+  params:
+    - name: GIT_REF
+      description: >-
+        The git revision reference to build.
+      type: string
+      default: dev
+
+    - name: CONTEXT
+      description: >-
+        The root path to the git repo.
+      type: string
+      default: tno
+
+    - name: IMAGE_TAG
+      description: >-
+        The tag given to the built images.
+        Use this to create versioned images.
+      type: string
+      default: latest
+
+    - name: PROJECT_SHORTNAME
+      description: >-
+        The project namespace shortname.
+        The part before the "-" (i.e. 9b301c-dev = 9b301c).
+      type: string
+      default: 9b301c
+
+    - name: DEPLOY_TO
+      description: >-
+        Identify the environment to deploy the solution to [dev,test,prod,tools].
+      type: string
+      default: dev
+
+  workspaces:
+    - name: source
+      description: |
+        Git repo source code.
+    - name: conditions
+      description: |
+        Pipeline configuration file.
+
+  tasks:
+    - name: git
+      taskRef:
+        name: git-conditions
+        kind: Task
+      params:
+        - name: GIT_REF
+          value: $(params.GIT_REF)
+        - name: CONTEXT
+          value: $(params.CONTEXT)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: output
+          workspace: conditions
+
+    - name: build-syndication
+      taskRef:
+        name: build-component
+        kind: Task
+      runAfter:
+        - git
+      params:
+        - name: COMPONENT
+          value: syndication
+        - name: CONTEXT
+          value: $(params.CONTEXT)/services/net
+        - name: DOCKERFILE
+          value: syndication/Dockerfile
+        - name: IMAGE
+          value: syndication-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: conditions
+          workspace: conditions
+
+    - name: deploy-syndication
+      runAfter:
+        - build-syndication
+      taskRef:
+        name: oc-deploy-with-tag
+        kind: Task
+      params:
+        - name: PROJECT_SHORTNAME
+          value: $(params.PROJECT_SHORTNAME)
+        - name: IMAGE
+          value: syndication-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+        - name: ENV
+          value: $(params.DEPLOY_TO)
+
+    - name: build-capture
+      taskRef:
+        name: build-component
+        kind: Task
+      runAfter:
+        - git
+      params:
+        - name: COMPONENT
+          value: capture
+        - name: CONTEXT
+          value: $(params.CONTEXT)/services/net
+        - name: DOCKERFILE
+          value: capture/Dockerfile
+        - name: IMAGE
+          value: capture-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: conditions
+          workspace: conditions
+
+    - name: deploy-capture
+      runAfter:
+        - build-capture
+      taskRef:
+        name: oc-deploy-with-tag
+        kind: Task
+      params:
+        - name: PROJECT_SHORTNAME
+          value: $(params.PROJECT_SHORTNAME)
+        - name: IMAGE
+          value: capture-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+        - name: ENV
+          value: $(params.DEPLOY_TO)
+
+    - name: build-clip
+      taskRef:
+        name: build-component
+        kind: Task
+      runAfter:
+        - git
+      params:
+        - name: COMPONENT
+          value: clip
+        - name: CONTEXT
+          value: $(params.CONTEXT)/services/net
+        - name: DOCKERFILE
+          value: clip/Dockerfile
+        - name: IMAGE
+          value: clip-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: conditions
+          workspace: conditions
+
+    - name: deploy-clip
+      runAfter:
+        - build-clip
+      taskRef:
+        name: oc-deploy-with-tag
+        kind: Task
+      params:
+        - name: PROJECT_SHORTNAME
+          value: $(params.PROJECT_SHORTNAME)
+        - name: IMAGE
+          value: clip-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+        - name: ENV
+          value: $(params.DEPLOY_TO)
+
+    - name: build-filemonitor
+      taskRef:
+        name: build-component
+        kind: Task
+      runAfter:
+        - git
+      params:
+        - name: COMPONENT
+          value: filemonitor
+        - name: CONTEXT
+          value: $(params.CONTEXT)/services/net
+        - name: DOCKERFILE
+          value: filemonitor/Dockerfile
+        - name: IMAGE
+          value: filemonitor-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: conditions
+          workspace: conditions
+
+    - name: deploy-filemonitor
+      runAfter:
+        - build-filemonitor
+      taskRef:
+        name: oc-deploy-with-tag
+        kind: Task
+      params:
+        - name: PROJECT_SHORTNAME
+          value: $(params.PROJECT_SHORTNAME)
+        - name: IMAGE
+          value: filemonitor-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+        - name: ENV
+          value: $(params.DEPLOY_TO)
+
+    - name: build-image
+      taskRef:
+        name: build-component
+        kind: Task
+      runAfter:
+        - git
+      params:
+        - name: COMPONENT
+          value: image
+        - name: CONTEXT
+          value: $(params.CONTEXT)/services/net
+        - name: DOCKERFILE
+          value: image/Dockerfile
+        - name: IMAGE
+          value: image-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: conditions
+          workspace: conditions
+
+    - name: deploy-image
+      runAfter:
+        - build-image
+      taskRef:
+        name: oc-deploy-with-tag
+        kind: Task
+      params:
+        - name: PROJECT_SHORTNAME
+          value: $(params.PROJECT_SHORTNAME)
+        - name: IMAGE
+          value: image-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+        - name: ENV
+          value: $(params.DEPLOY_TO)
+
+    - name: build-content
+      taskRef:
+        name: build-component
+        kind: Task
+      runAfter:
+        - git
+      params:
+        - name: COMPONENT
+          value: content
+        - name: CONTEXT
+          value: $(params.CONTEXT)/services/net
+        - name: DOCKERFILE
+          value: content/Dockerfile
+        - name: IMAGE
+          value: content-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: conditions
+          workspace: conditions
+
+    - name: deploy-content
+      runAfter:
+        - build-content
+      taskRef:
+        name: oc-deploy-with-tag
+        kind: Task
+      params:
+        - name: PROJECT_SHORTNAME
+          value: $(params.PROJECT_SHORTNAME)
+        - name: IMAGE
+          value: content-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+        - name: ENV
+          value: $(params.DEPLOY_TO)
+
+    - name: build-indexing
+      taskRef:
+        name: build-component
+        kind: Task
+      runAfter:
+        - git
+      params:
+        - name: COMPONENT
+          value: indexing
+        - name: CONTEXT
+          value: $(params.CONTEXT)/services/net
+        - name: DOCKERFILE
+          value: indexing/Dockerfile
+        - name: IMAGE
+          value: indexing-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: conditions
+          workspace: conditions
+
+    - name: deploy-indexing
+      runAfter:
+        - build-indexing
+      taskRef:
+        name: oc-deploy-with-tag
+        kind: Task
+      params:
+        - name: PROJECT_SHORTNAME
+          value: $(params.PROJECT_SHORTNAME)
+        - name: IMAGE
+          value: indexing-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+        - name: ENV
+          value: $(params.DEPLOY_TO)
+
+    - name: build-transcription
+      taskRef:
+        name: build-component
+        kind: Task
+      runAfter:
+        - git
+      params:
+        - name: COMPONENT
+          value: transcription
+        - name: CONTEXT
+          value: $(params.CONTEXT)/services/net
+        - name: DOCKERFILE
+          value: transcription/Dockerfile
+        - name: IMAGE
+          value: transcription-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: conditions
+          workspace: conditions
+
+    - name: deploy-transcription
+      runAfter:
+        - build-transcription
+      taskRef:
+        name: oc-deploy-with-tag
+        kind: Task
+      params:
+        - name: PROJECT_SHORTNAME
+          value: $(params.PROJECT_SHORTNAME)
+        - name: IMAGE
+          value: transcription-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+        - name: ENV
+          value: $(params.DEPLOY_TO)
+
+    - name: build-nlp
+      taskRef:
+        name: build-component
+        kind: Task
+      runAfter:
+        - git
+      params:
+        - name: COMPONENT
+          value: nlp
+        - name: CONTEXT
+          value: $(params.CONTEXT)/services/net
+        - name: DOCKERFILE
+          value: nlp/Dockerfile
+        - name: IMAGE
+          value: nlp-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: conditions
+          workspace: conditions
+
+    - name: deploy-nlp
+      runAfter:
+        - build-nlp
+      taskRef:
+        name: oc-deploy-with-tag
+        kind: Task
+      params:
+        - name: PROJECT_SHORTNAME
+          value: $(params.PROJECT_SHORTNAME)
+        - name: IMAGE
+          value: nlp-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+        - name: ENV
+          value: $(params.DEPLOY_TO)

--- a/openshift/kustomize/tekton/base/task-runs/buildah.yaml
+++ b/openshift/kustomize/tekton/base/task-runs/buildah.yaml
@@ -1,0 +1,22 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: example-buildah-run
+
+spec:
+  taskRef:
+    kind: Task
+    name: buildah
+
+  params:
+    - name: CONTEXT
+      value: ./tno
+    - name: DOCKERFILE
+      value: ./api/net/Dockerfile
+    - name: IMAGE
+      value: api
+
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: pipelines

--- a/openshift/kustomize/tekton/base/task-runs/git-pull.yaml
+++ b/openshift/kustomize/tekton/base/task-runs/git-pull.yaml
@@ -1,0 +1,20 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: example-git-pull-run
+
+spec:
+  taskRef:
+    kind: Task
+    name: git-pull
+
+  params:
+    - name: GIT_REF
+      value: dev
+    - name: CONTEXT
+      value: ./tno
+
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: pipelines

--- a/openshift/kustomize/tekton/base/tasks/build-component.yaml
+++ b/openshift/kustomize/tekton/base/tasks/build-component.yaml
@@ -1,0 +1,106 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: build-component
+  description: |
+    Using Buildah build a new image from source code and push the new image
+    to the specified image registry.
+    Only build the images that have been identified as updated by git.
+  annotations:
+    tekton.dev/displayName: Buildah Image
+    tekton.dev/pipelines.minVersion: 0.17.0
+    tekton.dev/tags: build
+  labels:
+    name: build-component
+    part-of: tno
+    version: 1.0.0
+    component: task
+    managed-by: kustomize
+spec:
+  params:
+    - name: CONTEXT
+      description: Path to the source code to build.
+      default: .
+    - name: DOCKERFILE
+      description: Path to the Dockerfile to build.
+      default: ./Dockerfile
+
+    - name: COMPONENT
+      description: |
+        The name of the component (often the same as the image name).
+        This must match the component names setup in the git-conditions Task.
+    - name: IMAGE_REGISTRY
+      description: The Root url of the image registry.
+      default: image-registry.openshift-image-registry.svc:5000/9b301c-tools
+    - name: IMAGE
+      description: Reference of the image buildah will produce.
+      default: db-migration
+    - name: IMAGE_TAG
+      description: The tag given to the built image.
+      type: string
+      default: latest
+
+    - name: STORAGE_DRIVER
+      description: Set buildah storage driver
+      default: vfs
+  workspaces:
+    - name: source
+    - name: conditions
+      mountPath: /data
+  steps:
+    - name: build
+      image: buildah:latest
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: IMAGE_REGISTRY_USER
+          valueFrom:
+            secretKeyRef:
+              name: pipelines
+              key: username
+        - name: IMAGE_REGISTRY_PASS
+          valueFrom:
+            secretKeyRef:
+              name: pipelines
+              key: password
+      resources:
+        requests:
+          memory: 250Mi
+          cpu: 250m
+        limits:
+          memory: 1Gi
+          cpu: 500m
+      script: |
+        #!/usr/bin/env bash
+
+        # Place config into environment variables.
+        if test -f $(workspaces.conditions.path)/build.env; then
+          export $(grep -v '^#' $(workspaces.conditions.path)/build.env | xargs)
+        else
+          echo 'Workspace conditions build.env not found'
+          exit 1;
+        fi
+
+        # Dynamic variable to control what will be built.
+        COMPONENT='BUILD_$(params.COMPONENT)'
+        COMPONENT=${COMPONENT^^}
+        echo $COMPONENT=${!COMPONENT}
+
+        # Check if this image needs to be built.
+        if [ "${!COMPONENT}" = true ]; then
+          echo 'Build $(params.IMAGE)'
+          if [ ! -z "$IMAGE_REGISTRY_USER" ];  then
+            buildah login \
+              -u $IMAGE_REGISTRY_USER \
+              -p $IMAGE_REGISTRY_PASS $(params.IMAGE_REGISTRY) > /dev/null
+          fi
+
+          # Build the image.
+          buildah --storage-driver=$(params.STORAGE_DRIVER) bud \
+            --no-cache -f $(params.DOCKERFILE) -t $(params.IMAGE_REGISTRY)/$(params.IMAGE):$(params.IMAGE_TAG) --isolation chroot $(params.CONTEXT)
+
+          # Push the image to the registry.
+          buildah --storage-driver=$(params.STORAGE_DRIVER) push $(params.IMAGE_REGISTRY)/$(params.IMAGE):$(params.IMAGE_TAG)
+          set -x
+        else
+          echo 'Do not build $(params.IMAGE)'
+        fi

--- a/openshift/kustomize/tekton/base/tasks/buildah.yaml
+++ b/openshift/kustomize/tekton/base/tasks/buildah.yaml
@@ -1,0 +1,79 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: buildah
+  description: |
+    Using Buildah build a new image from source code and push the new image
+    to the specified image registry.
+  annotations:
+    tekton.dev/displayName: Buildah Image
+    tekton.dev/pipelines.minVersion: 0.17.0
+    tekton.dev/tags: build
+  labels:
+    name: buildah
+    part-of: tno
+    version: 1.0.0
+    component: task
+    managed-by: kustomize
+spec:
+  params:
+    - name: CONTEXT
+      description: Path to the source code to build.
+      default: .
+    - name: DOCKERFILE
+      description: Path to the Dockerfile to build.
+      default: ./Dockerfile
+
+    - name: IMAGE_REGISTRY
+      description: The Root url of the image registry.
+      default: image-registry.openshift-image-registry.svc:5000/9b301c-tools
+    - name: IMAGE
+      description: Reference of the image buildah will produce.
+    - name: IMAGE_TAG
+      description: The tag given to the built image.
+      type: string
+      default: latest
+
+    - name: STORAGE_DRIVER
+      description: Set buildah storage driver
+      default: vfs
+  workspaces:
+    - name: source
+  steps:
+    - name: build
+      image: buildah:latest
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: IMAGE_REGISTRY_USER
+          valueFrom:
+            secretKeyRef:
+              name: pipelines
+              key: username
+        - name: IMAGE_REGISTRY_PASS
+          valueFrom:
+            secretKeyRef:
+              name: pipelines
+              key: password
+      resources:
+        requests:
+          memory: 250Mi
+          cpu: 250m
+        limits:
+          memory: 1Gi
+          cpu: 500m
+      script: |
+        #!/usr/bin/env bash
+
+        if [ ! -z "$IMAGE_REGISTRY_USER" ];  then
+          buildah login \
+            -u $IMAGE_REGISTRY_USER \
+            -p $IMAGE_REGISTRY_PASS $(params.IMAGE_REGISTRY) > /dev/null
+        fi
+
+        # Build the image.
+        buildah --storage-driver=$(params.STORAGE_DRIVER) bud \
+          --no-cache -f $(params.DOCKERFILE) -t $(params.IMAGE_REGISTRY)/$(params.IMAGE):$(params.IMAGE_TAG) --isolation chroot $(params.CONTEXT)
+
+        # Push the image to the registry.
+        buildah --storage-driver=$(params.STORAGE_DRIVER) push $(params.IMAGE_REGISTRY)/$(params.IMAGE):$(params.IMAGE_TAG)
+        set -x

--- a/openshift/kustomize/tekton/base/tasks/db-migration.yaml
+++ b/openshift/kustomize/tekton/base/tasks/db-migration.yaml
@@ -1,0 +1,72 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: db-migration
+  description: >-
+    This task runs the database migration.
+  annotations:
+    tekton.dev/displayName: Run Database Migration
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: docker
+  labels:
+    name: db-migration
+    part-of: tno
+    version: 1.0.0
+    component: task
+    managed-by: kustomize
+spec:
+  params:
+    - name: IMAGE
+      description: The name of the database migration image.
+      type: string
+      default: db-migration
+    - name: DB_SECRET_NAME
+      description: The name of the database secrets.
+      type: string
+      default: crunchy-pguser-admin
+    - name: API_NAME
+      description: The name of the database.
+      type: string
+      default: api
+    - name: PROJECT_SHORTNAME
+      description: The shortname of the project namespace.
+      type: string
+      default: 9b301c
+
+    - name: IMAGE_TAG
+      description: The tag given to the built image.
+      type: string
+      default: latest
+
+    - name: DEPLOY_TO
+      description: Which environment to deploy to
+      type: string
+      default: dev
+
+  steps:
+    - name: run
+      image: "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest"
+      resources: {}
+      script: |
+        #!/usr/bin/env bash
+        echo "Fetching connection information"
+
+        PROJECT=$(params.PROJECT_SHORTNAME)-$(params.DEPLOY_TO)
+        IMAGE=image-registry.apps.silver.devops.gov.bc.ca/$(params.PROJECT_SHORTNAME)-tools/$(params.IMAGE):$(params.IMAGE_TAG)
+        CONNECTION_STRING=$(oc -n $PROJECT get configmap $(params.API_NAME) -o jsonpath='{.data.CONNECTION_STRING}')
+        DB_USERNAME=$(oc -n $PROJECT get secret $(params.DB_SECRET_NAME) -o jsonpath='{.data.user}' | base64 -d)
+        DB_PASSWORD=$(oc -n $PROJECT get secret $(params.DB_SECRET_NAME) -o jsonpath='{.data.password}' | base64 -d)
+
+        echo "Running database migration in $PROJECT"
+        oc run $(params.IMAGE) \
+          -n $PROJECT \
+          --image=$IMAGE \
+          --image-pull-policy=Always \
+          --attach \
+          --rm \
+          --labels='role=migration,part-of=tno,component=database' \
+          --restart=Never \
+          --env=ConnectionStrings__TNO="$CONNECTION_STRING" \
+          --env=DB_POSTGRES_USERNAME="$DB_USERNAME" \
+          --env=DB_POSTGRES_PASSWORD="$DB_PASSWORD" \
+          --timeout=10m

--- a/openshift/kustomize/tekton/base/tasks/git-conditions.yaml
+++ b/openshift/kustomize/tekton/base/tasks/git-conditions.yaml
@@ -1,0 +1,110 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-conditions
+  description: |
+    Update the git repo in the shared workspace with the latest commits for the
+    specified branch reference.
+    Creates a build.env file containing all the components that should be built based
+    on the changes made in the referenced commit.
+  annotations:
+    tekton.dev/displayName: Git Pull
+    tekton.dev/pipelines.minVersion: 0.17.0
+    tekton.dev/tags: git
+  labels:
+    name: git-output
+    part-of: tno
+    version: 1.0.0
+    component: task
+    managed-by: kustomize
+spec:
+  params:
+    - name: GIT_REF
+      description: Git reference or branch to build from.
+      default: dev
+
+    - name: CONTEXT
+      description: Path to the source code to build.
+      default: .
+  workspaces:
+    - name: source
+    - name: output
+      mountPath: /data
+  steps:
+    - name: pull
+      image: bitnami/git:latest
+      workingDir: $(workspaces.source.path)/$(params.CONTEXT)
+      resources:
+        requests:
+          memory: 100Mi
+          cpu: 50m
+        limits:
+          memory: 500Mi
+          cpu: 100m
+      script: |
+        #!/usr/bin/env bash
+        pwd
+
+        # Update the git repo with the latest commit.
+        git config --global --add safe.directory '*'
+        git checkout $(params.GIT_REF)
+        git pull
+        git show -s
+
+        # Identify what has changed.
+        DIFF=$(git diff --name-only --diff-filter=AMDR @~..@)
+        cd $(workspaces.output.path)
+        pwd
+        touch build.env
+
+        # Identify what needs to be built and deployed.
+        function build_service {
+          BUILD='BUILD_${1^^}=true'
+          if grep -s services/net/$1 <<< $DIFF; then
+            echo '$BUILD' >> build.env
+          elif grep -s libs/net/services <<< $DIFF; then
+            echo '$BUILD' >> build.env
+          elif grep -s libs/net/kafka <<< $DIFF; then
+            echo '$BUILD' >> build.env
+          elif grep -s libs/net/core <<< $DIFF; then
+            echo '$BUILD' >> build.env
+          fi
+        }
+
+        if grep -s libs/net/dal <<< $DIFF; then
+          echo 'BUILD_DB=true' >> build.env
+        fi
+
+        if grep -s app/editor <<< $DIFF; then
+          echo 'BUILD_EDITOR=true' >> build.env
+        fi
+
+        if grep -s api/net <<< $DIFF; then
+          echo 'BUILD_API=true' >> build.env
+        elif grep -s libs/net/dal <<< $DIFF; then
+          echo 'BUILD_API=true' >> build.env
+        elif grep -s libs/net/core <<< $DIFF; then
+          echo 'BUILD_API=true' >> build.env
+        elif grep -s libs/net/entities <<< $DIFF; then
+          echo 'BUILD_API=true' >> build.env
+        elif grep -s libs/net/models <<< $DIFF; then
+          echo 'BUILD_API=true' >> build.env
+        elif grep -s libs/net/ches <<< $DIFF; then
+          echo 'BUILD_API=true' >> build.env
+        elif grep -s libs/net/keycloak <<< $DIFF; then
+          echo 'BUILD_API=true' >> build.env
+        elif grep -s libs/net/reports <<< $DIFF; then
+          echo 'BUILD_API=true' >> build.env
+        fi
+
+        build_service 'capture'
+        build_service 'clip'
+        build_service 'syndication'
+        build_service 'image'
+        build_service 'filemonitor'
+        build_service 'content'
+        build_service 'transcription'
+        build_service 'nlp'
+        build_service 'indexing'
+
+        cat build.env

--- a/openshift/kustomize/tekton/base/tasks/git-pull.yaml
+++ b/openshift/kustomize/tekton/base/tasks/git-pull.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-pull
+  description: |
+    Update the git repo in the shared workspace with the latest commits for the
+    specified branch reference.
+  annotations:
+    tekton.dev/displayName: Git Pull
+    tekton.dev/pipelines.minVersion: 0.17.0
+    tekton.dev/tags: git
+  labels:
+    name: git-pull
+    part-of: tno
+    version: 1.0.0
+    component: task
+    managed-by: kustomize
+spec:
+  params:
+    - name: GIT_REF
+      description: Git reference or branch to build from.
+      default: dev
+
+    - name: CONTEXT
+      description: Path to the source code to build.
+      default: .
+  workspaces:
+    - name: source
+  steps:
+    - name: git-pull
+      image: bitnami/git:latest
+      workingDir: $(workspaces.source.path)/$(params.CONTEXT)
+      resources:
+        requests:
+          memory: 100Mi
+          cpu: 50m
+        limits:
+          memory: 500Mi
+          cpu: 100m
+      script: |
+        #!/usr/bin/env bash
+        pwd
+
+        # Update the git repo with the latest commit.
+        git config --global --add safe.directory '*'
+        git checkout $(params.GIT_REF)
+        git pull

--- a/openshift/kustomize/tekton/base/tasks/oc-backup.yaml
+++ b/openshift/kustomize/tekton/base/tasks/oc-backup.yaml
@@ -1,0 +1,42 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: oc-backup
+  description: >-
+    This task makes a remote SSH connection to the database backup service and starts a backup.
+  annotations:
+    tekton.dev/displayName: openshift client
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: cli
+  labels:
+    name: oc-backup
+    part-of: tno
+    version: 1.0.0
+    component: task
+    managed-by: kustomize
+spec:
+  params:
+    - name: PROJECT
+      description: The project namespace to run the database backup in.
+      type: string
+      default: 9b301c-dev
+    - name: DEPLOYMENT_CONFIG
+      description: The name of the DeploymentConfig that is running the database backup service.
+      type: string
+    - name: ARGS
+      description: >-
+        The arguments to include when executing the backup.sh script.
+        -l : List existing backups
+        -h : Display help information
+        -c : Display current configuration
+        -1 : Run a single backup
+        -r <spec> : Restore the database with the specified <spec>
+      type: string
+      default: "-1"
+  steps:
+    - name: build
+      image: "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest"
+      resources: {}
+      script: |
+        echo "Running Database Backup"
+        oc rsh -n $(params.PROJECT) dc/$(params.DEPLOYMENT_CONFIG) bash -c './backup.sh $(params.ARGS)'

--- a/openshift/kustomize/tekton/base/tasks/oc-deploy-with-tag.yaml
+++ b/openshift/kustomize/tekton/base/tasks/oc-deploy-with-tag.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: oc-deploy-with-tag
+  description: >-
+    This task will tag a specific image with the environment name.
+    This will deploy the image if there is a DeployConfig trigger listening for the environment tag.
+  annotations:
+    tekton.dev/displayName: openshift client
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: cli
+  labels:
+    name: oc-deploy-with-tag
+    part-of: tno
+    version: 1.0.0
+    component: task
+    managed-by: kustomize
+spec:
+  params:
+    - name: PROJECT_SHORTNAME
+      description: The project namespace.
+      type: string
+      default: 9b301c
+    - name: IMAGE
+      description: The name given to the built image.
+      type: string
+    - name: IMAGE_TAG
+      description: The tag given to the built image.
+      type: string
+      default: latest
+    - name: ENV
+      description: The environment to deploy to.
+      type: string
+    - name: TIMEOUT
+      description: The timeout before it will stop waiting for the pod to become available.
+      type: string
+      default: "60s"
+
+  steps:
+    - name: deploy
+      image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+      resources: {}
+      script: |
+        echo "Tagging image to trigger deployment to $(params.ENV)"
+        oc tag $(params.IMAGE):$(params.IMAGE_TAG) $(params.IMAGE):$(params.ENV)
+
+        echo "Waiting for deployment to roll out"
+        oc wait --for=condition=available --timeout=$(params.TIMEOUT) dc/$(params.IMAGE) -n $(params.PROJECT_SHORTNAME)-$(params.ENV)
+
+        # timeout(10) {
+        # dc.rollout().status('--watch=true')
+        # }

--- a/openshift/kustomize/tekton/base/tasks/oc-patch-route.yaml
+++ b/openshift/kustomize/tekton/base/tasks/oc-patch-route.yaml
@@ -1,0 +1,37 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: oc-patch-route
+  description: >-
+    This task uses oc cli to update a route and point it to the specified service.
+  annotations:
+    tekton.dev/displayName: openshift client
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: cli
+  labels:
+    name: oc-patch-route
+    part-of: tno
+    version: 1.0.0
+    component: task
+    managed-by: kustomize
+spec:
+  params:
+    - name: PROJECT
+      description: The project namespace.
+      type: string
+      default: 9b301c-dev
+    - name: ROUTE
+      description: The name of the route to update.
+      type: string
+    - name: SERVICE
+      description: The name of the service to point the route to.
+      type: string
+
+  steps:
+    - name: update-route
+      image: "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest"
+      resources: {}
+      script: |
+        echo "Pointing route '$(params.ROUTE)' to '$(params.SERVICE)' in $(params.PROJECT)"
+
+        oc patch route/$(params.ROUTE) -n $(params.PROJECT) -p '{"spec":{"to":{"name":"$(params.SERVICE)"}}}'

--- a/openshift/kustomize/tekton/base/tasks/owasp-scanner.yaml
+++ b/openshift/kustomize/tekton/base/tasks/owasp-scanner.yaml
@@ -1,0 +1,53 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: owasp-scanner
+  description: >-
+    The worlds most widely used web app scanner. Free and open source.
+    Actively maintained by a dedicated international team of volunteers.
+  labels:
+    name: owasp-scanner
+    part-of: tno
+    version: 1.0.0
+    component: task
+    managed-by: kustomize
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Security
+    tekton.dev/tags: security
+    tekton.dev/displayName: owasp zap scanner
+    tekton.dev/platforms: linux/amd64
+spec:
+  workspaces:
+    - name: owasp-settings
+      optional: true
+      mountPath: /zap/wrk
+  params:
+    - name: TARGET_URL
+      description: Host URL where the sonarqube server is running
+    - name: SCAN_TYPE
+      description: Options include quick or full.
+      default: quick
+    - name: SCAN_DURATION
+      description: The duration of the OWASP scan.
+      default: 1
+  steps:
+    - name: owasp-scan
+      image: owasp/zap2docker-stable
+      workingDir: $(workspaces.owasp-settings.path)
+      script: |
+        #!/bin/bash
+        if [ $(params.SCAN_TYPE) = "quick" ]
+        then
+          echo "performing quick scan"
+          zap-baseline.py -t $(params.TARGET_URL) -d -g gen.conf -J owasp-quick-results.json -m $(params.SCAN_DURATION) -I
+          cat $(workspaces.owasp-settings.path)/owasp-quick-results.json
+        elif [ $(params.SCAN_TYPE) = "full" ]
+        then
+          echo "performing full scan"
+          zap-full-scan.py -t $(params.TARGET_URL) -d -g gen.conf -J owasp-full-results.json -m $(params.SCAN_DURATION) -I
+          cat $(workspaces.owasp-settings.path)/owasp-full-results.json
+        else
+          echo "ERROR: Scan type must be set to quick or full."
+          exit 1
+        fi

--- a/openshift/kustomize/tekton/base/tasks/pipeline-wait.yaml
+++ b/openshift/kustomize/tekton/base/tasks/pipeline-wait.yaml
@@ -1,0 +1,55 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: pipeline-wait
+  description: |
+    Makes the pipeline wait until a prior pipeline completes.
+  annotations:
+    tekton.dev/displayName: Git Pull
+    tekton.dev/pipelines.minVersion: 0.17.0
+    tekton.dev/tags: git
+  labels:
+    name: pipeline-wait
+    part-of: tno
+    version: 1.0.0
+    component: task
+    managed-by: kustomize
+spec:
+  params:
+    - name: PIPELINE_NAME
+      description: The name of current pipeline run
+      type: string
+  workspaces:
+    - name: manifest-dir
+      description: >-
+        The workspace which contains kubernetes manifests which we want to apply
+        on the cluster.
+      optional: true
+    - name: kubeconfig-dir
+      description: >-
+        The workspace which contains the the kubeconfig file if in case we want
+        to run the oc command on another cluster.
+      optional: true
+  steps:
+    - name: oc
+      image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+      resources: {}
+      script: |
+        #!/usr/bin/env bash
+        [[ "$(workspaces.manifest-dir.bound)" == "true" ]] && \
+        cd $(workspaces.manifest-dir.path)
+
+        [[ "$(workspaces.kubeconfig-dir.bound)" == "true" ]] && \
+        [[ -f $(workspaces.kubeconfig-dir.path)/kubeconfig ]] && \
+        export KUBECONFIG=$(workspaces.kubeconfig-dir.path)/kubeconfig
+
+        while true; do
+          PIPELINE_RUN=$(oc get pipelineruns --sort-by=.metadata.creationTimestamp | awk 'NR>1 {if (($5 == "") && ($3 == "Running") ) {print $0}}' | awk 'NR==1 {print $1}')
+          if [[ "$(params.PIPELINE_NAME)" == "${PIPELINE_RUN}" ]]; then
+            echo "All pending pipelineruns have been completed"
+            break
+          else
+            echo "Waiting for ${PIPELINE_RUN} to complete"
+            sleep 1m
+          fi
+        done

--- a/openshift/kustomize/tekton/base/triggers/binding.yaml
+++ b/openshift/kustomize/tekton/base/triggers/binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerBinding
+metadata:
+  name: git-dev
+spec:
+  params:
+    - name: GIT_URL
+      value: https://github.com/$(body.repository.full_name)
+    # - name: GIT_REF
+    #   value: $(body.ref.split('/')[2])
+    - name: GIT_REF
+      value: $(body.head_commit.id)
+    - name: VERSION
+      value: latest # TODO: Dynamically generate this somehow.
+    - name: DEPLOY_TO
+      value: dev

--- a/openshift/kustomize/tekton/base/triggers/ingress.yaml
+++ b/openshift/kustomize/tekton/base/triggers/ingress.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: git-webhook
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  rules:
+    - host: tno-tekton.apps.silver.devops.gov.bc.ca
+      http:
+        paths:
+          - path: /hooks
+            pathType: Exact
+            backend:
+              service:
+                name: el-git-webhook
+                port:
+                  number: 8080
+
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: git-webhook
+spec:
+  host: tno-tekton.apps.silver.devops.gov.bc.ca
+  path: /hooks
+  to:
+    kind: Service
+    name: el-git-webhook
+    weight: 100
+  port:
+    targetPort: http-listener
+  wildcardPolicy: None

--- a/openshift/kustomize/tekton/base/triggers/listener.yaml
+++ b/openshift/kustomize/tekton/base/triggers/listener.yaml
@@ -1,0 +1,85 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: git-webhook
+  component: app
+spec:
+  serviceAccountName: pipeline
+  triggers:
+    - name: github-listener
+      bindings:
+        - ref: git-dev
+      template:
+        ref: git-app
+      interceptors:
+        - github:
+            secretRef:
+              secretName: tno-webhook
+              secretKey: webhook
+            eventTypes:
+              - push
+        - cel:
+            filter: >-
+              body.ref == 'refs/heads/dev'
+              && (body.commits.exists(c, c.added.exists(m, m.startsWith('app/editor')))
+                || body.commits.exists(c, c.modified.exists(m, m.startsWith('app/editor')))
+                || body.commits.exists(c, c.removed.exists(m, m.startsWith('app/editor')))
+                || body.head_commit.added.exists(m, m.startsWith('app/editor'))
+                || body.head_commit.modified.exists(m, m.startsWith('app/editor'))
+                || body.head_commit.removed.exists(m, m.startsWith('app/editor'))
+
+                || body.commits.exists(c, c.added.exists(m, m.startsWith('api/net')))
+                || body.commits.exists(c, c.modified.exists(m, m.startsWith('api/net')))
+                || body.commits.exists(c, c.removed.exists(m, m.startsWith('api/net')))
+                || body.head_commit.added.exists(m, m.startsWith('api/net'))
+                || body.head_commit.modified.exists(m, m.startsWith('api/net'))
+                || body.head_commit.removed.exists(m, m.startsWith('api/net'))
+
+                || body.commits.exists(c, c.added.exists(m, m.startsWith('libs/net/dal')))
+                || body.commits.exists(c, c.modified.exists(m, m.startsWith('libs/net/dal')))
+                || body.commits.exists(c, c.removed.exists(m, m.startsWith('libs/net/dal')))
+                || body.head_commit.added.exists(m, m.startsWith('libs/net/dal'))
+                || body.head_commit.modified.exists(m, m.startsWith('libs/net/dal'))
+                || body.head_commit.removed.exists(m, m.startsWith('libs/net/dal'))
+
+                || body.commits.exists(c, c.added.exists(m, m.startsWith('libs/net/entities')))
+                || body.commits.exists(c, c.modified.exists(m, m.startsWith('libs/net/entities')))
+                || body.commits.exists(c, c.removed.exists(m, m.startsWith('libs/net/entities')))
+                || body.head_commit.added.exists(m, m.startsWith('libs/net/entities'))
+                || body.head_commit.modified.exists(m, m.startsWith('libs/net/entities'))
+                || body.head_commit.removed.exists(m, m.startsWith('libs/net/entities'))
+
+                || body.commits.exists(c, c.added.exists(m, m.startsWith('libs/net/core')))
+                || body.commits.exists(c, c.modified.exists(m, m.startsWith('libs/net/core')))
+                || body.commits.exists(c, c.removed.exists(m, m.startsWith('libs/net/core')))
+                || body.head_commit.added.exists(m, m.startsWith('libs/net/core'))
+                || body.head_commit.modified.exists(m, m.startsWith('libs/net/core'))
+                || body.head_commit.removed.exists(m, m.startsWith('libs/net/core'))
+
+                || body.commits.exists(c, c.added.exists(m, m.startsWith('libs/net/ches')))
+                || body.commits.exists(c, c.modified.exists(m, m.startsWith('libs/net/ches')))
+                || body.commits.exists(c, c.removed.exists(m, m.startsWith('libs/net/ches')))
+                || body.head_commit.added.exists(m, m.startsWith('libs/net/ches'))
+                || body.head_commit.modified.exists(m, m.startsWith('libs/net/ches'))
+                || body.head_commit.removed.exists(m, m.startsWith('libs/net/ches'))
+
+                || body.commits.exists(c, c.added.exists(m, m.startsWith('libs/net/keycloak')))
+                || body.commits.exists(c, c.modified.exists(m, m.startsWith('libs/net/keycloak')))
+                || body.commits.exists(c, c.removed.exists(m, m.startsWith('libs/net/keycloak')))
+                || body.head_commit.added.exists(m, m.startsWith('libs/net/keycloak'))
+                || body.head_commit.modified.exists(m, m.startsWith('libs/net/keycloak'))
+                || body.head_commit.removed.exists(m, m.startsWith('libs/net/keycloak'))
+
+                || body.commits.exists(c, c.added.exists(m, m.startsWith('libs/net/models')))
+                || body.commits.exists(c, c.modified.exists(m, m.startsWith('libs/net/models')))
+                || body.commits.exists(c, c.removed.exists(m, m.startsWith('libs/net/models')))
+                || body.head_commit.added.exists(m, m.startsWith('libs/net/models'))
+                || body.head_commit.modified.exists(m, m.startsWith('libs/net/models'))
+                || body.head_commit.removed.exists(m, m.startsWith('libs/net/models'))
+
+                || body.commits.exists(c, c.added.exists(m, m.startsWith('libs/net/reports')))
+                || body.commits.exists(c, c.modified.exists(m, m.startsWith('libs/net/reports')))
+                || body.commits.exists(c, c.removed.exists(m, m.startsWith('libs/net/reports')))
+                || body.head_commit.added.exists(m, m.startsWith('libs/net/reports'))
+                || body.head_commit.modified.exists(m, m.startsWith('libs/net/reports'))
+                || body.head_commit.removed.exists(m, m.startsWith('libs/net/reports')))

--- a/openshift/kustomize/tekton/base/triggers/secret.yaml
+++ b/openshift/kustomize/tekton/base/triggers/secret.yaml
@@ -1,0 +1,11 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: webhook
+  annotations:
+    description: GitHub webhook secret
+  labels:
+    component: webhook
+type: Opaque
+stringData:
+  webhook: ${WEBHOOK_SECRET}

--- a/openshift/kustomize/tekton/base/triggers/template.yaml
+++ b/openshift/kustomize/tekton/base/triggers/template.yaml
@@ -1,0 +1,60 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: git-app
+  component: app
+spec:
+  params:
+    - name: GIT_SOURCE
+      description: Identify the git source
+    - name: VERSION
+      description: The version to tag the image with
+    - name: DEPLOY_TO
+      description: The environment to deploy to
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: buildah-main-$(tt.params.VERSION)-
+        annotations:
+          description: >-
+            Build an docker image from a GIT repository using an existing BuildConfig.
+            Then deploy to the specified environment.
+          tags: "oc,git,docker,build,deploy"
+        labels:
+          name: buildah-main-$(tt.params.VERSION)
+          part-of: tno
+          version: $(tt.params.VERSION)
+          component: pipeline
+          managed-by: kustomize
+          tekton.dev/pipeline: buildah-main
+      spec:
+        pipelineRef:
+          name: buildah-main
+        serviceAccountName: pipeline
+        timeout: 1h45m0s
+        params:
+          - name: GIT_REF
+            value: $(tt.params.GIT_SOURCE)
+          - name: IMAGE_TAG
+            value: $(tt.params.VERSION)
+          - name: CONTEXT
+            value: tno
+          - name: DEPLOY_TO
+            value: $(tt.params.DEPLOY_TO)
+        workspaces:
+          - name: source
+            persistentVolumeClaim:
+              claimName: pipelines
+          - name: conditions
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 50Mi
+                storageClassName: netapp-file-standard
+                volumeMode: Filesystem
+          - name: owasp-settings
+            emptyDir: {}

--- a/openshift/kustomize/tekton/build/base/Dockerfile
+++ b/openshift/kustomize/tekton/build/base/Dockerfile
@@ -1,4 +1,6 @@
-FROM debian:latest
+FROM alpine:latest
 
-RUN apt-get -y update
-RUN apt-get -y install git
+RUN apk update
+RUN apk add git
+
+ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/openshift/templates/sysdig/authorize.yaml
+++ b/openshift/templates/sysdig/authorize.yaml
@@ -52,7 +52,7 @@ parameters:
     required: true
 
 objects:
-  - apiVersion: ops.gov.bc.ca/v1alpha1
+  - apiVersion: ops.gov.bc.ca/v1beta1
     kind: SysdigTeam
     metadata:
       name: ${PROJECT_NAMESPACE}-sysdigteam

--- a/openshift/templates/tekton/conditions/param-has-value.yaml
+++ b/openshift/templates/tekton/conditions/param-has-value.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Condition
 metadata:
   name: param-has-value

--- a/openshift/templates/tekton/conditions/param-is-true.yaml
+++ b/openshift/templates/tekton/conditions/param-is-true.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Condition
 metadata:
   name: param-is-true

--- a/openshift/templates/tekton/pipelines/api.yaml
+++ b/openshift/templates/tekton/pipelines/api.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: api

--- a/openshift/templates/tekton/pipelines/backup-database.yaml
+++ b/openshift/templates/tekton/pipelines/backup-database.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: backup-database

--- a/openshift/templates/tekton/pipelines/complete.yaml
+++ b/openshift/templates/tekton/pipelines/complete.yaml
@@ -69,7 +69,7 @@ parameters:
     value: https://tno-dev.apps.silver.devops.gov.bc.ca
 
 objects:
-  - apiVersion: tekton.dev/v1alpha1
+  - apiVersion: tekton.dev/v1beta1
     kind: Pipeline
     metadata:
       name: full-pipeline

--- a/openshift/templates/tekton/pipelines/db-migration.yaml
+++ b/openshift/templates/tekton/pipelines/db-migration.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: database-migration

--- a/openshift/templates/tekton/pipelines/deploy.yaml
+++ b/openshift/templates/tekton/pipelines/deploy.yaml
@@ -46,7 +46,7 @@ parameters:
     value: prod
 
 objects:
-  - apiVersion: tekton.dev/v1alpha1
+  - apiVersion: tekton.dev/v1beta1
     kind: Pipeline
     metadata:
       name: deploy

--- a/openshift/templates/tekton/pipelines/editor.yaml
+++ b/openshift/templates/tekton/pipelines/editor.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: editor

--- a/openshift/templates/tekton/pipelines/redirect-route.yaml
+++ b/openshift/templates/tekton/pipelines/redirect-route.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: redirect-route

--- a/openshift/templates/tekton/pipelines/syndication.yaml
+++ b/openshift/templates/tekton/pipelines/syndication.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: syndication-service


### PR DESCRIPTION
I haven't fully completed everything I'd like to do and we need to do for our DevOps pipelines.  However, I have dramatically improved what we have.

## Summary

- A copy of the github repo is stored on a local PVC.  This reduces the amount of network traffic required.
- The pipeline now uses Buildah.  This reduces the need to fetch the repo each build object.
- The pipeline only updates the local repo with the latest changes.
- The pipeline runs concurrently.  Only one pipeline can run at a time.  This allows us to merge PRs without having to manually wait for each to complete.
- The pipeline only builds the components that have been changed.
- The pipeline can now complete in less than 30 minutes.
- Many Tasks can now run in parallel.  This speeds everything up.
- There is a new pipeline for the services.  It is not automated however.

## Outstanding Future Work

- Only run the db-migration if it needs to
- Only deploy components that were built
- Provide a way to version pipelines
- Automate the services pipeline through webhook
- Automate deletion of old pipeline runs
- Backup database when required
- Create a rollback pipeline (requires versioning, and database restore)
- Provide pipeline approval process
- Create pipelines for TEST and PROD
- Convert all templates into Kustomize solution

## Main Pipeline

![image](https://user-images.githubusercontent.com/3180256/195730144-7a9c73b0-e7dd-4796-bc48-9fe67cc34083.png)

## Services Pipeline

![image](https://user-images.githubusercontent.com/3180256/195730172-b79104a5-b21a-490d-95e5-5a1a53959dc7.png)
