### PR TITLE
TNO-730: Clear button on react-select

### DIFF
--- a/app/editor/src/components/form/select/Select.tsx
+++ b/app/editor/src/components/form/select/Select.tsx
@@ -93,7 +93,7 @@ export const Select = <OptionType extends IOptionItem>({
   };
 
   return (
-    <styled.Select className="frm-in" width={width}>
+    <styled.Select className="frm-in">
       {label && (
         <label
           data-for="main-tooltip"

--- a/app/editor/src/components/form/select/Select.tsx
+++ b/app/editor/src/components/form/select/Select.tsx
@@ -82,8 +82,18 @@ export const Select = <OptionType extends IOptionItem>({
 }: ISelectProps<OptionType>) => {
   const selectRef = React.useRef(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
+
+  //  function that is called when the user clicks the "x" on the drop down */
+  const manualClear = () => {
+    if (selectRef.current) {
+      /** also run inherited on clear if present */
+      onClear?.();
+      (selectRef.current as any).clearValue();
+    }
+  };
+
   return (
-    <styled.Select className="frm-in">
+    <styled.Select className="frm-in" width={width}>
       {label && (
         <label
           data-for="main-tooltip"
@@ -94,36 +104,42 @@ export const Select = <OptionType extends IOptionItem>({
           {label} {tooltip && <FontAwesomeIcon icon={faInfoCircle} />}
         </label>
       )}
-      <Row
-        onKeyUp={(e) => {
-          if (e.code === 'Delete') {
-            onClear?.();
-          }
-        }}
-        data-for="select-tooltip"
-      >
-        <styled.SelectField
-          ref={selectRef}
-          id={id ?? `sel-${name}`}
-          name={name}
-          className={`${className ?? ''}${!!error ? ' alert' : ''}`}
-          classNamePrefix={classNamePrefix ?? 'rs'}
-          variant={variant}
-          required={required}
-          width={width}
-          value={value}
-          options={options}
-          onChange={(newValue: unknown, actionMeta: ActionMeta<unknown>) => {
-            onChange?.(newValue, actionMeta);
-            inputRef?.current?.setCustomValidity('');
+      <Row className="select-container">
+        <Row
+          onKeyUp={(e) => {
+            if (e.code === 'Delete') {
+              onClear?.();
+            }
           }}
-          onFocus={(e: any) => {
-            const input = e.target as HTMLSelectElement;
-            input?.setCustomValidity('');
-          }}
-          {...rest}
-        />
-        {children}
+          data-for="select-tooltip"
+          className="input-container"
+        >
+          <styled.SelectField
+            ref={selectRef}
+            id={id ?? `sel-${name}`}
+            name={name}
+            className={`${className ?? ''}${!!error ? ' alert' : ''}`}
+            classNamePrefix={classNamePrefix ?? 'rs'}
+            variant={variant}
+            required={required}
+            width={width}
+            value={value}
+            options={options}
+            onChange={(newValue: unknown, actionMeta: ActionMeta<unknown>) => {
+              onChange?.(newValue, actionMeta);
+              inputRef?.current?.setCustomValidity('');
+            }}
+            onFocus={(e: any) => {
+              const input = e.target as HTMLSelectElement;
+              input?.setCustomValidity('');
+            }}
+            {...rest}
+          />
+          <span className="clear" onClick={() => manualClear()}>
+            X
+          </span>
+        </Row>
+        <div className="children">{children}</div>
       </Row>
       {!rest.isDisabled && (
         <input

--- a/app/editor/src/components/form/select/styled/Select.tsx
+++ b/app/editor/src/components/form/select/styled/Select.tsx
@@ -6,6 +6,24 @@ export const Select = styled(Col)`
     content: ' *';
     color: ${(props) => props.theme.css.dangerColor};
   }
+  margin-right: 0.5em;
+  .select-container {
+    width: 100%;
+  }
+  .input-container {
+    position: relative;
+    .clear {
+      :hover {
+        color: ${(props) => props.theme.css.dangerColor};
+        cursor: pointer;
+      }
+      position: absolute;
+      right: 55px;
+      align-self: center;
+      font-weight: 500;
+      color: #cccccc;
+    }
+  }
 
   & > input {
     width: 0px !important; // Required to stop the input from using 100% width and causing horizontal overflow issues.

--- a/app/editor/src/components/form/select/styled/SelectField.tsx
+++ b/app/editor/src/components/form/select/styled/SelectField.tsx
@@ -30,8 +30,8 @@ export const SelectField = styled(Select)<ISelectProps<any>>`
     border-radius: 0.25rem;
     transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
       border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-    overflow: visible;
-    text-transform: none;
+      overflow: visible;
+      text-transform: none;
     color: ${(props) => {
       switch (props.variant) {
         case SelectVariant.warning:
@@ -68,7 +68,7 @@ export const SelectField = styled(Select)<ISelectProps<any>>`
     border-color: ${(props) => {
       switch (props.variant) {
         case SelectVariant.primary:
-          return props.required ? props.theme.css.inputRequiredBorderColor : '#38598a';
+          return props.required ? props.theme.css.inputRequiredBorderColor : '#606060';
         case SelectVariant.secondary:
           return props.required ? props.theme.css.inputRequiredBorderColor : '#6c757d';
         case SelectVariant.success:
@@ -98,26 +98,7 @@ export const SelectField = styled(Select)<ISelectProps<any>>`
             return props.theme.css.primaryColor;
         }
       }};
-      border-color: ${(props) => {
-        switch (props.variant) {
-          case SelectVariant.primary:
-            return '#294266';
-          case SelectVariant.secondary:
-            return '#545b62';
-          case SelectVariant.success:
-            return '#32662e';
-          case SelectVariant.info:
-            return '#6da7dc';
-          case SelectVariant.warning:
-            return '#f7bb23';
-          case SelectVariant.danger:
-            return '#be262c';
-          case SelectVariant.link:
-            return 'transparent';
-          default:
-            return '#fff';
-        }
-      }};
+
     }
 
     &:focus {
@@ -142,16 +123,13 @@ export const SelectField = styled(Select)<ISelectProps<any>>`
             return 'none';
         }
       }};
-      color: ${(props) => {
-        switch (props.variant) {
-          case SelectVariant.link:
-            return '#0631f3';
-        }
-      }};
-    }
   }
 
   .rs__menu {
     width: ${(props) => props.width};
+  }
+
+  .clear {
+    color: ${(props) => props.theme.css.primaryColor};
   }
 `;

--- a/app/editor/src/features/admin/users/UserForm.tsx
+++ b/app/editor/src/features/admin/users/UserForm.tsx
@@ -15,7 +15,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useLookup } from 'store/hooks';
 import { useUsers } from 'store/hooks/admin';
-import { Button, ButtonVariant, Show } from 'tno-core';
+import { Button, ButtonVariant, FieldSize, Show } from 'tno-core';
 import { Col, Row } from 'tno-core';
 import { getEnumStringOptions } from 'utils';
 
@@ -127,6 +127,7 @@ export const UserForm: React.FC = () => {
                     label="Roles"
                     name="role"
                     options={roleOptions}
+                    width={FieldSize.Big}
                     placeholder="Select Role"
                     tooltip="Add a role to the user"
                   >

--- a/app/editor/src/features/admin/users/styled/UserList.tsx
+++ b/app/editor/src/features/admin/users/styled/UserList.tsx
@@ -3,14 +3,15 @@ import styled from 'styled-components';
 
 export const UserList = styled(FormPage)`
   .filter-bar {
-    display: flex;
+    padding: 1.5%;
+    .txt {
+      margin-right: 0.5em;
+    }
+    .frm-in {
+      padding: 0;
+    }
     align-items: center;
-    .rs__control {
-      margin-top: 3.5%;
-    }
-    input {
-      margin-top: 3.5%;
-    }
+    display: flex;
     button {
       background-color: white;
     }

--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -443,11 +443,13 @@ export const ContentForm: React.FC<IContentFormProps> = ({
                             sourceOptions.find((mt) => mt.value === props.values.sourceId) ?? ''
                           }
                           onChange={(newValue: any) => {
-                            const source = sources.find((ds) => ds.id === newValue.value);
-                            props.setFieldValue('sourceId', newValue.value);
-                            props.setFieldValue('otherSource', source?.code ?? '');
-                            if (!!source) {
-                              props.setFieldValue('licenseId', source.licenseId);
+                            if (!!newValue) {
+                              const source = sources.find((ds) => ds.id === newValue.value);
+                              props.setFieldValue('sourceId', newValue.value);
+                              props.setFieldValue('otherSource', source?.code ?? '');
+                              if (!!source) {
+                                props.setFieldValue('licenseId', source.licenseId);
+                              }
                             }
                           }}
                           options={sourceOptions.filter(

--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -489,6 +489,7 @@ export const ContentForm: React.FC<IContentFormProps> = ({
                               productOptions.find((mt) => mt.value === props.values.productId) ?? ''
                             }
                             label="Designation"
+                            width={FieldSize.Big}
                             options={productOptions}
                             required
                           />

--- a/app/editor/src/features/content/list-view/ContentFilter.tsx
+++ b/app/editor/src/features/content/list-view/ContentFilter.tsx
@@ -90,9 +90,10 @@ export const ContentFilter: React.FC<IContentFilterProps> = ({ search }) => {
           label="Product Designation"
           options={productOptions}
           value={productOptions.find((mt) => mt.value === filter.productId)}
+          width={FieldSize.Big}
           defaultValue={productOptions[0]}
           onChange={(newValue) => {
-            var productId = (newValue as IOptionItem).value ?? 0;
+            var productId = !!newValue ? (newValue as IOptionItem).value : 0;
             storeFilter({
               ...filter,
               pageIndex: 0,
@@ -103,6 +104,7 @@ export const ContentFilter: React.FC<IContentFilterProps> = ({ search }) => {
         <Select
           name="user"
           label="User"
+          width={FieldSize.Big}
           options={userOptions}
           value={userOptions.find((u) => u.value === filter.userId)}
           onChange={(newValue) => {


### PR DESCRIPTION
TODO: 
- [x] Cleanup styling for various forms 

- Can now click an "x" within the react-select to clear input, works for both formik and non-formik
- Also removed some dead CSS
![tno-730](https://user-images.githubusercontent.com/15724124/201866233-19df9c20-b011-4a56-a787-769e9aa806b0.gif)

