### PR TITLE
TNO-1004: Can't clear source

### DIFF
--- a/app/editor/src/features/content/tool-bar/sections/filter/AdvancedSearchSection.tsx
+++ b/app/editor/src/features/content/tool-bar/sections/filter/AdvancedSearchSection.tsx
@@ -50,11 +50,15 @@ export const AdvancedSearchSection: React.FC<IAdvancedSearchSectionProps> = ({
                 if (e.key === 'Enter') onSearch({ ...filter, pageIndex: 0, ...filterAdvanced });
               }}
               onChange={(newValue: any) => {
-                const optionItem = sourceOptions.find((ds) => ds.value === newValue.value);
-                const newSearchTerm =
-                  optionItem?.label.substring(optionItem.label.indexOf('(') + 1).replace(')', '') ??
-                  '';
-                onChange({ ...filterAdvanced, searchTerm: newSearchTerm });
+                if (!newValue) onChange({ ...filterAdvanced, searchTerm: '' });
+                else {
+                  const optionItem = sourceOptions.find((ds) => ds.value === newValue.value);
+                  const newSearchTerm =
+                    optionItem?.label
+                      .substring(optionItem.label.indexOf('(') + 1)
+                      .replace(')', '') ?? '';
+                  onChange({ ...filterAdvanced, searchTerm: newSearchTerm });
+                }
               }}
               options={[new OptionItem('', 0) as IOptionItem].concat([...sourceOptions])}
               value={sourceOptions.find((s) => s.label === filterAdvanced.searchTerm)}


### PR DESCRIPTION
- Fix bug where the user cannot clear source on the react-select component in the content tool bar

![tno-1004](https://user-images.githubusercontent.com/15724124/213555498-1ccc0ab4-d4e5-4586-ae2d-c56596873228.gif)
