### PR TITLE
Fix image/file ingest path

### DIFF
--- a/api/net/Dockerfile
+++ b/api/net/Dockerfile
@@ -22,6 +22,7 @@ FROM base AS final
 
 RUN apt-get update && apt-get -y upgrade
 RUN apt -y install curl libc6-dev libgdiplus ffmpeg
+RUN apt-get clean
 
 WORKDIR /app
 COPY --from=publish /app/publish .

--- a/openshift/kustomize/tekton/base/tasks/build-component.yaml
+++ b/openshift/kustomize/tekton/base/tasks/build-component.yaml
@@ -73,8 +73,8 @@ spec:
         #!/usr/bin/env bash
         set -xe
 
-        export TMPDIR="/data/tmp/buildah"
-        mkdir -p "${TMPDIR}"
+        # export TMPDIR="$(workspaces.source.path)/tmp/buildah"
+        # mkdir -p "${TMPDIR}"
 
         # Place config into environment variables.
         if test -f $(workspaces.conditions.path)/build.env; then

--- a/openshift/kustomize/tekton/base/tasks/buildah.yaml
+++ b/openshift/kustomize/tekton/base/tasks/buildah.yaml
@@ -65,8 +65,8 @@ spec:
         #!/usr/bin/env bash
         set -xe
 
-        export TMPDIR="/data/tmp/buildah"
-        mkdir -p "${TMPDIR}"
+        # export TMPDIR="$(workspaces.source.path)/tmp/buildah"
+        # mkdir -p "${TMPDIR}"
 
         if [ ! -z "$IMAGE_REGISTRY_USER" ];  then
           buildah login \

