### PR TITLE
TNO-906 Improve ingest admin

### DIFF
--- a/api/net/Areas/Admin/Controllers/ContentReferenceController.cs
+++ b/api/net/Areas/Admin/Controllers/ContentReferenceController.cs
@@ -27,17 +27,17 @@ namespace TNO.API.Areas.Admin.Controllers;
 public class ContentReferenceController : ControllerBase
 {
     #region Variables
-    private readonly IContentReferenceService _service;
+    private readonly IContentReferenceService _contentReferenceService;
     #endregion
 
     #region Constructors
     /// <summary>
     /// Creates a new instance of a ContentReferenceController object, initializes with specified parameters.
     /// </summary>
-    /// <param name="service"></param>
-    public ContentReferenceController(IContentReferenceService service)
+    /// <param name="contentReferenceService"></param>
+    public ContentReferenceController(IContentReferenceService contentReferenceService)
     {
-        _service = service;
+        _contentReferenceService = contentReferenceService;
     }
     #endregion
 
@@ -54,7 +54,7 @@ public class ContentReferenceController : ControllerBase
     {
         var uri = new Uri(this.Request.GetDisplayUrl());
         var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
-        var result = _service.Find(new DAL.Models.ContentReferenceFilter(query));
+        var result = _contentReferenceService.Find(new DAL.Models.ContentReferenceFilter(query));
         var page = new Paged<ContentReferenceModel>(result.Items.Select(cr => new ContentReferenceModel(cr)), result.Page, result.Quantity, result.Total);
         return new JsonResult(page);
     }
@@ -72,7 +72,7 @@ public class ContentReferenceController : ControllerBase
     [SwaggerOperation(Tags = new[] { "ContentReference" })]
     public IActionResult FindById(string source, [FromQuery] string uid)
     {
-        var result = _service.FindById(new[] { source, uid });
+        var result = _contentReferenceService.FindById(new[] { source, uid });
 
         if (result == null) return new NoContentResult();
         return new JsonResult(new ContentReferenceModel(result));
@@ -90,7 +90,7 @@ public class ContentReferenceController : ControllerBase
     [SwaggerOperation(Tags = new[] { "ContentReference" })]
     public IActionResult Update(ContentReferenceModel model)
     {
-        var result = _service.UpdateAndSave(model.ToEntity());
+        var result = _contentReferenceService.UpdateAndSave(model.ToEntity());
         return new JsonResult(new ContentReferenceModel(result));
     }
 
@@ -106,8 +106,23 @@ public class ContentReferenceController : ControllerBase
     [SwaggerOperation(Tags = new[] { "ContentReference" })]
     public IActionResult Delete(ContentReferenceModel model)
     {
-        _service.DeleteAndSave(model.ToEntity());
+        _contentReferenceService.DeleteAndSave(model.ToEntity());
         return new JsonResult(model);
+    }
+
+    /// <summary>
+    /// Find all the content ids for the specified 'uid'.
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <returns></returns>
+    [HttpGet("content/ids")]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(typeof(long[]), (int)HttpStatusCode.OK)]
+    [SwaggerOperation(Tags = new[] { "ContentReference" })]
+    public IActionResult FindContentId([FromQuery] string uid)
+    {
+        var result = _contentReferenceService.FindContentIds(uid);
+        return new JsonResult(result);
     }
     #endregion
 }

--- a/app/editor/src/features/admin/ingests/constants/contentReferenceColumns.tsx
+++ b/app/editor/src/features/admin/ingests/constants/contentReferenceColumns.tsx
@@ -8,22 +8,28 @@ export const contentReferenceColumns: (Column<IContentReferenceModel> &
   {
     Header: 'UID',
     accessor: 'uid',
+    width: 5,
+  },
+  {
+    Header: 'Source',
+    accessor: 'source',
+    width: 1,
   },
   {
     Header: 'Published On',
     accessor: 'publishedOn',
     Cell: (cell) => <CellDate value={cell.value} />,
-    width: 25,
+    width: 1,
   },
   {
     Header: 'Updated On',
     accessor: 'sourceUpdatedOn',
     Cell: (cell) => <CellDate value={cell.value} />,
-    width: 25,
+    width: 1,
   },
   {
     Header: 'Status',
     accessor: (row) => row.status,
-    width: 25,
+    width: 1,
   },
 ];

--- a/app/editor/src/features/admin/ingests/constants/defaultContentReferenceFilter.ts
+++ b/app/editor/src/features/admin/ingests/constants/defaultContentReferenceFilter.ts
@@ -4,6 +4,7 @@ export const defaultContentReferenceFilter: IContentReferenceListFilter = {
   pageIndex: 0,
   pageSize: 100,
   source: '',
+  sources: [],
   uid: '',
   topic: '',
   status: '',

--- a/app/editor/src/features/admin/ingests/interfaces/IContentReferenceListFilter.ts
+++ b/app/editor/src/features/admin/ingests/interfaces/IContentReferenceListFilter.ts
@@ -6,6 +6,7 @@ export interface IContentReferenceListFilter {
   pageIndex: number;
   pageSize: number;
   source?: string;
+  sources: string[];
   uid: string;
   topic: string;
   status: WorkflowStatusName | '';

--- a/app/editor/src/hooks/api-editor/admin/useApiAdminContentReferences.ts
+++ b/app/editor/src/hooks/api-editor/admin/useApiAdminContentReferences.ts
@@ -45,5 +45,10 @@ export const useApiAdminContentReferences = (
         },
       );
     },
+    findContentIds: (uid: string) => {
+      return api.get<number[], AxiosResponse<number[]>, any>(
+        `/admin/content/references/content/ids?uid=${uid}`,
+      );
+    },
   }).current;
 };

