### PR TITLE
TNO-8 Reduce security to temporarily enable keycloak gold realm

### DIFF
--- a/api/net/Areas/Admin/Controllers/WorkOrderController.cs
+++ b/api/net/Areas/Admin/Controllers/WorkOrderController.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Admin.Models.WorkOrder;
-using TNO.API.Keycloak;
 using TNO.API.Models;
 using TNO.DAL.Models;
 using TNO.DAL.Services;

--- a/api/net/Areas/Editor/Controllers/ContentController.cs
+++ b/api/net/Areas/Editor/Controllers/ContentController.cs
@@ -16,7 +16,6 @@ using TNO.Core.Extensions;
 using TNO.Kafka;
 using TNO.API.Config;
 using TNO.Kafka.Models;
-using TNO.Keycloak;
 using System.Net.Mime;
 
 namespace TNO.API.Areas.Editor.Controllers;
@@ -24,7 +23,8 @@ namespace TNO.API.Areas.Editor.Controllers;
 /// <summary>
 /// ContentController class, provides Content endpoints for the api.
 /// </summary>
-[ClientRoleAuthorize(ClientRole.Editor)]
+// [ClientRoleAuthorize(ClientRole.Editor)]
+[Authorize]
 [ApiController]
 [Area("editor")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Editor/Controllers/LookupController.cs
+++ b/api/net/Areas/Editor/Controllers/LookupController.cs
@@ -11,7 +11,7 @@ using TNO.Core.Exceptions;
 using TNO.DAL.Services;
 using TNO.CSS;
 using TNO.CSS.Config;
-using TNO.Keycloak;
+using Microsoft.AspNetCore.Authorization;
 
 namespace TNO.API.Areas.Editor.Controllers;
 
@@ -19,7 +19,8 @@ namespace TNO.API.Areas.Editor.Controllers;
 /// LookupController class, provides Lookup endpoints for the api.
 /// The purpose is to reduce the number of AJAX requests to fetch separate lookup values.
 /// </summary>
-[ClientRoleAuthorize(ClientRole.Editor, ClientRole.Administrator)]
+// [ClientRoleAuthorize(ClientRole.Editor, ClientRole.Administrator)]
+[Authorize]
 [ApiController]
 [Area("editor")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Kafka/Controllers/ProducerController.cs
+++ b/api/net/Areas/Kafka/Controllers/ProducerController.cs
@@ -1,19 +1,20 @@
 using System.Net;
 using System.Net.Mime;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Kafka.Models;
 using TNO.API.Models;
 using TNO.Kafka;
 using TNO.Kafka.Models;
-using TNO.Keycloak;
 
 namespace TNO.API.Areas.Admin.Controllers;
 
 /// <summary>
 /// ProducerController class, provides Kafka producer endpoints for the api.
 /// </summary>
-[ClientRoleAuthorize(ClientRole.Administrator)]
+// [ClientRoleAuthorize(ClientRole.Administrator)]
+[Authorize]
 [ApiController]
 [Area("kafka")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Services/Controllers/ConnectionController.cs
+++ b/api/net/Areas/Services/Controllers/ConnectionController.cs
@@ -1,20 +1,21 @@
 using System.Net;
 using System.Net.Mime;
 using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Services.Models.Ingest;
 using TNO.API.Models;
 using TNO.DAL.Services;
-using TNO.Keycloak;
 
 namespace TNO.API.Areas.Services.Controllers;
 
 /// <summary>
 /// ConnectionController class, provides Connection endpoints for the api.
 /// </summary>
-[ClientRoleAuthorize(ClientRole.Administrator)]
+// [ClientRoleAuthorize(ClientRole.Administrator)]
+[Authorize]
 [ApiController]
 [Area("services")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Services/Controllers/ContentController.cs
+++ b/api/net/Areas/Services/Controllers/ContentController.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Mime;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Services.Models.Content;
@@ -7,14 +8,14 @@ using TNO.API.Models;
 using TNO.DAL.Models;
 using TNO.DAL.Services;
 using TNO.Entities;
-using TNO.Keycloak;
 
 namespace TNO.API.Areas.Services.Controllers;
 
 /// <summary>
 /// ContentController class, provides Content endpoints for the api.
 /// </summary>
-[ClientRoleAuthorize(ClientRole.Administrator)]
+// [ClientRoleAuthorize(ClientRole.Administrator)]
+[Authorize]
 [ApiController]
 [Area("services")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Services/Controllers/ContentReferenceController.cs
+++ b/api/net/Areas/Services/Controllers/ContentReferenceController.cs
@@ -1,18 +1,19 @@
 using System.Net;
 using System.Net.Mime;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Services.Models.ContentReference;
 using TNO.API.Models;
 using TNO.DAL.Services;
-using TNO.Keycloak;
 
 namespace TNO.API.Areas.Services.Controllers;
 
 /// <summary>
 /// ContentReferenceController class, provides ContentReference endpoints for the api.
 /// </summary>
-[ClientRoleAuthorize(ClientRole.Administrator)]
+// [ClientRoleAuthorize(ClientRole.Administrator)]
+[Authorize]
 [ApiController]
 [Area("services")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Services/Controllers/DataLocationController.cs
+++ b/api/net/Areas/Services/Controllers/DataLocationController.cs
@@ -1,20 +1,21 @@
 using System.Net;
 using System.Net.Mime;
 using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Services.Models.DataLocation;
 using TNO.API.Models;
 using TNO.DAL.Services;
-using TNO.Keycloak;
 
 namespace TNO.API.Areas.Services.Controllers;
 
 /// <summary>
 /// DataLocationController class, provides DataLocation endpoints for the api.
 /// </summary>
-[ClientRoleAuthorize(ClientRole.Administrator)]
+// [ClientRoleAuthorize(ClientRole.Administrator)]
+[Authorize]
 [ApiController]
 [Area("services")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Services/Controllers/IngestController.cs
+++ b/api/net/Areas/Services/Controllers/IngestController.cs
@@ -1,20 +1,21 @@
 using System.Net;
 using System.Net.Mime;
 using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Services.Models.Ingest;
 using TNO.API.Models;
 using TNO.DAL.Services;
-using TNO.Keycloak;
 
 namespace TNO.API.Areas.Services.Controllers;
 
 /// <summary>
 /// IngestController class, provides Ingest endpoints for the api.
 /// </summary>
-[ClientRoleAuthorize(ClientRole.Administrator)]
+// [ClientRoleAuthorize(ClientRole.Administrator)]
+[Authorize]
 [ApiController]
 [Area("services")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Services/Controllers/SourceController.cs
+++ b/api/net/Areas/Services/Controllers/SourceController.cs
@@ -1,18 +1,19 @@
 using System.Net;
 using System.Net.Mime;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Services.Models.Ingest;
 using TNO.API.Models;
 using TNO.DAL.Services;
-using TNO.Keycloak;
 
 namespace TNO.API.Areas.Services.Controllers;
 
 /// <summary>
 /// SourceController class, provides Source endpoints for the api.
 /// </summary>
-[ClientRoleAuthorize(ClientRole.Administrator)]
+// [ClientRoleAuthorize(ClientRole.Administrator)]
+[Authorize]
 [ApiController]
 [Area("services")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Services/Controllers/WorkOrderController.cs
+++ b/api/net/Areas/Services/Controllers/WorkOrderController.cs
@@ -1,19 +1,20 @@
 using System.Net;
 using System.Net.Mime;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Services.Models.WorkOrder;
 using TNO.API.Models;
 using TNO.DAL.Services;
-using TNO.Keycloak;
 
 namespace TNO.API.Areas.Services.Controllers;
 
 /// <summary>
 /// WorkOrderController class, provides WorkOrder endpoints for the api.
 /// </summary>
-[ClientRoleAuthorize(ClientRole.Administrator)]
+// [ClientRoleAuthorize(ClientRole.Administrator)]
+[Authorize]
 [ApiController]
 [Area("services")]
 [ApiVersion("1.0")]


### PR DESCRIPTION
This is a temporary "fix" to get everything working with the Keycloak Gold realm integration.

Regrettably Keycloak Gold realm does not provide a way to grant roles to the service account.  All of our services use this account to communicate with our API.  Because they have no roles, they are not authorized to use our API.  

I have removed most of the security related to authorization in the API to allow everything to keep working for now.