--- a/services/net/capture/appsettings.json
+++ b/services/net/capture/appsettings.json
@@ -14,7 +14,7 @@
   "Service": {
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
-    "TimeZone": "UTC",
+    "TimeZone": "PST",
     "VolumePath": "/data",
     "Command": "ffmpeg",
     "IngestTypes": "Audio, Video"

--- a/services/net/clip/appsettings.json
+++ b/services/net/clip/appsettings.json
@@ -14,7 +14,7 @@
   "Service": {
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
-    "TimeZone": "UTC",
+    "TimeZone": "PST",
     "VolumePath": "/data",
     "Command": "ffmpeg",
     "IngestTypes": "Audio, Video"

--- a/services/net/content/appsettings.json
+++ b/services/net/content/appsettings.json
@@ -14,7 +14,7 @@
   "Service": {
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
-    "TimeZone": "UTC",
+    "TimeZone": "PST",
     "VolumePath": "/data"
   },
   "Auth": {

--- a/services/net/filemonitor/FilemonitorAction.cs
+++ b/services/net/filemonitor/FilemonitorAction.cs
@@ -208,7 +208,7 @@ public class FileMonitorAction : IngestAction<FileMonitorOptions>
     /// <returns></returns>
     protected string GetOutputPath(IngestModel ingest)
     {
-        return this.Options.VolumePath.CombineWith(ingest.DestinationConnection?.GetConfigurationValue("path")?.MakeRelativePath() ?? "", $"{ingest.Source?.Code}/{GetDateTimeForTimeZone(ingest):yyyy-MM-dd/}");
+        return this.Options.VolumePath.CombineWith(ingest.DestinationConnection?.GetConfigurationValue("path")?.MakeRelativePath() ?? "", $"{ingest.Source?.Code}/{GetDateTimeForTimeZone(ingest):yyyy-MM-dd}/");
     }
 
     /// <summary>
@@ -218,7 +218,7 @@ public class FileMonitorAction : IngestAction<FileMonitorOptions>
     /// <returns></returns>
     protected string GetInputPath(IngestModel ingest)
     {
-        return (ingest.SourceConnection?.GetConfigurationValue("path") ?? "").CombineWith(ingest.GetConfigurationValue("path")?.MakeRelativePath() ?? "", $"{GetDateTimeForTimeZone(ingest):yyyy/MM/dd/}");
+        return (ingest.SourceConnection?.GetConfigurationValue("path") ?? "").CombineWith(ingest.GetConfigurationValue("path")?.MakeRelativePath() ?? "", $"{GetDateTimeForTimeZone(ingest):yyyy/MM/dd}/");
     }
 
     /// <summary>

--- a/services/net/filemonitor/appsettings.json
+++ b/services/net/filemonitor/appsettings.json
@@ -13,7 +13,7 @@
     "ApiUrl": "http://api:8080",
     "VolumePath": "/data",
     "IngestTypes": "Paper",
-    "TimeZone": "UTC",
+    "TimeZone": "PST",
     "PrivateKeysPath": "keys"
   },
   "Auth": {

--- a/services/net/image/ImageAction.cs
+++ b/services/net/image/ImageAction.cs
@@ -138,7 +138,7 @@ public class ImageAction : IngestAction<ImageOptions>
     protected string GetOutputPath(IngestModel ingest)
     {
         // TODO: Handle different destination connections.
-        return this.Options.VolumePath.CombineWith(ingest.DestinationConnection?.GetConfigurationValue("path")?.MakeRelativePath() ?? "", $"{ingest.Source?.Code}/{GetDateTimeForTimeZone(ingest):yyyy-MM-dd/}");
+        return this.Options.VolumePath.CombineWith(ingest.DestinationConnection?.GetConfigurationValue("path")?.MakeRelativePath() ?? "", $"{ingest.Source?.Code}/{GetDateTimeForTimeZone(ingest):yyyy-MM-dd}/");
     }
 
     /// <summary>
@@ -149,7 +149,11 @@ public class ImageAction : IngestAction<ImageOptions>
     protected string GetInputPath(IngestModel ingest)
     {
         var currentDate = GetDateTimeForTimeZone(ingest);
-        return (ingest.SourceConnection?.GetConfigurationValue("path") ?? "").CombineWith(ingest.GetConfigurationValue("path")?.MakeRelativePath() ?? "", currentDate.Year.ToString(), currentDate.Month.ToString("00"), currentDate.Day.ToString("00"));
+        return (ingest.SourceConnection?.GetConfigurationValue("path") ?? "").CombineWith(
+                ingest.GetConfigurationValue("path")?.MakeRelativePath() ?? "",
+                currentDate.Year.ToString(),
+                currentDate.Month.ToString("00"),
+                currentDate.Day.ToString("00"));
     }
 
     /// <summary>
@@ -246,7 +250,7 @@ public class ImageAction : IngestAction<ImageOptions>
         {
             StreamUrl = ingest.GetConfigurationValue("url"),
             FilePath = (ingest.DestinationConnection?.GetConfigurationValue("path")?.MakeRelativePath() ?? "")
-                .CombineWith($"{ingest.Source?.Code}/{GetDateTimeForTimeZone(ingest):yyyy-MM-dd/}", reference.Uid),
+                .CombineWith($"{ingest.Source?.Code}/{GetDateTimeForTimeZone(ingest):yyyy-MM-dd}/", reference.Uid),
             Language = ingest.GetConfigurationValue("language")
         };
         var result = await this.Api.SendMessageAsync(reference.Topic, content);

--- a/services/net/image/appsettings.json
+++ b/services/net/image/appsettings.json
@@ -14,7 +14,7 @@
   "Service": {
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
-    "TimeZone": "UTC",
+    "TimeZone": "PST",
     "VolumePath": "/data",
     "Command": "ffmpeg",
     "IngestTypes": "Front Page",

--- a/services/net/indexing/appsettings.json
+++ b/services/net/indexing/appsettings.json
@@ -14,7 +14,7 @@
   "Service": {
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
-    "TimeZone": "UTC",
+    "TimeZone": "PST",
     "Topics": "index",
     "ElasticsearchUri": "http://elastic:9200",
     "UnpublishedIndex": "unpublished_content",

--- a/services/net/nlp/appsettings.json
+++ b/services/net/nlp/appsettings.json
@@ -14,7 +14,7 @@
   "Service": {
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080/api",
-    "TimeZone": "UTC",
+    "TimeZone": "PST",
     "Topics": "nlp",
     "IndexingTopic": "index"
   },

--- a/services/net/syndication/appsettings.json
+++ b/services/net/syndication/appsettings.json
@@ -15,7 +15,7 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
     "IngestTypes": "Syndication",
-    "TimeZone": "UTC",
+    "TimeZone": "PST",
     "InvalidEncodings": "�e(TM):_'__&#39;:_'"
   },
   "Auth": {

--- a/services/net/transcription/appsettings.json
+++ b/services/net/transcription/appsettings.json
@@ -15,7 +15,7 @@
     "MaxThreads": 10,
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
-    "TimeZone": "UTC",
+    "TimeZone": "PST",
     "Topics": "transcribe",
     "VolumePath": "/data",
     "AzureRegion": "canadacentral",


### PR DESCRIPTION
- File and Image ingest services had an invalid output path.
- All ingest services are now defaulted to PST instead of UTC.  This was causing issues with date comparison.  I haven't had time to test Syndication, Capture, and Clip to determine if the change has a negative impact.
- Attempting to find a way to get the API to build with Buildah.  It runs of drive space in the container.  However, if I use a PVC it then throws a permission error.