### PR TITLE
TNO-713: More smarts to tags

### DIFF
--- a/app/editor/src/features/content/form/ContentSummaryForm.tsx
+++ b/app/editor/src/features/content/form/ContentSummaryForm.tsx
@@ -19,7 +19,7 @@ import * as styled from './styled';
 import { TimeLogTable } from './TimeLogTable';
 import { getTotalTime } from './utils';
 
-const tagMatch = /(?!\[).+?(?=\])/g;
+const tagMatch = /\[.*\](?![\S\s])$/g;
 export interface IContentSummaryFormProps {
   setContent: (content: IContentForm) => void;
   content: IContentForm;
@@ -234,7 +234,9 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
               onBlur={(e) => {
                 const value = e.currentTarget.value;
                 if (!!value) {
-                  const values = value.match(tagMatch)?.toString()?.split(', ') ?? [];
+                  const stringValue = value.match(tagMatch)?.toString();
+                  const values =
+                    stringValue?.substring(1, stringValue.length - 1).split(', ') ?? [];
                   const tags = extractTags(values);
                   setFieldValue('tags', tags);
                 }


### PR DESCRIPTION
Still working on the other tag related ticket.

- now checks for tags at end of summary (last line)
- still iOS friendly
- having tags above the last line will no longer delete the proper ones

I think eventually we should implement something like GitHub has for PR labels, much easier to maintain.. probably easier for the user too

![tno-713](https://user-images.githubusercontent.com/15724124/199097380-8ff7dcb2-6896-4c38-a508-187c84de5177.gif)
