### PR TITLE
TNO-996 Fix CrunchyDB template

### DIFF
--- a/openshift/kustomize/postgres/crunchy/base/deploy.yaml
+++ b/openshift/kustomize/postgres/crunchy/base/deploy.yaml
@@ -20,7 +20,7 @@ spec:
   monitoring:
     pgmonitor:
       exporter:
-        # image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.0.4-0
+        image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-exporter:ubi8-5.0.4-0
         resources:
           requests:
             cpu: 25m
@@ -28,7 +28,7 @@ spec:
           limits:
             cpu: 50m
             memory: 250Mi
-  # image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-0
+  image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres:centos8-14.1-0
   postgresVersion: 14
   instances:
     - name: postgres
@@ -70,7 +70,7 @@ spec:
     pgbackrest:
       global:
         repo1-retention-full: "2"
-      # image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-0
+      image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbackrest:centos8-2.36-0
       repoHost:
         resources:
           requests:
@@ -112,7 +112,7 @@ spec:
       config:
         global:
           client_tls_sslmode: disable
-      # image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-3
+      image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbouncer:centos8-1.16-0
       replicas: 2
       resources:
         requests:


### PR DESCRIPTION
Due to some issue in Openshift the default images from `registry.developers.crunchydata.com` were no longer available or working.  Had to update the images in our template to `artifacts.developer.gov.bc.ca/bcgov-docker-local` and `apply` the changes.

I've updated DEV and everything appears to be stable.  I will updated TEST when our round of testing is complete.