### PR TITLE
TNO-874 Fix Clip service

### DIFF
--- a/libs/net/dal/Migrations/Initial/Up/PostUp/02-Ingest.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/02-Ingest.sql
@@ -185,7 +185,7 @@ INSERT INTO public.ingest (
   , 'CPNEWS' -- topic
   , wireId -- product_id
   , '{ "url":"http://www.commandnews.com/fpweb/fp.dll/$bc-rss/htm/rss/x_searchlist.htm/_drawerid/!default_bc-rss/_profileid/rss/_iby/daj/_iby/daj/_svc/cp_pub/_k/XQkKHjnAUpumRfdr",
-      "timeZone": "Pacific Standard Time",
+      "timeZone": "Eastern Standard Time",
       "language": "en-CA",
       "fetchContent": true,
       "post": true,

--- a/services/net/clip/ClipAction.cs
+++ b/services/net/clip/ClipAction.cs
@@ -522,7 +522,7 @@ public class ClipAction : CommandAction<ClipOptions>
     private static string GetCopy(IngestModel ingest)
     {
         var value = ingest.GetConfigurationValue("copy");
-        return String.IsNullOrWhiteSpace(value) ? " -c:v copy -c:a copy" : $" {value}";
+        return String.IsNullOrWhiteSpace(value) ? "" : $" {value}";
     }
     #endregion
 }


### PR DESCRIPTION
The Clip Service was applying a default codecs copy which was resulting in invalid AV files.  I've removed the default value and now FFmpeg appears to be able to create valid `mp4` clips from a `webm` format.

Also fixed the default timezone configuration for the CP News syndication feed.