### PR TITLE
TNO-710 Update Clip service to run remotely

### DIFF
--- a/app/editor/src/features/admin/connections/configurations/AWSConfiguration.tsx
+++ b/app/editor/src/features/admin/connections/configurations/AWSConfiguration.tsx
@@ -34,6 +34,7 @@ export const AWSConfiguration = () => {
             label="Username"
             name="configuration.username"
             value={values.configuration?.username}
+            autoComplete="off"
           />
         </Col>
         <Col flex="1 1 0">
@@ -42,7 +43,7 @@ export const AWSConfiguration = () => {
             name="configuration.password"
             value={values.configuration?.password}
             type="password"
-            autoComplete="off"
+            autoComplete="new-password"
           />
         </Col>
         <Col flex="1 1 0">

--- a/app/editor/src/features/admin/connections/configurations/AzureConfiguration.tsx
+++ b/app/editor/src/features/admin/connections/configurations/AzureConfiguration.tsx
@@ -34,6 +34,7 @@ export const AzureConfiguration = () => {
             label="Username"
             name="configuration.username"
             value={values.configuration?.username}
+            autoComplete="off"
           />
         </Col>
         <Col flex="1 1 0">
@@ -42,7 +43,7 @@ export const AzureConfiguration = () => {
             name="configuration.password"
             value={values.configuration?.password}
             type="password"
-            autoComplete="off"
+            autoComplete="new-password"
           />
         </Col>
         <Col flex="1 1 0">

--- a/app/editor/src/features/admin/connections/configurations/FTPConfiguration.tsx
+++ b/app/editor/src/features/admin/connections/configurations/FTPConfiguration.tsx
@@ -35,6 +35,7 @@ export const FTPConfiguration = () => {
             label="Username"
             name="configuration.username"
             value={values.configuration?.username}
+            autoComplete="off"
           />
         </Col>
         <Col flex="1 1 0">
@@ -43,7 +44,7 @@ export const FTPConfiguration = () => {
             name="configuration.password"
             value={values.configuration?.password}
             type="password"
-            autoComplete="off"
+            autoComplete="new-password"
           />
         </Col>
       </Row>

--- a/app/editor/src/features/admin/connections/configurations/HTTPConfiguration.tsx
+++ b/app/editor/src/features/admin/connections/configurations/HTTPConfiguration.tsx
@@ -21,6 +21,7 @@ export const HTTPConfiguration = () => {
             label="Username"
             name="configuration.username"
             value={values.configuration?.username}
+            autoComplete="off"
           />
         </Col>
         <Col flex="1 1 0">
@@ -29,7 +30,7 @@ export const HTTPConfiguration = () => {
             name="configuration.password"
             value={values.configuration?.password}
             type="password"
-            autoComplete="off"
+            autoComplete="new-password"
           />
         </Col>
       </Row>

--- a/app/editor/src/features/admin/connections/configurations/NASConfiguration.tsx
+++ b/app/editor/src/features/admin/connections/configurations/NASConfiguration.tsx
@@ -26,6 +26,7 @@ export const NASConfiguration = () => {
             label="Username"
             name="configuration.username"
             value={values.configuration?.username}
+            autoComplete="off"
           />
         </Col>
         <Col flex="1 1 0">
@@ -34,7 +35,7 @@ export const NASConfiguration = () => {
             name="configuration.password"
             value={values.configuration?.password}
             type="password"
-            autoComplete="off"
+            autoComplete="new-password"
           />
         </Col>
       </Row>

--- a/app/editor/src/features/admin/connections/configurations/SFTPConfiguration.tsx
+++ b/app/editor/src/features/admin/connections/configurations/SFTPConfiguration.tsx
@@ -35,6 +35,7 @@ export const SFTPConfiguration = () => {
             label="Username"
             name="configuration.username"
             value={values.configuration?.username}
+            autoComplete="off"
           />
         </Col>
         <Col flex="1 1 0">
@@ -43,7 +44,7 @@ export const SFTPConfiguration = () => {
             name="configuration.password"
             value={values.configuration?.password}
             type="password"
-            autoComplete="off"
+            autoComplete="new-password"
           />
         </Col>
       </Row>

--- a/app/editor/src/features/admin/connections/configurations/SSHConfiguration.tsx
+++ b/app/editor/src/features/admin/connections/configurations/SSHConfiguration.tsx
@@ -35,6 +35,7 @@ export const SSHConfiguration = () => {
             label="Username"
             name="configuration.username"
             value={values.configuration?.username}
+            autoComplete="off"
           />
         </Col>
         <Col flex="1 1 0">
@@ -43,7 +44,7 @@ export const SSHConfiguration = () => {
             name="configuration.password"
             value={values.configuration?.password}
             type="password"
-            autoComplete="off"
+            autoComplete="new-password"
           />
         </Col>
         <Col flex="1 1 0">

--- a/app/editor/src/features/admin/ingests/IngestSettings.tsx
+++ b/app/editor/src/features/admin/ingests/IngestSettings.tsx
@@ -113,7 +113,7 @@ export const IngestSettings: React.FC<IIngestSettingsProps> = () => {
                     value={values.sourceConnection?.configuration.password}
                     type="password"
                     disabled
-                    autoComplete="off"
+                    autoComplete="new-password"
                   />
                 </Col>
               </Row>

--- a/app/editor/src/features/admin/ingests/configurations/AudioClip.tsx
+++ b/app/editor/src/features/admin/ingests/configurations/AudioClip.tsx
@@ -22,15 +22,10 @@ export const AudioClip: React.FC = (props) => {
         options={TimeZones}
         value={timeZone}
       />
-      <FormikText
-        label="Format"
-        name="configuration.format"
-        tooltip="Format of the clip"
-        placeholder="mp3"
-      />
+      <FormikText label="Format" name="configuration.format" tooltip="Format of the clip" />
       <p>Use "{'{schedule.Name}'}.mp3" to name the file with the schedule name.</p>
       <FormikText
-        label="File Name"
+        label="Output File Name"
         name="configuration.fileName"
         tooltip="File name and output format"
         placeholder="{schedule.Name}.mp3"

--- a/app/editor/src/features/admin/ingests/configurations/AudioStream.tsx
+++ b/app/editor/src/features/admin/ingests/configurations/AudioStream.tsx
@@ -35,15 +35,10 @@ export const AudioStream: React.FC = (props) => {
         options={Languages}
         value={language}
       />
-      <FormikText
-        label="Format"
-        name="configuration.format"
-        tooltip="Format of the stream"
-        placeholder="mp3"
-      />
+      <FormikText label="Format" name="configuration.format" tooltip="Format of the stream" />
       <p>Use "{'{schedule.Name}'}.mp3" to name the file with the schedule name.</p>
       <FormikText
-        label="File Name"
+        label="Output File Name"
         name="configuration.fileName"
         tooltip="File name and output format"
         placeholder="{schedule.Name}.mp3"

--- a/app/editor/src/features/admin/ingests/configurations/VideoClip.tsx
+++ b/app/editor/src/features/admin/ingests/configurations/VideoClip.tsx
@@ -28,15 +28,10 @@ export const VideoClip: React.FC = (props) => {
         options={TimeZones}
         value={timeZone}
       />
-      <FormikText
-        label="Format"
-        name="configuration.format"
-        tooltip="Format of the clip"
-        placeholder="mp4"
-      />
+      <FormikText label="Format" name="configuration.format" tooltip="Format of the clip" />
       <p>Use "{'{schedule.Name}'}.mp4" to name the file with the schedule name.</p>
       <FormikText
-        label="File Name"
+        label="Output File Name"
         name="configuration.fileName"
         tooltip="File name and output format"
         placeholder="{schedule.Name}.mp4"

--- a/app/editor/src/features/admin/ingests/configurations/VideoStream.tsx
+++ b/app/editor/src/features/admin/ingests/configurations/VideoStream.tsx
@@ -41,15 +41,10 @@ export const VideoStream: React.FC = (props) => {
         options={Languages}
         value={language}
       />
-      <FormikText
-        label="Format"
-        name="configuration.format"
-        tooltip="Format of the stream"
-        placeholder="mp4"
-      />
+      <FormikText label="Format" name="configuration.format" tooltip="Format of the stream" />
       <p>Use "{'{schedule.Name}'}.mp4" to name the file with the schedule name.</p>
       <FormikText
-        label="File Name"
+        label="Output File Name"
         name="configuration.fileName"
         tooltip="File name and output format"
         placeholder="{schedule.Name}.mp4"

--- a/libs/net/core/Extensions/StringExtensions.cs
+++ b/libs/net/core/Extensions/StringExtensions.cs
@@ -335,12 +335,9 @@ public static class StringExtensions
     /// <param name="directorySeparatorChar"></param>
     /// <param name="paths"></param>
     /// <returns></returns>
-    public static string CombineWith(this string path, char directorySeparatorChar, params string[] paths)
+    public static string CombineWith(this string path, params string[] paths)
     {
-        var values = new string[paths.Length + 1];
-        values[0] = path;
-        paths.CopyTo(values, 1);
-        return Path.Combine(values).Replace(Path.DirectorySeparatorChar, directorySeparatorChar);
+        return path.CombineWith(Path.AltDirectorySeparatorChar, paths);
     }
 
     /// <summary>
@@ -351,9 +348,8 @@ public static class StringExtensions
     /// <param name="directorySeparatorChar"></param>
     /// <param name="paths"></param>
     /// <returns></returns>
-    public static string CombineWith(this string path, params string[] paths)
+    public static string CombineWith(this string path, char directorySeparatorChar, params string[] paths)
     {
-        var directorySeparatorChar = Path.AltDirectorySeparatorChar;
         var values = new string[paths.Length + 1];
         values[0] = path;
         paths.CopyTo(values, 1);

--- a/libs/net/dal/Extensions/IngestExtensions.cs
+++ b/libs/net/dal/Extensions/IngestExtensions.cs
@@ -16,7 +16,11 @@ public static class IngestExtensions
     /// <returns></returns>
     public static Ingest AddToContext(this TNOContext context, Ingest updated)
     {
-        updated.Schedules.AddRange(updated.SchedulesManyToMany.Select(s => s.Schedule!).Where(s => s != null).ToArray());
+        updated.SchedulesManyToMany.Where(s => s.Schedule != null).ForEach(s =>
+        {
+            context.Add(s.Schedule!);
+            context.Add(s);
+        });
         updated.DataLocationsManyToMany.ForEach(a =>
         {
             context.Add(a);

--- a/services/net/Makefile
+++ b/services/net/Makefile
@@ -57,6 +57,14 @@ b-capture-linux: ## Build Capture Service for Linux x64.
 	$(info Build Capture Service for Linux x64)
 	@cd capture; dotnet publish --runtime linux-x64 --self-contained
 
+b-clip-arm: ## Build Clip Service for Linux ARM.
+	$(info Build Clip Service for Linux ARM)
+	@cd clip; dotnet publish --runtime linux-arm64 --self-contained
+
+b-clip-linux: ## Build Clip Service for Linux x64.
+	$(info Build Clip Service for Linux x64)
+	@cd clip; dotnet publish --runtime linux-x64 --self-contained
+
 ##############################################################################
 # Dotnet Tools
 ##############################################################################

--- a/services/net/clip/TNO.Services.Clip.csproj
+++ b/services/net/clip/TNO.Services.Clip.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
+    <RuntimeIdentifiers>win-x64;linux-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
     <Nullable>enable</Nullable>
     <RootNamespace>TNO.Services.Clip</RootNamespace>
     <Version>1.0.0.0</Version>

--- a/services/net/content/ContentManager.cs
+++ b/services/net/content/ContentManager.cs
@@ -385,7 +385,7 @@ public class ContentManager : ServiceManager<ContentOptions>
         Stream? file = null;
         try
         {
-            var fullPath = path.CombineWith(model.FilePath.MakeRelativePath());
+            var fullPath = path.CombineWith(model.FilePath.MakeRelativePath()).Replace("~/", $"{client.WorkingDirectory}/");
             if (client.Exists(fullPath))
             {
                 var fileName = Path.GetFileName(fullPath);
@@ -409,24 +409,6 @@ public class ContentManager : ServiceManager<ContentOptions>
             if (file != null)
                 file.Close();
         }
-    }
-
-    /// <summary>
-    /// Download the file from the remote 'sourcePath' and copy it to the local 'destinationPath'.
-    /// Ensures the 'destinationPath' exists.  If it doesn't it will create the folders.
-    /// </summary>
-    /// <param name="client"></param>
-    /// <param name="source"></param>
-    /// <param name="destination"></param>
-    /// <returns></returns>
-    private static async Task<FileStream> DownloadFileAsync(SftpClient client, string sourcePath, string destinationPath)
-    {
-        var path = Path.GetDirectoryName(destinationPath);
-        if (!String.IsNullOrWhiteSpace(path))
-            Directory.CreateDirectory(path);
-        using var saveFile = File.OpenWrite(destinationPath);
-        await Task.Factory.FromAsync(client.BeginDownloadFile(sourcePath, saveFile), client.EndDownloadFile);
-        return saveFile;
     }
 
     /// <summary>

--- a/services/net/filemonitor/FilemonitorAction.cs
+++ b/services/net/filemonitor/FilemonitorAction.cs
@@ -146,6 +146,7 @@ public class FileMonitorAction : IngestAction<FileMonitorOptions>
         using var client = new SftpClient(connectionInfo);
         client.Connect();
 
+        remotePath = remotePath.Replace("~/", $"{client.WorkingDirectory}/");
         var files = await FetchFileListingAsync(client, remotePath);
         files = files.Where(f => match.Match(f.Name).Success);
         this.Logger.LogDebug("{count} files were discovered that match the filter '{filter}'.", files.Count(), filePattern);

--- a/services/net/image/ImageAction.cs
+++ b/services/net/image/ImageAction.cs
@@ -84,13 +84,13 @@ public class ImageAction : IngestAction<ImageOptions>
         if (File.Exists(sshKeyFile))
         {
             var keyFile = new PrivateKeyFile(sshKeyFile);
-
             var keyFiles = new[] { keyFile };
             var connectionInfo = new ConnectionInfo(hostname,
                                                 username,
                                                 new PrivateKeyAuthenticationMethod(username, keyFiles));
             using var client = new SftpClient(connectionInfo);
             client.Connect();
+            remotePath = remotePath.Replace("~/", $"{client.WorkingDirectory}/");
             var files = await FetchImagesAsync(client, remotePath);
             files = files.Where(f => f.Name.Contains(inputFileName));
             this.Logger.LogDebug("{count} files were discovered that match the filter '{filter}'.", files.Count(), inputFileName);


### PR DESCRIPTION
The Clip Service needs access to the capture files.  Which means it either needs to copy a large file across the network, or the Clip Service needs to be run in the same location as the capture files.  For performance, the best option is to run it in the same location.

## Summary
- Clip service creates a temporary file if the stream is a mkv file, so that it can calculate duration.
- Fixed a bug where remote path include `~` for the current user's home directory.
- Fixed bug when saving a new Ingest configuration with a schedule.