### PR TITLE
TNO-888, 887: Date range trigger and clear

### DIFF
--- a/app/editor/src/components/form/toning/styled/ToningGroup.tsx
+++ b/app/editor/src/components/form/toning/styled/ToningGroup.tsx
@@ -17,6 +17,9 @@ export const ToningGroup = styled(Col)`
     min-width: 2rem;
     min-height: 2rem;
     align-self: center;
+    :hover {
+      cursor: pointer;
+    }
   }
 
   .blank {

--- a/app/editor/src/features/content/tool-bar/ContentToolBar.tsx
+++ b/app/editor/src/features/content/tool-bar/ContentToolBar.tsx
@@ -45,6 +45,7 @@ export const ContentToolBar: React.FC<IContentToolBarProps> = ({ onSearch }) => 
       <FilterContentSection
         onChange={onFilterChange}
         onAdvancedFilterChange={onAdvancedFilterChange}
+        onSearch={onSearch}
       />
       {/* third section */}
       <ShowOnlySection onChange={onFilterChange} />

--- a/app/editor/src/features/content/tool-bar/sections/filter/DateRangeSection.tsx
+++ b/app/editor/src/features/content/tool-bar/sections/filter/DateRangeSection.tsx
@@ -1,0 +1,68 @@
+import {
+  IContentListAdvancedFilter,
+  IContentListFilter,
+} from 'features/content/list-view/interfaces';
+import React from 'react';
+import { FaCalendarAlt } from 'react-icons/fa';
+import { useContent } from 'store/hooks';
+import { SelectDate } from 'tno-core';
+
+import * as styled from './styled';
+
+export interface IDateRangeSectionProps {
+  onAdvancedFilterChange: (filter: IContentListAdvancedFilter) => void;
+  onSearch: (filter: IContentListFilter & IContentListAdvancedFilter) => void;
+}
+export const DateRangeSection: React.FC<IDateRangeSectionProps> = ({
+  onAdvancedFilterChange,
+  onSearch,
+}) => {
+  const [{ filter, filterAdvanced }] = useContent();
+  /** retrigger fetch on change of date or clear*/
+  React.useEffect(() => {
+    onSearch({ ...filter, pageIndex: 0, ...filterAdvanced });
+  }, [filter, filterAdvanced, onSearch]);
+
+  return (
+    <styled.DateRangeSection>
+      <FaCalendarAlt className="action-icon calendar" />
+      <SelectDate
+        name="startDate"
+        placeholderText="mm/dd/yyyy"
+        selected={!!filterAdvanced.startDate ? new Date(filterAdvanced.startDate) : undefined}
+        width="8em"
+        onChange={(date) =>
+          onAdvancedFilterChange({
+            ...filterAdvanced,
+            startDate: !!date ? date.toString() : undefined,
+          })
+        }
+      />
+      <SelectDate
+        name="endDate"
+        placeholderText="mm/dd/yyyy"
+        selected={!!filterAdvanced.endDate ? new Date(filterAdvanced.endDate) : undefined}
+        width="8em"
+        onChange={(date) => {
+          date?.setHours(23, 59, 59);
+          onAdvancedFilterChange({
+            ...filterAdvanced,
+            endDate: !!date ? date.toString() : undefined,
+          });
+        }}
+      />
+      <span
+        className="clear"
+        onClick={() => {
+          onAdvancedFilterChange({
+            ...filterAdvanced,
+            startDate: undefined,
+            endDate: undefined,
+          });
+        }}
+      >
+        X
+      </span>
+    </styled.DateRangeSection>
+  );
+};

--- a/app/editor/src/features/content/tool-bar/sections/filter/FilterContentSection.tsx
+++ b/app/editor/src/features/content/tool-bar/sections/filter/FilterContentSection.tsx
@@ -6,37 +6,33 @@ import {
 } from 'features/content/list-view/interfaces';
 import { useLookupOptions } from 'hooks';
 import React from 'react';
-import { FaCalendarAlt, FaClock, FaFilter, FaIcons, FaUsers } from 'react-icons/fa';
+import { FaClock, FaFilter, FaIcons, FaUsers } from 'react-icons/fa';
 import { useApp, useContent } from 'store/hooks';
-import {
-  Col,
-  FieldSize,
-  fromQueryString,
-  IOptionItem,
-  OptionItem,
-  Row,
-  Select,
-  SelectDate,
-} from 'tno-core';
+import { Col, FieldSize, fromQueryString, IOptionItem, OptionItem, Row, Select } from 'tno-core';
 import { getUserOptions } from 'utils';
 
+import { DateRangeSection } from '.';
 import { InputOption } from './InputOption';
 
 export interface IFilterContentSectionProps {
   onChange: (filter: IContentListFilter) => void;
   onAdvancedFilterChange: (filter: IContentListAdvancedFilter) => void;
+  onSearch: (filter: IContentListFilter & IContentListAdvancedFilter) => void;
 }
 
 /**
  * Component containing the filter section of the content tool bar
  * @param onChange determine what happens when filter changes are applied
+ * @param onAdvancedFilterChange determine what happens when advanced filter changes are applied
+ * @param onSearch determine what happens when the search button is clicked
  * @returns The filter content section
  */
 export const FilterContentSection: React.FC<IFilterContentSectionProps> = ({
   onChange,
   onAdvancedFilterChange,
+  onSearch,
 }) => {
-  const [{ filter, filterAdvanced }] = useContent();
+  const [{ filter }] = useContent();
   const [{ productOptions: pOptions, users }] = useLookupOptions();
   const [productOptions, setProductOptions] = React.useState<IOptionItem[]>([]);
   const [userOptions, setUserOptions] = React.useState<IOptionItem[]>([]);
@@ -119,37 +115,7 @@ export const FilterContentSection: React.FC<IFilterContentSectionProps> = ({
             </Row>
           </Col>
           <Col>
-            <Row className="date-range">
-              <FaCalendarAlt className="action-icon" />
-
-              <SelectDate
-                name="startDate"
-                placeholderText="mm/dd/yyyy"
-                selected={
-                  !!filterAdvanced.startDate ? new Date(filterAdvanced.startDate) : undefined
-                }
-                width="8em"
-                onChange={(date) =>
-                  onAdvancedFilterChange({
-                    ...filterAdvanced,
-                    startDate: !!date ? date.toString() : undefined,
-                  })
-                }
-              />
-              <SelectDate
-                name="endDate"
-                placeholderText="mm/dd/yyyy"
-                selected={!!filterAdvanced.endDate ? new Date(filterAdvanced.endDate) : undefined}
-                width="8em"
-                onChange={(date) => {
-                  date?.setHours(23, 59, 59);
-                  onAdvancedFilterChange({
-                    ...filterAdvanced,
-                    endDate: !!date ? date.toString() : undefined,
-                  });
-                }}
-              />
-            </Row>
+            <DateRangeSection onAdvancedFilterChange={onAdvancedFilterChange} onSearch={onSearch} />
             <Row>
               <FaIcons className="icon-indicator" height="2em" width="2em" />
               <Select

--- a/app/editor/src/features/content/tool-bar/sections/filter/index.ts
+++ b/app/editor/src/features/content/tool-bar/sections/filter/index.ts
@@ -1,5 +1,6 @@
 export * from './AdvancedSearchSection';
 export * from './CreateNewSection';
+export * from './DateRangeSection';
 export * from './FilterContentSection';
 export * from './InputOption';
 export * from './ShowOnlySection';

--- a/app/editor/src/features/content/tool-bar/sections/filter/styled/DateRangeSection.tsx
+++ b/app/editor/src/features/content/tool-bar/sections/filter/styled/DateRangeSection.tsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+import { Row } from 'tno-core';
+
+export const DateRangeSection = styled(Row)`
+  .clear {
+    :hover {
+      cursor: pointer;
+      color: ${(props) => props.theme.css.dangerColor};
+    }
+    align-self: center;
+    font-size: 1.25em;
+    padding-bottom: 0.25em;
+    padding-left: 0.25em;
+    color: ${(props) => props.theme.css.lightVariantColor};
+  }
+  .calendar {
+    color: ${(props) => props.theme.css.primaryColor};
+    height: 1.25em;
+    width: 1.25em;
+  }
+`;

--- a/app/editor/src/features/content/tool-bar/sections/filter/styled/index.ts
+++ b/app/editor/src/features/content/tool-bar/sections/filter/styled/index.ts
@@ -1,0 +1,1 @@
+export * from './DateRangeSection';


### PR DESCRIPTION
- moved date range to its own component for easier styling
- an x button now appears to the right of the date range component to allow the user to clear their date selection
- filter is now applied whenever date is changed or cleared

TNO-888 requests for the date to be triggered on hitting 'enter'; however, I believe the above fits in with the content tool bar better as it behaves the same as the section it is contained in. Let me know if we want it changed.

See behaviour in GIF below:
![date-range](https://user-images.githubusercontent.com/15724124/213305640-95505814-fde7-4a1e-a5fc-4ffa2338f34e.gif)

