### PR TITLE
Tno 644 - Add Globe and Mail import to the filemonitor service

### DIFF
--- a/libs/net/dal/Migrations/Initial/Up/PostUp/00-Connection.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/00-Connection.sql
@@ -98,6 +98,18 @@ INSERT INTO public.connection (
   , ''
   , DEFAULT_USER_ID
   , ''
+), (
+  'SSH - Globe Newspaper Upload' -- 6
+  , 'Globe and Mail upload files to this location.' -- description
+  , true -- is_enabled
+  , 7 -- connection_type - SSH
+  , '{"path":"/","username":"nc0002","hostname":"gamdelivery.globeandmail.ca","password": "rond9dil"}' -- configuration
+  , true -- is_read_only
+  , 0 -- sort_order
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
 );
 
 END $$;

--- a/libs/net/dal/Migrations/Initial/Up/PostUp/00-Connection.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/00-Connection.sql
@@ -103,7 +103,7 @@ INSERT INTO public.connection (
   , 'Globe and Mail upload files to this location.' -- description
   , true -- is_enabled
   , 7 -- connection_type - SSH
-  , '{"passwordAuth": true,"path":"/","username":"nc0002","hostname":"gamdelivery.globeandmail.ca","password": "rond9dil"}' -- configuration
+  , '{"passwordAuth": true,"path":"/","username":"nc0002","hostname":"gamdelivery.globeandmail.ca","password": ""}' -- configuration
   , true -- is_read_only
   , 0 -- sort_order
   , DEFAULT_USER_ID

--- a/libs/net/dal/Migrations/Initial/Up/PostUp/00-Connection.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/00-Connection.sql
@@ -103,7 +103,7 @@ INSERT INTO public.connection (
   , 'Globe and Mail upload files to this location.' -- description
   , true -- is_enabled
   , 7 -- connection_type - SSH
-  , '{"path":"/","username":"nc0002","hostname":"gamdelivery.globeandmail.ca","password": "rond9dil"}' -- configuration
+  , '{"passwordAuth": true,"path":"/","username":"nc0002","hostname":"gamdelivery.globeandmail.ca","password": "rond9dil"}' -- configuration
   , true -- is_read_only
   , 0 -- sort_order
   , DEFAULT_USER_ID

--- a/libs/net/dal/Migrations/Initial/Up/PostUp/01-Schedule.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/01-Schedule.sql
@@ -199,6 +199,26 @@ INSERT INTO public.schedule (
   , CURRENT_TIMESTAMP -- version
   , '0'
 ), (
+  'GLOBEA' -- name
+  , 'Globe and Mail article import' -- description
+  , true -- is_enabled
+  , 1 -- schedule_type
+  , 30000 -- delay_ms
+  , NULL -- run_on
+  , '00:00:00' -- start_at
+  , '23:59:59' -- stop_at
+  , 0 -- repeat
+  , 127 -- run_on_week_days
+  , 0 -- run_on_months
+  , 0 -- day_of_month
+  , DEFAULT_USER_ID -- created_by_id
+  , ''  -- created_by
+  , CURRENT_TIMESTAMP -- created_on
+  , DEFAULT_USER_ID  -- updated_by
+  , '' -- updated_on
+  , CURRENT_TIMESTAMP -- version
+  , '0'
+), (
   'GLOBE' -- name
   , 'Globe and Mail front page images' -- description
   , true -- is_enabled

--- a/libs/net/dal/Migrations/Initial/Up/PostUp/01-Schedule.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/01-Schedule.sql
@@ -199,7 +199,7 @@ INSERT INTO public.schedule (
   , CURRENT_TIMESTAMP -- version
   , '0'
 ), (
-  'GLOBEA' -- name
+  'GLOBE - Articles' -- name
   , 'Globe and Mail article import' -- description
   , true -- is_enabled
   , 1 -- schedule_type

--- a/libs/net/dal/Migrations/Initial/Up/PostUp/02-Ingest.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/02-Ingest.sql
@@ -19,6 +19,7 @@ DECLARE conLocalImagesId INT := (SELECT id FROM public.connection WHERE Name = '
 DECLARE conLocalPapersId INT := (SELECT id FROM public.connection WHERE Name = 'Local Volume - Papers'); -- connection_id
 DECLARE conPublicInternetId INT := (SELECT id FROM public.connection WHERE Name = 'Public Internet'); -- connection_id
 DECLARE conSSHId INT := (SELECT id FROM public.connection WHERE Name = 'SSH - Newspaper Upload'); -- connection_id
+DECLARE conGlobeSSHId INT := (SELECT id FROM public.connection WHERE Name = 'SSH - Globe Newspaper Upload'); -- connection_id
 BEGIN
 
 INSERT INTO public.ingest (
@@ -301,7 +302,7 @@ INSERT INTO public.ingest (
 -- Paper
 -- ******************************************************
 (
-  'Globe and Mail'
+  'Globe & Mail - Articles'
   , '' -- description
   , true -- is_enabled
   , ingestPaperId -- media_type_id
@@ -312,7 +313,7 @@ INSERT INTO public.ingest (
       "language": "en-CA",
       "post": true,
       "import": true,
-      "path": "processed",
+      "path": "",
       "papername": "pubdata!name",
       "headline": "hl1",
       "summary": "hl1",
@@ -325,10 +326,12 @@ INSERT INTO public.ingest (
       "item": "nitf",
       "dateFmt": "yyyyMMdd",
       "selfPublished": true,
-      "dateOffset": -1 }' -- configuration
+      "filePattern":"^<date>(.+).xml$",
+      "passwordAuth":true,
+      "dateOffset": 0 }' -- configuration
   , 1 -- schedule_type
   , 3 -- retry_limit
-  , conSSHId -- source_connection_id
+  , conGlobeSSHId -- source_connection_id
   , conLocalPapersId -- destination_connection_id
   , DEFAULT_USER_ID
   , ''

--- a/libs/net/dal/Migrations/Initial/Up/PostUp/03-IngestSchedule.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/03-IngestSchedule.sql
@@ -94,7 +94,7 @@ INSERT INTO public.ingest_schedule (
   , CURRENT_TIMESTAMP
 ), (
   (SELECT id FROM public.ingest WHERE name = 'Globe & Mail - Articles')  -- ingest_id
-  , (SELECT id FROM public.schedule WHERE name = 'GLOBEA')  -- schedule_id
+  , (SELECT id FROM public.schedule WHERE name = 'GLOBE - Articles')  -- schedule_id
   , DEFAULT_USER_ID
   , ''
   , CURRENT_TIMESTAMP

--- a/libs/net/dal/Migrations/Initial/Up/PostUp/03-IngestSchedule.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/03-IngestSchedule.sql
@@ -92,6 +92,15 @@ INSERT INTO public.ingest_schedule (
   , DEFAULT_USER_ID
   , ''
   , CURRENT_TIMESTAMP
+), (
+  (SELECT id FROM public.ingest WHERE name = 'Globe & Mail - Articles')  -- ingest_id
+  , (SELECT id FROM public.schedule WHERE name = 'GLOBEA')  -- schedule_id
+  , DEFAULT_USER_ID
+  , ''
+  , CURRENT_TIMESTAMP
+  , DEFAULT_USER_ID
+  , ''
+  , CURRENT_TIMESTAMP
 );
 
 END $$;

--- a/services/net/filemonitor/FilemonitorAction.cs
+++ b/services/net/filemonitor/FilemonitorAction.cs
@@ -28,7 +28,6 @@ public class FileMonitorAction : IngestAction<FileMonitorOptions>
     #region Variables
     private readonly IKafkaMessenger _kafka;
     private readonly ILogger _logger;
-    private readonly IOptions<FileMonitorOptions> _options;
     #endregion
 
     #region Constructors
@@ -43,7 +42,6 @@ public class FileMonitorAction : IngestAction<FileMonitorOptions>
     {
         _kafka = kafka;
         _logger = logger;
-        _options = options;
     }
     #endregion
 
@@ -96,25 +94,23 @@ public class FileMonitorAction : IngestAction<FileMonitorOptions>
         // Extract the source connection configuration settings.
         var remotePath = manager.Ingest.SourceConnection?.GetConfigurationValue("path");
         var username = manager.Ingest.SourceConnection?.GetConfigurationValue("username");
-        var keyFileName = manager.Ingest.SourceConnection?.GetConfigurationValue("keyFileName");
+        var keyFileName = manager.Ingest.SourceConnection?.GetConfigurationValue("keyFileName") ?? "";
         var hostname = manager.Ingest.SourceConnection?.GetConfigurationValue("hostname");
         var password = manager.Ingest.SourceConnection?.GetConfigurationValue("password");
-        var passwordAuth = manager.Ingest.SourceConnection?.GetConfigurationValue<bool>("passwordAuth");
         if (String.IsNullOrWhiteSpace(hostname)) throw new ConfigurationException($"Ingest '{manager.Ingest.Name}' source connection is missing a 'hostname'.");
         if (String.IsNullOrWhiteSpace(username)) throw new ConfigurationException($"Ingest '{manager.Ingest.Name}' source connection is missing a 'username'.");
-        if (!(passwordAuth ?? false) && String.IsNullOrWhiteSpace(keyFileName)) throw new ConfigurationException($"Ingest '{manager.Ingest.Name}' source connection is missing a 'keyFileName'");
-        if ((passwordAuth ?? false) && String.IsNullOrWhiteSpace(password)) throw new ConfigurationException($"Ingest '{manager.Ingest.Name}' source connection is missing a 'password'");
+        if (String.IsNullOrWhiteSpace(keyFileName) && String.IsNullOrWhiteSpace(password)) throw new ConfigurationException($"Ingest '{manager.Ingest.Name}' one of 'keyFileName' or 'password' required in source connection.");
         if (String.IsNullOrWhiteSpace(remotePath)) throw new ConfigurationException($"Ingest '{manager.Ingest.Name}' source connection is missing a 'path'.");
 
         // The ingest configuration may have a different path than the root connection path.
         remotePath = Path.Combine(remotePath, manager.Ingest.GetConfigurationValue("path")?.MakeRelativePath() ?? "");
 
-        if (passwordAuth == true)
+        ConnectionInfo? connectionInfo = null;
+        AuthenticationMethod? authMethod = null;
+
+        if (!String.IsNullOrWhiteSpace(password))
         {
-            var connectionInfo = new ConnectionInfo(hostname,
-                                        username,
-                                        new PasswordAuthenticationMethod(username, password));
-            await FetchFiles(connectionInfo, remotePath, manager);
+            authMethod = new PasswordAuthenticationMethod(username, password);
         }
         else
         {
@@ -123,18 +119,25 @@ public class FileMonitorAction : IngestAction<FileMonitorOptions>
             {
                 var keyFile = new PrivateKeyFile(sshKeyFile);
                 var keyFiles = new[] { keyFile };
-                var connectionInfo = new ConnectionInfo(hostname,
-                                            username,
-                                            new PrivateKeyAuthenticationMethod(username, keyFiles));
-                await FetchFiles(connectionInfo, remotePath, manager);
+                authMethod = new PrivateKeyAuthenticationMethod(username, keyFiles);
             }
             else
             {
                 throw new ConfigurationException($"SSH Private key file does not exist: {sshKeyFile}");
             }
         }
+
+        connectionInfo = new ConnectionInfo(hostname, username, authMethod);
+        await FetchFiles(connectionInfo, remotePath, manager);
     }
 
+    /// <summary>
+    /// Fetch all files matching the ingest's file pattern from the remote sftp host.
+    /// </summary>
+    /// <param name="connectionInfo"></param>
+    /// <param name="remotePath"></param>
+    /// <param name="manager"></param>
+    /// <returns></returns>
     private async Task FetchFiles(ConnectionInfo connectionInfo, string remotePath, IIngestServiceActionManager manager)
     {
         // Extract the ingest configuration settings

--- a/services/net/filemonitor/appsettings.json
+++ b/services/net/filemonitor/appsettings.json
@@ -11,7 +11,7 @@
   "Service": {
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
-    "VolumePath": "/workspaces/tno/monitored",
+    "VolumePath": "/data",
     "IngestTypes": "Paper",
     "TimeZone": "UTC",
     "PrivateKeysPath": "keys"
@@ -21,9 +21,6 @@
       "Authority": "https://oidc.gov.bc.ca/auth/realms/gcpe",
       "Audience": "tno-service-account",
       "Secret": "{DO NOT STORE SECRET HERE}"
-    },
-    "Sftp": {
-      "SftpPasswords": ""
     }
   },
   "Serialization": {

--- a/services/net/filemonitor/appsettings.json
+++ b/services/net/filemonitor/appsettings.json
@@ -11,7 +11,7 @@
   "Service": {
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
-    "VolumePath": "/data",
+    "VolumePath": "/workspaces/tno/monitored",
     "IngestTypes": "Paper",
     "TimeZone": "UTC",
     "PrivateKeysPath": "keys"
@@ -21,6 +21,9 @@
       "Authority": "https://oidc.gov.bc.ca/auth/realms/gcpe",
       "Audience": "tno-service-account",
       "Secret": "{DO NOT STORE SECRET HERE}"
+    },
+    "Sftp": {
+      "SftpPasswords": ""
     }
   },
   "Serialization": {


### PR DESCRIPTION
This is the gist of it. I already see a couple of issues with what I pushed, but I have to get to Openshift training. I added the `passwordAuth` property to the connection to make explicit that the Globe and Mail requires password-based authentication. I struggled a bit with how to compare bool? with bool in my error detection code. Let me know if my solution could be improved.

Sorry about the two commits, when I did `git rebase -i origin/dev` it didn't hook in to vscode...probably the same option I fixed before, but don't have time to mess with it.