### PR TITLE
TNO-909: If using date range widget, the Today 24 HR 48 HR ALL panel should be greyed out

### DIFF
--- a/app/editor/src/components/toggle-group/ToggleGroup.tsx
+++ b/app/editor/src/components/toggle-group/ToggleGroup.tsx
@@ -13,17 +13,25 @@ export interface IToggleGroupProps {
   label?: string;
   options: IToggleOption[];
   defaultSelected?: string;
+  disabled?: boolean;
 }
 
 /**
  * A group of toggle buttons that can be used to perform actions
  * @param options The options to display in the toggle group, can contain a label and an onClick function
  * @param defaultSelected The default selected option
+ * @param disabled Whether the toggle group is disabled
  * @returns The ToggleGroup component
  */
-export const ToggleGroup: React.FC<IToggleGroupProps> = ({ label, options, defaultSelected }) => {
+export const ToggleGroup: React.FC<IToggleGroupProps> = ({
+  label,
+  options,
+  defaultSelected,
+  disabled,
+}) => {
   const [activeToggle, setActiveToggle] = React.useState(defaultSelected?.toLowerCase() ?? '');
   const [showDropDown, setShowDropDown] = React.useState(false);
+
   const onDropDownClick = () => {
     setShowDropDown(!showDropDown);
   };
@@ -32,7 +40,8 @@ export const ToggleGroup: React.FC<IToggleGroupProps> = ({ label, options, defau
   // ensure default selected gets reset when new content is loaded
   React.useEffect(() => {
     if (defaultSelected) setActiveToggle(defaultSelected?.toLowerCase());
-  }, [defaultSelected]);
+    if (disabled) setActiveToggle('');
+  }, [defaultSelected, disabled]);
 
   // Close dropdown when clicking outside of it
   React.useEffect(() => {
@@ -53,6 +62,7 @@ export const ToggleGroup: React.FC<IToggleGroupProps> = ({ label, options, defau
       {options?.map((option, index) => (
         <button
           key={option.label}
+          disabled={disabled}
           className={`toggle-item ${activeToggle === option.label.toLowerCase() ? 'active' : ''}`}
           type="button"
           onClick={() => {

--- a/app/editor/src/components/toggle-group/styled/ToggleGroup.tsx
+++ b/app/editor/src/components/toggle-group/styled/ToggleGroup.tsx
@@ -9,6 +9,9 @@ export const ToggleGroup = styled(Row)`
     color: ${(props) => props.theme.css.backgroundColor};
   }
   .toggle-item {
+    :disabled {
+      cursor: not-allowed;
+    }
     position: relative;
     .dd-menu {
       left: 0;

--- a/app/editor/src/features/content/tool-bar/sections/filter/DateRangeSection.tsx
+++ b/app/editor/src/features/content/tool-bar/sections/filter/DateRangeSection.tsx
@@ -11,11 +11,13 @@ import * as styled from './styled';
 
 export interface IDateRangeSectionProps {
   onAdvancedFilterChange: (filter: IContentListAdvancedFilter) => void;
+  onChange: (filter: IContentListFilter) => void;
   onSearch: (filter: IContentListFilter & IContentListAdvancedFilter) => void;
 }
 export const DateRangeSection: React.FC<IDateRangeSectionProps> = ({
   onAdvancedFilterChange,
   onSearch,
+  onChange,
 }) => {
   const [{ filter, filterAdvanced }] = useContent();
   /** retrigger fetch on change of date or clear*/
@@ -59,6 +61,7 @@ export const DateRangeSection: React.FC<IDateRangeSectionProps> = ({
             startDate: undefined,
             endDate: undefined,
           });
+          onChange({ ...filter, timeFrame: 0 });
         }}
       >
         X

--- a/app/editor/src/features/content/tool-bar/sections/filter/FilterContentSection.tsx
+++ b/app/editor/src/features/content/tool-bar/sections/filter/FilterContentSection.tsx
@@ -32,7 +32,7 @@ export const FilterContentSection: React.FC<IFilterContentSectionProps> = ({
   onAdvancedFilterChange,
   onSearch,
 }) => {
-  const [{ filter }] = useContent();
+  const [{ filter, filterAdvanced }] = useContent();
   const [{ productOptions: pOptions, users }] = useLookupOptions();
   const [productOptions, setProductOptions] = React.useState<IOptionItem[]>([]);
   const [userOptions, setUserOptions] = React.useState<IOptionItem[]>([]);
@@ -69,6 +69,13 @@ export const FilterContentSection: React.FC<IFilterContentSectionProps> = ({
   const onOtherClick = (value?: number) => {
     value && onChange({ ...filter, userId: value });
   };
+
+  /** clear time fram when start end date is selected */
+  React.useEffect(() => {
+    if ((!!filterAdvanced.startDate || !!filterAdvanced.endDate) && filter.timeFrame !== '') {
+      onChange({ ...filter, timeFrame: '' });
+    }
+  }, [filterAdvanced, filter, onChange]);
 
   return (
     <ToolBarSection

--- a/app/editor/src/features/content/tool-bar/sections/filter/FilterContentSection.tsx
+++ b/app/editor/src/features/content/tool-bar/sections/filter/FilterContentSection.tsx
@@ -79,6 +79,7 @@ export const FilterContentSection: React.FC<IFilterContentSectionProps> = ({
               <FaClock className="icon-indicator" />
               <ToggleGroup
                 defaultSelected={timeFrameSelected}
+                disabled={!!filterAdvanced.startDate || !!filterAdvanced.endDate}
                 options={[
                   {
                     label: 'TODAY',

--- a/app/editor/src/features/content/tool-bar/sections/filter/FilterContentSection.tsx
+++ b/app/editor/src/features/content/tool-bar/sections/filter/FilterContentSection.tsx
@@ -75,7 +75,7 @@ export const FilterContentSection: React.FC<IFilterContentSectionProps> = ({
     if ((!!filterAdvanced.startDate || !!filterAdvanced.endDate) && filter.timeFrame !== '') {
       onChange({ ...filter, timeFrame: '' });
     }
-  }, [filterAdvanced, filter, onChange]);
+  }, [filterAdvanced.startDate, filterAdvanced.endDate, filter, onChange]);
 
   return (
     <ToolBarSection
@@ -123,7 +123,11 @@ export const FilterContentSection: React.FC<IFilterContentSectionProps> = ({
             </Row>
           </Col>
           <Col>
-            <DateRangeSection onAdvancedFilterChange={onAdvancedFilterChange} onSearch={onSearch} />
+            <DateRangeSection
+              onChange={onChange}
+              onAdvancedFilterChange={onAdvancedFilterChange}
+              onSearch={onSearch}
+            />
             <Row>
               <FaIcons className="icon-indicator" height="2em" width="2em" />
               <Select


### PR DESCRIPTION
- also clears the timeframe filter when selected
- hovering over the options will also show a not allowed while there is a start or end date selected 
- after clearing start/end date it will default the time frame back to today (is this what we want?)

![date-range-disable](https://user-images.githubusercontent.com/15724124/213315358-1d1a7a19-6464-44e3-98fa-5f4a0893cef7.gif)
