### PR TITLE
Fix local api build

### DIFF
--- a/api/net/Dockerfile.openshift
+++ b/api/net/Dockerfile.openshift
@@ -1,10 +1,5 @@
 ARG BUILD_CONFIGURATION=Release
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
-
-RUN apt-get update && apt-get -y upgrade
-RUN apt -y install curl libc6-dev libgdiplus ffmpeg
-RUN apt-get clean
-
+FROM image-registry.apps.silver.devops.gov.bc.ca/9b301c-tools/aspnet:6.0 AS base
 EXPOSE 443 8080
 
 # Copy csproj and restore as distinct layers

--- a/openshift/kustomize/api/build/base/build.yaml
+++ b/openshift/kustomize/api/build/base/build.yaml
@@ -45,7 +45,7 @@ spec:
     type: Docker
     dockerStrategy:
       imageOptimizationPolicy: SkipLayers
-      dockerfilePath: api/net/Dockerfile
+      dockerfilePath: api/net/Dockerfile.openshift
   output:
     to:
       kind: ImageStreamTag

--- a/openshift/kustomize/tekton/base/pipelines/buildah-api.yaml
+++ b/openshift/kustomize/tekton/base/pipelines/buildah-api.yaml
@@ -93,7 +93,7 @@ spec:
         - name: CONTEXT
           value: $(params.CONTEXT)
         - name: DOCKERFILE
-          value: $(params.CONTEXT)/api/net/Dockerfile
+          value: $(params.CONTEXT)/api/net/Dockerfile.openshift
         - name: IMAGE
           value: api
         - name: IMAGE_TAG

--- a/openshift/kustomize/tekton/base/pipelines/buildah-main.yaml
+++ b/openshift/kustomize/tekton/base/pipelines/buildah-main.yaml
@@ -144,7 +144,7 @@ spec:
         - name: CONTEXT
           value: $(params.CONTEXT)
         - name: DOCKERFILE
-          value: $(params.CONTEXT)/api/net/Dockerfile
+          value: $(params.CONTEXT)/api/net/Dockerfile.openshift
         - name: IMAGE
           value: api
         - name: IMAGE_TAG


### PR DESCRIPTION
The change to the BuildConfig for the API regrettably required authentication to build locally.  Which complicates the ease of setting up a new developer environment.  I've created two separate Dockerfile's so that it will work locally without issues.  This of course now requires us to update both to keep them in sync, which isn't ideal.