### PR TITLE
First stab at end-to-end support for product id override on source

### DIFF
--- a/api/net/Areas/Admin/Models/Ingest/SourceModel.cs
+++ b/api/net/Areas/Admin/Models/Ingest/SourceModel.cs
@@ -47,6 +47,11 @@ public class SourceModel : AuditColumnsModel
     /// get/set -
     /// </summary>
     public int? OwnerId { get; set; }
+
+    /// <summary>
+    /// get/set -
+    /// </summary>
+    public int? ProductId { get; set; }
     #endregion
 
     #region Constructors
@@ -69,6 +74,7 @@ public class SourceModel : AuditColumnsModel
         this.IsEnabled = entity.IsEnabled;
         this.LicenseId = entity.LicenseId;
         this.OwnerId = entity.OwnerId;
+        this.ProductId = entity.ProductId;
     }
     #endregion
 
@@ -96,6 +102,7 @@ public class SourceModel : AuditColumnsModel
             Description = model.Description,
             IsEnabled = model.IsEnabled,
             OwnerId = model.OwnerId,
+            ProductId = model.ProductId,
             Version = model.Version ?? 0
         };
 

--- a/api/net/Areas/Admin/Models/Source/SourceModel.cs
+++ b/api/net/Areas/Admin/Models/Source/SourceModel.cs
@@ -1,3 +1,4 @@
+using TNO.API.Areas.Admin.Models.Product;
 using TNO.API.Models;
 
 namespace TNO.API.Areas.Admin.Models.Source;
@@ -59,6 +60,11 @@ public class SourceModel : AuditColumnsModel
     public UserModel? Owner { get; set; }
 
     /// <summary>
+    /// get/set -
+    /// </summary>
+    public int? ProductId { get; set; }
+
+    /// <summary>
     /// get/set - Whether content with this category should be automatically transcribed.
     /// </summary>
     public bool AutoTranscribe { get; set; }
@@ -100,6 +106,7 @@ public class SourceModel : AuditColumnsModel
         this.LicenseId = entity.LicenseId;
         this.License = entity.License != null ? new LicenseModel(entity.License) : null;
         this.OwnerId = entity.OwnerId;
+        this.ProductId = entity.ProductId;
         this.Owner = entity.Owner != null ? new UserModel(entity.Owner) : null;
         this.AutoTranscribe = entity.AutoTranscribe;
         this.DisableTranscribe = entity.DisableTranscribe;
@@ -133,6 +140,7 @@ public class SourceModel : AuditColumnsModel
             Description = model.Description,
             IsEnabled = model.IsEnabled,
             OwnerId = model.OwnerId,
+            ProductId = model.ProductId,
             AutoTranscribe = model.AutoTranscribe,
             DisableTranscribe = model.DisableTranscribe,
             Version = model.Version ?? 0

