### PR TITLE
TNO-908: Default to Source not Headline

### DIFF
--- a/app/editor/src/store/slices/content/contentSlice.ts
+++ b/app/editor/src/store/slices/content/contentSlice.ts
@@ -27,7 +27,7 @@ export const initialContentState: IContentState = {
     sort: [],
   },
   filterAdvanced: {
-    fieldType: fieldTypes[0].value,
+    fieldType: fieldTypes[3].value,
     logicalOperator: LogicalOperator.Contains,
     searchTerm: '',
   },


### PR DESCRIPTION
Advanced search now defaults to source instead of headline.

<img width="923" alt="image" src="https://user-images.githubusercontent.com/15724124/212781774-97973fe1-3500-409f-9d77-58366c9afd8f.png">
