### PR TITLE
Reduce api build image size

### DIFF
--- a/api/net/Dockerfile
+++ b/api/net/Dockerfile
@@ -4,24 +4,22 @@ EXPOSE 443 8080
 
 # Copy csproj and restore as distinct layers
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+
+ENV PATH="$PATH:/root/.dotnet/tools"
+RUN dotnet tool install --global dotnet-ef --version 6.0.3
+
 WORKDIR /src/api/net
 COPY api/net/ .
 COPY libs/net/ /src/libs/net/
 
 RUN dotnet restore
-ENV PATH="$PATH:/root/.dotnet/tools"
-RUN dotnet tool install --global dotnet-ef --version 6.0.3
-
-RUN dotnet build "TNO.API.csproj" -c "$BUILD_CONFIGURATION" -o /app/build
-
-FROM build AS publish
 RUN dotnet publish "TNO.API.csproj" -c "$BUILD_CONFIGURATION" -o /app/publish
 
 # Runtime image
 FROM base AS final
 
 WORKDIR /app
-COPY --from=publish /app/publish .
+COPY --from=build /app/publish .
 COPY api/net/entrypoint.sh .
 RUN chmod +x /app/entrypoint.sh
 


### PR DESCRIPTION
Another attempt at resolving our build issue.  For some reason Buildah runs out of device space.