### PR TITLE
Change api Dockerfile image

### DIFF
--- a/api/net/Dockerfile
+++ b/api/net/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILD_CONFIGURATION=Release
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM image-registry.apps.silver.devops.gov.bc.ca/9b301c-tools/aspnet:6.0 AS base
 EXPOSE 443 8080
 
 # Copy csproj and restore as distinct layers
@@ -19,10 +19,6 @@ RUN dotnet publish "TNO.API.csproj" -c "$BUILD_CONFIGURATION" -o /app/publish
 
 # Runtime image
 FROM base AS final
-
-RUN apt-get update && apt-get -y upgrade
-RUN apt -y install curl libc6-dev libgdiplus ffmpeg
-RUN apt-get clean
 
 WORKDIR /app
 COPY --from=publish /app/publish .

--- a/api/net/Dockerfile.aspnet
+++ b/api/net/Dockerfile.aspnet
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+
+RUN apt-get update && apt-get -y upgrade
+RUN apt -y install curl libc6-dev libgdiplus ffmpeg
+RUN apt-get clean


### PR DESCRIPTION
This may not work, but will attempt to use a prebuilt image for aspnet:6.0.  This image is stored in our image registry.

I do not know if our image registry is accessible without authentication.  I'll test with my laptop shortly if the pipeline is able to complete the build.