### PR TITLE
Added tooltips to wysiwyg editor toolbar

### DIFF
--- a/app/editor/src/components/form/wysiwyg/CustomToolbar.tsx
+++ b/app/editor/src/components/form/wysiwyg/CustomToolbar.tsx
@@ -19,37 +19,37 @@ export const CustomToolbar: React.FC<ICustomToolbarProps> = ({
 }) => (
   <div ref={innerRef} className="toolbar">
     <span className="ql-formats">
-      <select className="ql-header" />
-      <button className="ql-bold" />
-      <button className="ql-italic" />
-      <button className="ql-underline" />
-      <button className="ql-strike" />
+      <select className="ql-header" title="Format Type" />
+      <button className="ql-bold" title="Bold Text" />
+      <button className="ql-italic" title="Italic Text" />
+      <button className="ql-underline" title="Underline Text" />
+      <button className="ql-strike" title="Strikethrough Text" />
     </span>
     <span className="ql-formats">
-      <select className="ql-align" />
-      <select className="ql-color" />
+      <select className="ql-align" title="Alignment" />
+      <select className="ql-color" title="Text colour" />
     </span>
     <span className="ql-formats">
-      <button className="ql-list" value="ordered" />
-      <button className="ql-list" value="bullet" />
-      <button className="ql-indent" value="-1" />
-      <button className="ql-indent" value="+1" />
+      <button className="ql-list" value="ordered" title="Numbered List" />
+      <button className="ql-list" value="bullet" title="Bulleted list" />
+      <button className="ql-indent" value="-1" title="Outdent" />
+      <button className="ql-indent" value="+1" title="Indent" />
     </span>
     <span className="ql-formats">
-      <button type="button" onClick={onClickRaw}>
+      <button type="button" onClick={onClickRaw} title="Show code">
         <FaCode className="custom-icon" />
       </button>
-      <button type="button" onClick={onClickRemoveFormat}>
+      <button type="button" onClick={onClickRemoveFormat} title="Remove formatting">
         <FaRemoveFormat className="custom-icon" />
       </button>
-      <button type="button" onClick={onClickFormatRaw}>
+      <button type="button" onClick={onClickFormatRaw} title="Format raw html">
         <FaPaintBrush className="custom-icon" />
       </button>
-      <button className="ql-link"></button>
-      <button className="ql-image"></button>
+      <button className="ql-link" title="Link"></button>
+      <button className="ql-image" title="Insert image"></button>
     </span>
     <span className="ql-formats">
-      <button type="button" onClick={onClickExpand}>
+      <button type="button" onClick={onClickExpand} title="Popout editor">
         <FaExpandAlt className="custom-icon" />
       </button>
     </span>


### PR DESCRIPTION
I initially wanted to enable react-tooltip text on the buttons in the toolbar, but the buttons use html &lt;button&gt; tags rather than the React &lt;Button&gt; component, so the functionality is not available.

The toolbar is implemented using a React Quill CustomToolbar using the `snow` theme. This theme does not support tooltips out of the box and the documentation indicates that you have to create a custom theme to add tooltips. I used the html `title` attribute on each of the toolbar buttons to achieve the desired result. It may have been better to implement these attributes in the css, but the css classes are part of the Quill component in node_modules and the use of themes is the preferred method of overriding them. As I wanted to avoid the complexity of introducing a new theme I hope this solution will suffice.