### PR TITLE
TNO-815 Fix keycloak gold

### DIFF
--- a/api/net/Controllers/AuthController.cs
+++ b/api/net/Controllers/AuthController.cs
@@ -54,7 +54,7 @@ public class AuthController : ControllerBase
     [HttpPost("userinfo")]
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType(typeof(PrincipalModel), 200)]
-    [SwaggerOperation(Tags = new[] { "health" })]
+    [SwaggerOperation(Tags = new[] { "Auth" })]
     public async Task<IActionResult> UserInfoAsync()
     {
         var user = await _cssHelper.ActivateAsync(this.User);
@@ -72,7 +72,7 @@ public class AuthController : ControllerBase
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType(typeof(RegisterModel), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
-    [SwaggerOperation(Tags = new[] { "User" })]
+    [SwaggerOperation(Tags = new[] { "Auth" })]
     public async Task<IActionResult> RequestCodeAsync(RegisterModel model)
     {
         // Get the account with the preapproved email address.
@@ -120,7 +120,7 @@ public class AuthController : ControllerBase
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType(typeof(UserModel), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
-    [SwaggerOperation(Tags = new[] { "User" })]
+    [SwaggerOperation(Tags = new[] { "Auth" })]
     public IActionResult RequestApproval(UserModel model)
     {
         // Only allow a user to update their own account.


### PR DESCRIPTION
A first time user login will now perform the following steps to activate their account.

1) Check if a user with the same key exists (should only occur if they have already been activated)
2) NEW - Check if a user with the same username exists in the database
3) Check if a user with the same email exists in the database

This is to solve an issue where the preapproved user email doesn't match the username.  When the user logs in the first time, it attempts to create a new account, but the username already exists.