### PR TITLE
Tweaks to address issues introduced from TNO-711

### DIFF
--- a/app/editor/src/components/form/formpage/styled/FormPage.tsx
+++ b/app/editor/src/components/form/formpage/styled/FormPage.tsx
@@ -9,7 +9,7 @@ export const FormPage = styled.div<IFormPageProps>`
   ${(props) => (props.maxWidth !== '' ? `max-width: ${props.maxWidth ?? '1200px'}` : '')};
   padding: 0.5em 2em 0 2em;
   margin: 0px auto;
-  overflow: hidden;
+  overflow: auto;
 
   div[role='rowgroup'] {
     min-height: 100px;

--- a/app/editor/src/features/admin/ingests/IngestForm.tsx
+++ b/app/editor/src/features/admin/ingests/IngestForm.tsx
@@ -5,10 +5,11 @@ import { useModal } from 'hooks';
 import { IIngestModel } from 'hooks/api-editor';
 import { IngestSchema } from 'hooks/api-editor/validation';
 import React from 'react';
+import { FaEye, FaEyeSlash, FaWrench } from 'react-icons/fa';
 import { Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useIngests } from 'store/hooks/admin';
-import { Button, ButtonVariant, Col, Row, Tab, Tabs } from 'tno-core';
+import { Button, ButtonVariant, Col, Row, Show, Tab, Tabs } from 'tno-core';
 
 import { IngestStatus } from '.';
 import { defaultIngest } from './constants';
@@ -23,6 +24,7 @@ export const IngestForm: React.FC<IIngestProps> = (props) => {
   const { isShowing, toggle } = useModal();
 
   const ingestId = Number(id);
+  const [showStatus, setShowStatus] = React.useState<boolean>(true);
   const [ingest, setIngest] = React.useState<IIngestModel>((state as any)?.ingest ?? defaultIngest);
   const navigate = useNavigate();
 
@@ -64,6 +66,11 @@ export const IngestForm: React.FC<IIngestProps> = (props) => {
         <Col flex="1" className="info">
           <p>This provides a way to configure ingestion services.</p>
         </Col>
+        <Col>
+          <Button onClick={() => setShowStatus(!showStatus)} tooltip={'Toggle status information'}>
+            {showStatus ? <FaEyeSlash /> : <FaEye />}
+          </Button>
+        </Col>
       </Row>
       <FormikForm
         initialValues={ingest}
@@ -79,6 +86,9 @@ export const IngestForm: React.FC<IIngestProps> = (props) => {
         {({ isSubmitting, errors }) => (
           <Row>
             <Col flex="2 1">
+              <Show visible={showStatus}>
+                <IngestStatus className="status" flex="1 1" />
+              </Show>
               <Tabs
                 tabs={
                   <>
@@ -134,7 +144,6 @@ export const IngestForm: React.FC<IIngestProps> = (props) => {
                 />
               </Tabs>
             </Col>
-            <IngestStatus className="status" flex="1 1" />
           </Row>
         )}
       </FormikForm>

--- a/app/editor/src/features/admin/ingests/IngestForm.tsx
+++ b/app/editor/src/features/admin/ingests/IngestForm.tsx
@@ -5,7 +5,7 @@ import { useModal } from 'hooks';
 import { IIngestModel } from 'hooks/api-editor';
 import { IngestSchema } from 'hooks/api-editor/validation';
 import React from 'react';
-import { FaEye, FaEyeSlash, FaWrench } from 'react-icons/fa';
+import { FaEye, FaEyeSlash } from 'react-icons/fa';
 import { Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useIngests } from 'store/hooks/admin';

--- a/app/editor/src/features/admin/ingests/IngestStatus.tsx
+++ b/app/editor/src/features/admin/ingests/IngestStatus.tsx
@@ -33,14 +33,14 @@ export const IngestStatus: React.FC<IIngestStatusProps> = (props) => {
 
   return (
     <styled.IngestStatus {...props}>
-      <Text label="Status" name="lastRanOn" disabled value={getStatus()} />
-      <FormikText
-        label="Last Run On"
-        name="lastRanOn"
-        disabled
-        formatter={(value) => formatDate(value, 'YYYY-MM-DD h:mm:ss a')}
-      />
-      <Row alignItems="flex-end">
+      <Row justifyContent="center">
+        <Text label="Status" name="status" disabled value={getStatus()} />
+        <FormikText
+          label="Last Run On"
+          name="lastRanOn"
+          disabled
+          formatter={(value) => formatDate(value, 'YYYY-MM-DD h:mm:ss a')}
+        />
         <FormikText
           label="Failure Limit"
           name="retryLimit"

--- a/app/editor/src/features/admin/ingests/styled/IngestForm.tsx
+++ b/app/editor/src/features/admin/ingests/styled/IngestForm.tsx
@@ -17,7 +17,6 @@ export const IngestForm = styled(FormPage)`
     padding: 0.5em;
   }
   .status {
-    max-width: 14em;
     padding: 0 1em 0 1em;
   }
 `;

--- a/app/editor/src/features/admin/ingests/styled/IngestStatus.tsx
+++ b/app/editor/src/features/admin/ingests/styled/IngestStatus.tsx
@@ -1,9 +1,4 @@
 import styled from 'styled-components';
 import { Col } from 'tno-core/dist/components/flex';
 
-export const IngestStatus = styled(Col)`
-  input[name$='startAt'],
-  input[name$='stopAt'] {
-    width: 115px;
-  }
-`;
+export const IngestStatus = styled(Col)``;


### PR DESCRIPTION
Was hoping to bundle this with the user list fix, but still fighting with it.

- Added a toggle for status information on ingest and made it take up less space - can remove if needed. Was just playing around and thought it could be handy
- Form page no longer has hidden attribute
- Tables still scroll for admin sections
![styling-tweaks](https://user-images.githubusercontent.com/15724124/198411269-23e68352-d991-4a27-a2bf-508c1101edf2.gif)

