### PR TITLE
TNO-792 Fix Content service

### DIFF
--- a/app/editor/src/features/content/form/WorkOrderStatus.tsx
+++ b/app/editor/src/features/content/form/WorkOrderStatus.tsx
@@ -1,4 +1,4 @@
-import { IWorkOrderModel, WorkOrderStatusName, WorkOrderTypeName } from 'hooks';
+import { IWorkOrderModel, useTooltips, WorkOrderStatusName, WorkOrderTypeName } from 'hooks';
 import { FaCheckCircle, FaExclamationCircle, FaTimesCircle } from 'react-icons/fa';
 import { Spinner, SpinnerVariant } from 'tno-core';
 
@@ -18,17 +18,35 @@ export interface ITranscriptionStatusProps {
  */
 export const WorkOrderStatus: React.FC<ITranscriptionStatusProps> = ({ workOrders, type }) => {
   const workOrder = findWorkOrder(workOrders, type);
+  useTooltips();
 
   if (!workOrder) return <></>;
 
   switch (workOrder?.status) {
     case WorkOrderStatusName.Cancelled:
-      return <FaTimesCircle className="spinner" />;
+      return (
+        <FaTimesCircle className="spinner" data-for="main-tooltip" data-tip={workOrder.status} />
+      );
     case WorkOrderStatusName.Completed:
-      return <FaCheckCircle className="spinner" />;
+      return (
+        <FaCheckCircle className="spinner" data-for="main-tooltip" data-tip={workOrder.status} />
+      );
     case WorkOrderStatusName.Failed:
-      return <FaExclamationCircle className="spinner" />;
+      return (
+        <FaExclamationCircle
+          className="spinner"
+          data-for="main-tooltip"
+          data-tip={workOrder.status}
+        />
+      );
     default:
-      return <Spinner variant={SpinnerVariant.light} size="0.5em" />;
+      return (
+        <Spinner
+          variant={SpinnerVariant.light}
+          size="0.5em"
+          data-for="main-tooltip"
+          data-tip={workOrder.status}
+        />
+      );
   }
 };

--- a/libs/net/kafka/KafkaListener`.cs
+++ b/libs/net/kafka/KafkaListener`.cs
@@ -304,6 +304,7 @@ public class KafkaListener<TKey, TValue> : IKafkaListener<TKey, TValue>, IDispos
         if (_open)
         {
             _logger.LogInformation("Consumer is stopping");
+            this.Topics = Array.Empty<string>();
             this.IsConsuming = false;
             this.IsPaused = false;
             this.Consumer?.Close();

--- a/services/net/content/ContentManager.cs
+++ b/services/net/content/ContentManager.cs
@@ -122,7 +122,7 @@ public class ContentManager : ServiceManager<ContentOptions>
                         this.Listener.Subscribe(topics);
                         ConsumeMessages();
                     }
-                    else if (topics.Length == 0)
+                    else
                     {
                         this.Listener.Stop();
                     }

--- a/tools/scripts/gen-env-files.sh
+++ b/tools/scripts/gen-env-files.sh
@@ -553,10 +553,12 @@ Auth__Keycloak__Audience=tno-service-account
 Auth__Keycloak__Secret={YOU WILL NEED TO GET THIS FROM KEYCLOAK}
 Auth__OIDC__Token=/realms/tno/protocol/openid-connect/token
 
-Service__ApiUrl=http://host.docker.internal:$portApi/api
-Service__TranscriptionTopic=transcription
+Kafka__Admin__BootstrapServers=host.docker.internal:$portKafkaBorkerAdvertisedExternal
+Kafka__Producer__BootstrapServers=host.docker.internal:$portKafkaBorkerAdvertisedExternal
+Kafka__Consumer__BootstrapServers=host.docker.internal:$portKafkaBorkerAdvertisedExternal
 
-Kafka__BootstrapServers=host.docker.internal:$portKafkaBorkerAdvertisedExternal" >> ./services/net/content/.env
+Service__ApiUrl=http://host.docker.internal:$portApi/api
+Service__TranscriptionTopic=transcription" >> ./services/net/content/.env
     echo "./services/net/content/.env created"
 fi
 


### PR DESCRIPTION
The content service was having issues restarting after going to sleep.  

The reason the content service fails regrettably is due to a known challenge with deployments.  We still need a way to tell all our services to go to sleep during a deployment of the API.