### PR TITLE
TNO-702: Default date

### DIFF
--- a/app/editor/src/features/content/form/ContentSummaryForm.tsx
+++ b/app/editor/src/features/content/form/ContentSummaryForm.tsx
@@ -74,6 +74,11 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
     );
   }, [setFieldValue, values.publishedOn]);
 
+  /** set default value to todays date */
+  React.useEffect(() => {
+    if (!values.publishedOn) setFieldValue('publishedOn', moment().format('MMM D, yyyy'));
+  }, [setFieldValue, values.publishedOn]);
+
   React.useEffect(() => {
     setCategoryOptions(getSortableOptions(categories));
   }, [categories]);


### PR DESCRIPTION
Set default date via `setFieldValue`, as other logic in the content form rely on the `formik` value (cannot simply set value within the date picker)