### PR TITLE
TNO-906 Fix File Service Source, Syndication Feed Request

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -326,6 +326,42 @@
       "problemMatcher": "$msCompile"
     },
     {
+      "label": "build-filemonitor",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/services/net/filemonitor/TNO.Services.FileMonitor.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish-filemonitor",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/services/net/filemonitor/TNO.Services.FileMonitor.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch-filemonitor",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "--project",
+        "${workspaceFolder}/services/net/filemonitor/TNO.Services.FileMonitor.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
       "label": "build-image",
       "command": "dotnet",
       "type": "process",

--- a/app/editor/src/features/admin/ingests/IngestDetails.tsx
+++ b/app/editor/src/features/admin/ingests/IngestDetails.tsx
@@ -14,6 +14,7 @@ import {
   FormikSelect,
   FormikText,
   FormikTextArea,
+  OptionItem,
   Row,
 } from 'tno-core';
 import { getSortableOptions } from 'utils';
@@ -22,6 +23,10 @@ import * as styled from './styled';
 
 interface IIngestDetailsProps {}
 
+/**
+ * A component with ingest detail form.
+ * @returns Component provides ingest detail form.
+ */
 export const IngestDetails: React.FC<IIngestDetailsProps> = () => {
   const { values, setFieldValue, setErrors, errors } = useFormikContext<IIngestModel>();
   const [lookups] = useLookup();
@@ -31,7 +36,11 @@ export const IngestDetails: React.FC<IIngestDetailsProps> = () => {
   const [loading, setLoading] = React.useState(true);
   const dataLocationOptions = getSortableOptions(dataLocations);
 
-  const sources = getSortableOptions(lookups.sources);
+  const sources = getSortableOptions(
+    lookups.sources,
+    [],
+    (i) => new OptionItem(`(${i.code}) ${i.name}`, i.id),
+  );
   const products = getSortableOptions(lookups.products);
 
   React.useEffect(() => {

--- a/libs/net/services/Managers/IngestManager`.cs
+++ b/libs/net/services/Managers/IngestManager`.cs
@@ -72,7 +72,7 @@ public abstract class IngestManager<TIngestServiceActionManager, TOption> : Serv
             else if (!this.Ingests.Any(ds => ds.IsEnabled))
             {
                 // If there are no ingests, then we need to keep the service alive.
-                this.Logger.LogWarning("There are no configured ingests for this data location");
+                this.Logger.LogWarning("There are no configured ingests for this data location '{Location}'", this.Options.DataLocation);
             }
             else
             {

--- a/services/net/filemonitor/FileMonitorIngestActionManager.cs
+++ b/services/net/filemonitor/FileMonitorIngestActionManager.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Options;
-using System.Text.Json;
 using TNO.API.Areas.Services.Models.Ingest;
 using TNO.Models.Extensions;
 using TNO.Services.Actions.Managers;

--- a/services/net/filemonitor/FilemonitorAction.cs
+++ b/services/net/filemonitor/FilemonitorAction.cs
@@ -234,7 +234,7 @@ public class FileMonitorAction : IngestAction<FileMonitorOptions>
         try
         {
             // Fetch content reference.
-            var reference = await this.FindContentReferenceAsync(manager.Ingest.Source?.Code, content.Uid);
+            var reference = await this.FindContentReferenceAsync(content.Source, content.Uid);
             if (reference == null)
             {
                 reference = await AddContentReferenceAsync(manager.Ingest, content);
@@ -273,7 +273,7 @@ public class FileMonitorAction : IngestAction<FileMonitorOptions>
         // Add a content reference record.
         var model = new ContentReferenceModel()
         {
-            Source = ingest.Source?.Code ?? throw new InvalidOperationException($"Ingest '{ingest.Name}' is missing source code."),
+            Source = content.Source,
             Uid = content.Uid,
             Topic = ingest.Topic,
             Status = (int)WorkflowStatus.InProgress,

--- a/services/net/filemonitor/FilemonitorManager.cs
+++ b/services/net/filemonitor/FilemonitorManager.cs
@@ -2,8 +2,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using TNO.Services.Managers;
 using TNO.Services.FileMonitor.Config;
-using TNO.API.Areas.Services.Models.Ingest;
-using TNO.Models.Extensions;
 
 namespace TNO.Services.FileMonitor;
 

--- a/services/net/syndication/SyndicationAction.cs
+++ b/services/net/syndication/SyndicationAction.cs
@@ -320,6 +320,13 @@ public class SyndicationAction : IngestAction<SyndicationOptions>
         var response = await _httpClient.GetAsync(url);
         var data = await response.Content.ReadAsStringAsync();
 
+        if (!response.IsSuccessStatusCode)
+        {
+            var ex = new HttpRequestException(response.ReasonPhrase, null, response.StatusCode);
+            this.Logger.LogError(ex, "Failed to fetch syndication feed for ingest '{name}'", manager.Ingest.Name);
+            throw ex;
+        }
+
         try
         {
             // Reformat dates because timezone abbreviations don't work...


### PR DESCRIPTION
The File Service was not using the correct source code when add/updating the content reference.  This was causing significant error logs.

Also fixed configuration so that we can run the File Service locally.

Fixed Syndication Service to correctly handle failed requests for feeds.