### PR TITLE
TNO-711: Double scroll bar fix

### DIFF
--- a/app/editor/src/components/form/formpage/styled/FormPage.tsx
+++ b/app/editor/src/components/form/formpage/styled/FormPage.tsx
@@ -13,7 +13,7 @@ export const FormPage = styled.div<IFormPageProps>`
 
   div[role='rowgroup'] {
     min-height: 100px;
-    max-height: calc(100vh - 600px);
+    max-height: calc(100vh - 400px);
     overflow-y: scroll;
     overflow-x: hidden;
   }

--- a/app/editor/src/components/form/formpage/styled/FormPage.tsx
+++ b/app/editor/src/components/form/formpage/styled/FormPage.tsx
@@ -9,6 +9,12 @@ export const FormPage = styled.div<IFormPageProps>`
   ${(props) => (props.maxWidth !== '' ? `max-width: ${props.maxWidth ?? '1200px'}` : '')};
   padding: 0.5em 2em 0 2em;
   margin: 0px auto;
-  overflow-y: overlay;
-  overflow-x: hidden;
+  overflow: hidden;
+
+  div[role='rowgroup'] {
+    min-height: 100px;
+    max-height: calc(100vh - 600px);
+    overflow-y: scroll;
+    overflow-x: hidden;
+  }
 `;

--- a/app/editor/src/features/admin/work-orders/WorkOrderList.tsx
+++ b/app/editor/src/features/admin/work-orders/WorkOrderList.tsx
@@ -1,4 +1,3 @@
-import { FormPage } from 'components/form';
 import { IWorkOrderModel } from 'hooks';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';

--- a/app/editor/src/features/admin/work-orders/WorkOrderList.tsx
+++ b/app/editor/src/features/admin/work-orders/WorkOrderList.tsx
@@ -74,23 +74,21 @@ export const WorkOrderList = () => {
 
   return (
     <styled.WorkOrderList>
-      <FormPage>
-        <Row className="add-media" justifyContent="flex-end">
-          <Col flex="1 1 0">
-            A work order is a request submitted to the system (i.e. transcription, NLP).
-          </Col>
-        </Row>
-        <PagedTable
-          columns={columns}
-          header={WorkOrderListFilter}
-          sorting={{ sortBy: workOrderFilter.sort }}
-          isLoading={!!requests.length}
-          page={page}
-          onRowClick={(row) => navigate(`${row.original.id}`)}
-          onChangeSort={handleChangeSort}
-          onChangePage={handleChangePage}
-        ></PagedTable>
-      </FormPage>
+      <Row className="add-media" justifyContent="flex-end">
+        <Col flex="1 1 0">
+          A work order is a request submitted to the system (i.e. transcription, NLP).
+        </Col>
+      </Row>
+      <PagedTable
+        columns={columns}
+        header={WorkOrderListFilter}
+        sorting={{ sortBy: workOrderFilter.sort }}
+        isLoading={!!requests.length}
+        page={page}
+        onRowClick={(row) => navigate(`${row.original.id}`)}
+        onChangeSort={handleChangeSort}
+        onChangePage={handleChangePage}
+      ></PagedTable>
     </styled.WorkOrderList>
   );
 };

--- a/app/editor/src/features/admin/work-orders/styled/WorkOrderList.tsx
+++ b/app/editor/src/features/admin/work-orders/styled/WorkOrderList.tsx
@@ -1,6 +1,7 @@
+import { FormPage } from 'components/form';
 import styled from 'styled-components';
 
-export const WorkOrderList = styled.div`
+export const WorkOrderList = styled(FormPage)`
   .h-createdOn {
     text-align: center;
     align-items: center;


### PR DESCRIPTION
- Tables now scroll rather than the full form page (like the content list view), also stops the page from jumping around when a pagination value is changed
- Work orders slightly adjusted to match other admin areas
- Double scroll bar no longer on content list view

![formpagefix](https://user-images.githubusercontent.com/15724124/197904399-fa0d2e64-cc6a-4c9d-bd84-7c553e899684.gif)