--- a/app/editor/src/features/admin/sources/SourceDetails.tsx
+++ b/app/editor/src/features/admin/sources/SourceDetails.tsx
@@ -19,6 +19,7 @@ export const SourceDetails: React.FC<ISourceDetailsProps> = () => {
 
   const users = getUserOptions(lookups.users);
   const licenses = getSortableOptions(lookups.licenses);
+  const products = getSortableOptions(lookups.products);
 
   React.useEffect(() => {
     // Ensures the connection settings can display the correct form on initial load.
@@ -63,6 +64,12 @@ export const SourceDetails: React.FC<ISourceDetailsProps> = () => {
           name="ownerId"
           tooltip="The user that manages this content"
           options={users}
+        />
+        <FormikSelect
+          label="Product Designation Override"
+          name="productId"
+          tooltip="The product designation the source content will be assigned (overrides the value in the ingest)"
+          options={products}
         />
       </Col>
       <Col>

--- a/app/editor/src/hooks/api-editor/interfaces/ISourceModel.ts
+++ b/app/editor/src/hooks/api-editor/interfaces/ISourceModel.ts
@@ -6,6 +6,7 @@ export interface ISourceModel extends ISortableModel<number> {
   licenseId: number;
   license?: ILicenseModel;
   ownerId?: number;
+  productId?: number;
   owner?: IUserModel;
   autoTranscribe: boolean;
   disableTranscribe: boolean;

--- a/libs/net/dal/Migrations/20221028170850_Initial.cs
+++ b/libs/net/dal/Migrations/20221028170850_Initial.cs
@@ -465,6 +465,12 @@ namespace TNO.DAL.Migrations
                         principalTable: "user",
                         principalColumn: "id",
                         onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_source_product_product_id",
+                        column: x => x.product_id,
+                        principalTable: "product",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.CreateTable(

--- a/libs/net/dal/Migrations/Initial/Up/PostUp/01-Source.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/01-Source.sql
@@ -367,19 +367,6 @@ INSERT INTO public.source (
   , DEFAULT_USER_ID
   , ''
 ), (
-  'The Province'
-  , 'PROVINCE'
-  , '' -- short_name
-  , '' -- description
-  , true -- is_enabled
-  , false
-  , false
-  , 3 -- license_id
-  , DEFAULT_USER_ID
-  , ''
-  , DEFAULT_USER_ID
-  , ''
-), (
   'Creston Valley Advance'
   , 'CVA'
   , '' -- short_name
@@ -1108,32 +1095,6 @@ INSERT INTO public.source (
   , DEFAULT_USER_ID
   , ''
 ), (
-  'Vancouver Sun'
-  , 'SUN'
-  , '' -- short_name
-  , '' -- description
-  , true -- is_enabled
-  , false
-  , false
-  , 3 -- license_id
-  , DEFAULT_USER_ID
-  , ''
-  , DEFAULT_USER_ID
-  , ''
-), (
-  'Times Colonist (Victoria)'
-  , 'TC'
-  , '' -- short_name
-  , '' -- description
-  , true -- is_enabled
-  , false
-  , false
-  , 3 -- license_id
-  , DEFAULT_USER_ID
-  , ''
-  , DEFAULT_USER_ID
-  , ''
-), (
   'CFAX'
   , 'CFAX'
   , '' -- short_name
@@ -1305,19 +1266,6 @@ INSERT INTO public.source (
 ), (
   'SHAW'
   , 'SHAW'
-  , '' -- short_name
-  , '' -- description
-  , true -- is_enabled
-  , false
-  , false
-  , 3 -- license_id
-  , DEFAULT_USER_ID
-  , ''
-  , DEFAULT_USER_ID
-  , ''
-), (
-  'National Post'
-  , 'POST'
   , '' -- short_name
   , '' -- description
   , true -- is_enabled
@@ -3258,6 +3206,78 @@ INSERT INTO public.source (
   , '' -- short_name
   , '' -- description
   , true -- is_enabled
+  , false
+  , false
+  , 3 -- license_id
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+);
+
+INSERT INTO public.source (
+  "name"
+  , "code"
+  , "short_name"
+  , "description"
+  , "is_enabled"
+  , "product_id"
+  , "auto_transcribe"
+  , "disable_transcribe"
+  , "license_id"
+  , "created_by_id"
+  , "created_by"
+  , "updated_by_id"
+  , "updated_by"
+) VALUES (
+  'Times Colonist (Victoria)'
+  , 'TC'
+  , '' -- short_name
+  , '' -- description
+  , true -- is_enabled
+  , 1 -- product_id
+  , false
+  , false
+  , 3 -- license_id
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+), (
+  'Vancouver Sun'
+  , 'SUN'
+  , '' -- short_name
+  , '' -- description
+  , true -- is_enabled
+  , 1 -- product_id
+  , false
+  , false
+  , 3 -- license_id
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+), (
+  'National Post'
+  , 'POST'
+  , '' -- short_name
+  , '' -- description
+  , true -- is_enabled
+  , 1 -- product_id
+  , false
+  , false
+  , 3 -- license_id
+  , DEFAULT_USER_ID
+  , ''
+  , DEFAULT_USER_ID
+  , ''
+), (
+  'The Province'
+  , 'PROVINCE'
+  , '' -- short_name
+  , '' -- description
+  , true -- is_enabled
+  , 1 -- product_id
   , false
   , false
   , 3 -- license_id

--- a/libs/net/dal/Models/SourceFilter.cs
+++ b/libs/net/dal/Models/SourceFilter.cs
@@ -11,6 +11,7 @@ public class SourceFilter : PageFilter
     public string? ShortName { get; set; }
     public int? LicenseId { get; set; }
     public int? OwnerId { get; set; }
+    public int? ProductId { get; set; }
     public string[] Actions { get; set; } = Array.Empty<string>();
     public string[] Sort { get; set; } = Array.Empty<string>();
     #endregion
@@ -28,6 +29,7 @@ public class SourceFilter : PageFilter
 
         this.LicenseId = filter.GetIntNullValue(nameof(this.LicenseId));
         this.OwnerId = filter.GetIntNullValue(nameof(this.OwnerId));
+        this.ProductId = filter.GetIntNullValue(nameof(this.ProductId));
 
         this.Actions = filter.GetStringArrayValue(nameof(this.Actions));
         this.Sort = filter.GetStringArrayValue(nameof(this.Sort));

--- a/libs/net/entities/Source.cs
+++ b/libs/net/entities/Source.cs
@@ -41,6 +41,12 @@ public class Source : BaseType<int>
     public int? OwnerId { get; set; }
 
     /// <summary>
+    /// get/set - Foreign key to product.
+    /// </summary>
+    [Column("product_id")]
+    public int? ProductId { get; set; }
+
+    /// <summary>
     /// get/set - The user who owns this source.
     /// </summary>
     public virtual User? Owner { get; set; }

--- a/libs/net/models/Areas/Editor/Models/Content/SourceModel.cs
+++ b/libs/net/models/Areas/Editor/Models/Content/SourceModel.cs
@@ -33,6 +33,11 @@ public class SourceModel : BaseTypeModel<int>
     /// <summary>
     /// get/set -
     /// </summary>
+    public int? ProductId { get; set; }
+
+    /// <summary>
+    /// get/set -
+    /// </summary>
     public bool AutoTranscribe { get; set; }
 
     /// <summary>
@@ -62,6 +67,7 @@ public class SourceModel : BaseTypeModel<int>
         this.SortOrder = entity.SortOrder;
         this.LicenseId = entity.LicenseId;
         this.OwnerId = entity.OwnerId;
+        this.ProductId = entity.ProductId;
         this.AutoTranscribe = entity.AutoTranscribe;
         this.DisableTranscribe = entity.DisableTranscribe;
     }
@@ -82,6 +88,7 @@ public class SourceModel : BaseTypeModel<int>
             IsEnabled = model.IsEnabled,
             SortOrder = model.SortOrder,
             OwnerId = model.OwnerId,
+            ProductId = model.ProductId,
             AutoTranscribe = model.AutoTranscribe,
             DisableTranscribe = model.DisableTranscribe
         };

--- a/libs/net/models/Areas/Editor/Models/Source/SourceModel.cs
+++ b/libs/net/models/Areas/Editor/Models/Source/SourceModel.cs
@@ -61,6 +61,11 @@ public class SourceModel
     /// <summary>
     /// get/set -
     /// </summary>
+    public int? ProductId { get; set; }
+
+    /// <summary>
+    /// get/set -
+    /// </summary>
     public bool AutoTranscribe { get; set; }
 
     /// <summary>
@@ -97,6 +102,7 @@ public class SourceModel
         this.LicenseId = entity.LicenseId;
         this.License = entity.License?.Name ?? "";
         this.OwnerId = entity.OwnerId;
+        this.ProductId = entity.ProductId;
         this.AutoTranscribe = entity.AutoTranscribe;
         this.DisableTranscribe = entity.DisableTranscribe;
 

--- a/libs/net/models/Areas/Services/Models/Ingest/SourceModel.cs
+++ b/libs/net/models/Areas/Services/Models/Ingest/SourceModel.cs
@@ -56,6 +56,11 @@ public class SourceModel : AuditColumnsModel
     /// <summary>
     /// get/set -
     /// </summary>
+    public int? ProductId { get; set; }
+
+    /// <summary>
+    /// get/set -
+    /// </summary>
     public bool AutoTranscribe { get; set; }
 
     /// <summary>
@@ -85,6 +90,7 @@ public class SourceModel : AuditColumnsModel
         this.LicenseId = entity.LicenseId;
         this.License = entity.License != null ? new LicenseModel(entity.License) : null;
         this.OwnerId = entity.OwnerId;
+        this.ProductId = entity.ProductId;
         this.AutoTranscribe = entity.AutoTranscribe;
         this.DisableTranscribe = entity.DisableTranscribe;
     }
@@ -114,6 +120,7 @@ public class SourceModel : AuditColumnsModel
             Description = model.Description,
             IsEnabled = model.IsEnabled,
             OwnerId = model.OwnerId,
+            ProductId = model.ProductId,
             AutoTranscribe = model.AutoTranscribe,
             DisableTranscribe = model.DisableTranscribe,
             Version = model.Version ?? 0

--- a/services/net/content/ContentManager.cs
+++ b/services/net/content/ContentManager.cs
@@ -245,7 +245,7 @@ public class ContentManager : ServiceManager<ContentOptions>
                     SourceId = source?.Id,
                     OtherSource = model.Source,
                     ContentType = model.ContentType,
-                    ProductId = model.ProductId,
+                    ProductId = productId,
                     LicenseId = source?.LicenseId ?? 1,  // TODO: Default license by configuration.
                     SeriesId = null, // TODO: Provide default series from Data Source config settings.
                     OtherSeries = null, // TODO: Provide default series from Data Source config settings.


### PR DESCRIPTION
Due to a glitch on my end, the commit message is wrong, but this shouldn't affect the content. 

I rejigged the insert statements for the daily print papers in 01-Source.sql to avoid having to edit the other 246 entries.