--- a/app/editor/src/hooks/api-editor/interfaces/IContentReferenceFilter.ts
+++ b/app/editor/src/hooks/api-editor/interfaces/IContentReferenceFilter.ts
@@ -3,6 +3,7 @@ import { IPageFilter } from '.';
 
 export interface IContentReferenceFilter extends IPageFilter {
   source?: string;
+  sources?: string[];
   uid?: string;
   topic?: string;
   status?: WorkflowStatusName;

--- a/app/editor/src/store/hooks/admin/useContentReferences.ts
+++ b/app/editor/src/store/hooks/admin/useContentReferences.ts
@@ -23,6 +23,12 @@ interface IContentReferenceController {
    * Make an AJAX DELETE request to delete the content reference.
    */
   deleteContentReference: (model: IContentReferenceModel) => Promise<IContentReferenceModel>;
+  /**
+   * Find all content ids for specified 'uid'.
+   * @param uid
+   * @returns
+   */
+  findContentIds: (uid: string) => Promise<number[]>;
 }
 
 /**
@@ -58,6 +64,12 @@ export const useContentReferences = (): [IAdminState, IContentReferenceControlle
       deleteContentReference: async (model: IContentReferenceModel) => {
         const response = await dispatch<IContentReferenceModel>('delete-data-source', () =>
           api.deleteContentReference(model),
+        );
+        return response.data;
+      },
+      findContentIds: async (uid: string) => {
+        const response = await dispatch<number[]>('find-content-references-content-ids', () =>
+          api.findContentIds(uid),
         );
         return response.data;
       },

--- a/libs/net/dal/Models/ContentReferenceFilter.cs
+++ b/libs/net/dal/Models/ContentReferenceFilter.cs
@@ -11,6 +11,7 @@ public class ContentReferenceFilter : PageFilter
     public int? Offset { get; set; }
     public int? Partition { get; set; }
     public string? Source { get; set; }
+    public string[]? Sources { get; set; }
     public string? Uid { get; set; }
     public string? Topic { get; set; }
     public DateTime? PublishedOn { get; set; }
@@ -32,6 +33,7 @@ public class ContentReferenceFilter : PageFilter
         this.Status = filter.GetEnumNullValue<WorkflowStatus>(nameof(this.Status));
 
         this.Source = filter.GetStringValue(nameof(this.Source));
+        this.Sources = filter.GetStringArrayValue(nameof(this.Sources));
         this.Uid = filter.GetStringValue(nameof(this.Uid));
         this.Topic = filter.GetStringValue(nameof(this.Topic));
 

--- a/libs/net/dal/Services/ContentReferenceService.cs
+++ b/libs/net/dal/Services/ContentReferenceService.cs
@@ -20,7 +20,11 @@ public class ContentReferenceService : BaseService<ContentReference, string[]>, 
     #endregion
 
     #region Methods
-
+    /// <summary>
+    /// Make a request to the database fro the specified filter.
+    /// </summary>
+    /// <param name="filter"></param>
+    /// <returns></returns>
     public IPaged<ContentReference> Find(ContentReferenceFilter filter)
     {
         var query = this.Context.ContentReferences
@@ -32,6 +36,8 @@ public class ContentReferenceService : BaseService<ContentReference, string[]>, 
 
         if (!String.IsNullOrWhiteSpace(filter.Source))
             query = query.Where(c => c.Source == filter.Source);
+        if (filter.Sources?.Any() == true)
+            query = query.Where(c => filter.Sources.Contains(c.Source));
         if (!String.IsNullOrWhiteSpace(filter.Uid))
             query = query.Where(c => EF.Functions.Like(c.Uid.ToLower(), $"%{filter.Uid.ToLower()}%"));
         if (!String.IsNullOrWhiteSpace(filter.Topic))
@@ -99,6 +105,19 @@ public class ContentReferenceService : BaseService<ContentReference, string[]>, 
         this.Context.ResetVersion(original);
         base.UpdateAndSave(original);
         return original;
+    }
+
+    /// <summary>
+    /// Find all the content ids for the specified 'uid'.
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <returns></returns>
+    public long[] FindContentIds(string uid)
+    {
+        return this.Context.Contents
+            .AsNoTracking()
+            .Where(c => c.Uid.ToLower() == uid.ToLower()).Select(c => c.Id)
+            .ToArray();
     }
     #endregion
 }

--- a/libs/net/dal/Services/Interfaces/IContentReferenceService.cs
+++ b/libs/net/dal/Services/Interfaces/IContentReferenceService.cs
@@ -8,4 +8,5 @@ namespace TNO.DAL.Services;
 public interface IContentReferenceService : IBaseService<ContentReference, string[]>
 {
     IPaged<ContentReference> Find(ContentReferenceFilter filter);
+    long[] FindContentIds(string uid);
 }

--- a/libs/net/entities/ContentReference.cs
+++ b/libs/net/entities/ContentReference.cs
@@ -57,7 +57,7 @@ public class ContentReference : AuditColumns
     public DateTime? PublishedOn { get; set; }
 
     /// <summary>
-    /// get/set - When the content was updated.
+    /// get/set - When the content was updated by the source.
     /// </summary>
     [Column("source_updated_on")]
     public DateTime? SourceUpdateOn { get; set; }


### PR DESCRIPTION
The Ingest admin page has an 'Ingesting' tab to help debug.  This tab lists related content references.  I've updated this table to include all possible `source` values for the ingest.  Previously it was only filtering on the main `source`.  The papers however ingest many different sources.'

You can also now click on the row and load the content if it exists.

![image](https://user-images.githubusercontent.com/3180256/213310742-389662dd-0cdb-4548-8e2f-2563d966350b.png)
