### PR TITLE
TNO-606: Ensure validation is run on publish

### DIFF
--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -46,7 +46,7 @@ import {
 import { defaultFormValues } from './constants';
 import { IContentForm } from './interfaces';
 import * as styled from './styled';
-import { isSnippetForm, switchStatus, toForm, toModel } from './utils';
+import { isSnippetForm, switchStatus, toForm, toModel, triggerFormikValidate } from './utils';
 
 export interface IContentFormProps {
   /** The content type this form will create */
@@ -178,7 +178,7 @@ export const ContentForm: React.FC<IContentFormProps> = ({ contentType: initCont
 
   const handlePublish = async (props: FormikProps<IContentForm>) => {
     const values = props.values;
-    await props.validateForm(values);
+    triggerFormikValidate(props);
 
     if (props.isValid) {
       const defaultTonePool = tonePools.find((t) => t.name === 'Default');

--- a/app/editor/src/features/content/form/utils/index.ts
+++ b/app/editor/src/features/content/form/utils/index.ts
@@ -4,3 +4,4 @@ export * from './isSnippetForm';
 export * from './switchStatus';
 export * from './toForm';
 export * from './toModel';
+export * from './triggerFormikValidate';

--- a/app/editor/src/features/content/form/utils/triggerFormikValidate.ts
+++ b/app/editor/src/features/content/form/utils/triggerFormikValidate.ts
@@ -1,0 +1,12 @@
+import { FormikProps, FormikTouched, setNestedObjectValues } from 'formik';
+
+/**
+ * When a button is not of type submit, this function can be used to force validate formik errors
+ * @param {FormikProps} props - The formik props from the designated component
+ * */
+export const triggerFormikValidate = <T>(props: FormikProps<T>) => {
+  const errors = props.errors;
+  if (Object.keys(errors).length !== 0) {
+    props.setTouched(setNestedObjectValues<FormikTouched<T>>(errors, true));
+  }
+};


### PR DESCRIPTION
- Provide a utility function that can be used when a button that is not of type submit needs to trigger the Formik validation and present errors to the user. 
- Also ensured that this is called when content is published.