### PR TITLE
Correct Front page published on date

### DIFF
--- a/app/editor/src/features/admin/ingests/configurations/FrontPage.tsx
+++ b/app/editor/src/features/admin/ingests/configurations/FrontPage.tsx
@@ -22,6 +22,19 @@ export const FrontPage: React.FC = (props) => {
         name="configuration.fileName"
         value={values.configuration.fileName}
       />
+      <p>
+        Front pages are often delivered the evening before the publish date. Use a regular
+        expression to parse the file name to determine the published on date. Use regex group names
+        to identify each part of the date, (?&lt;year&gt;) (?&lt;month&gt;) (?&lt;day&gt;)
+        (?&lt;hour&gt;) (?&lt;minute&gt;) (?&lt;second&gt;)
+      </p>
+      <FormikText
+        label="Parse Published On from File Name"
+        name="configuration.publishedOnExpression"
+        tooltip="Use a regex to extract the published on date"
+        placeholder="^sv-GLB-[A-Za-z]{3}-(?<day>[0-9]{2})(?<month>[0-9]{2})(?<year>[0-9]{4})"
+        value={values.configuration.publishedOnExpression}
+      />
     </styled.IngestType>
   );
 };

--- a/libs/net/dal/Migrations/Initial/Up/PostUp/02-Ingest.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/02-Ingest.sql
@@ -462,6 +462,7 @@ INSERT INTO public.ingest (
   , frontPageId -- product_id
   , '{ "path": "binaryroot",
       "fileName": "sv-GLB",
+      "publishedOnExpression": "^sv-GLB-[A-Za-z]{3}-(?<day>[0-9]{2})(?<month>[0-9]{2})(?<year>[0-9]{4})",
       "post": true,
       "import": true }' -- configuration
   , 1 -- schedule_type
@@ -482,6 +483,7 @@ INSERT INTO public.ingest (
   , frontPageId -- product_id
   , '{ "path": "binaryroot",
       "fileName": "NTNP",
+      "publishedOnExpression": "^NTNP(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})(?<hour>[0-9]{2})(?<minute>[0-9]{2})(?<second>[0-9]{2})",
       "post": true,
       "import": true }' -- configuration
   , 1 -- schedule_type
@@ -502,6 +504,7 @@ INSERT INTO public.ingest (
   , frontPageId -- product_id
   , '{ "path": "binaryroot",
       "fileName": "VAPR",
+      "publishedOnExpression": "^VAPR(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})(?<hour>[0-9]{2})(?<minute>[0-9]{2})(?<second>[0-9]{2})",
       "post": true,
       "import": true }' -- configuration
   , 1 -- schedule_type
@@ -522,6 +525,7 @@ INSERT INTO public.ingest (
   , frontPageId -- product_id
   , '{ "path": "binaryroot",
       "fileName": "VITC",
+      "publishedOnExpression": "^VITC(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})(?<hour>[0-9]{2})(?<minute>[0-9]{2})(?<second>[0-9]{2})",
       "post": true,
       "import": true }' -- configuration
   , 1 -- schedule_type
@@ -542,6 +546,7 @@ INSERT INTO public.ingest (
   , frontPageId -- product_id
   , '{ "path": "binaryroot",
       "fileName": "VASN",
+      "publishedOnExpression": "^VASN(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})(?<hour>[0-9]{2})(?<minute>[0-9]{2})(?<second>[0-9]{2})",
       "post": true,
       "import": true }' -- configuration
   , 1 -- schedule_type


### PR DESCRIPTION
Front pages are often delivered the evening before their published on date.  There is now a way to add a regex to parse the published on date from the file name.

![image](https://user-images.githubusercontent.com/3180256/199781856-657573aa-e4b6-4af1-b50e-ea583bcac959.png)
