### PR TITLE
TNO-818: Toolbar Responsiveness

### DIFF
--- a/app/editor/src/components/tool-bar/styled/ToolBarSection.tsx
+++ b/app/editor/src/components/tool-bar/styled/ToolBarSection.tsx
@@ -2,8 +2,15 @@ import styled from 'styled-components';
 import { Col } from 'tno-core';
 
 export const ToolBarSection = styled(Col)`
+@media screen and (max-width: 1847px) {
+  padding: 0.2em;
+}
+
+@media screen and (min-width: 1847px) {
   padding: 0.5em;
+}
   min-height: 7.25em;
+  z-index: 100;
   .title-container {
     font-weight: 600;
     font-size: 1.25em;

--- a/app/editor/src/features/content/form/constants/ShowOnlyValues.ts
+++ b/app/editor/src/features/content/form/constants/ShowOnlyValues.ts
@@ -1,0 +1,7 @@
+export enum ShowOnlyValues {
+  PrintContent = 'PrintContent',
+  IncludedInEod = 'EoD',
+  OnTicker = 'On Ticker',
+  Commentary = 'Commentary',
+  TopStory = 'Top Story',
+}

--- a/app/editor/src/features/content/form/constants/ShowOnlyValues.ts
+++ b/app/editor/src/features/content/form/constants/ShowOnlyValues.ts
@@ -1,7 +1,6 @@
 export enum ShowOnlyValues {
   PrintContent = 'PrintContent',
   IncludedInEod = 'EoD',
-  OnTicker = 'On Ticker',
   Commentary = 'Commentary',
   TopStory = 'Top Story',
 }

--- a/app/editor/src/features/content/form/constants/showOnlyOptions.ts
+++ b/app/editor/src/features/content/form/constants/showOnlyOptions.ts
@@ -5,7 +5,6 @@ import { ShowOnlyValues } from './ShowOnlyValues';
 export const showOnlyOptions = [
   new OptionItem('Print Content', ShowOnlyValues.PrintContent),
   new OptionItem('Included in EoD', ShowOnlyValues.IncludedInEod),
-  new OptionItem('On Ticker', ShowOnlyValues.PrintContent),
   new OptionItem('Commentary', ShowOnlyValues.Commentary),
   new OptionItem('Top Story', ShowOnlyValues.TopStory),
 ];

--- a/app/editor/src/features/content/form/constants/showOnlyOptions.ts
+++ b/app/editor/src/features/content/form/constants/showOnlyOptions.ts
@@ -1,10 +1,11 @@
-import { ContentTypeName } from 'hooks';
 import { OptionItem } from 'tno-core';
 
+import { ShowOnlyValues } from './ShowOnlyValues';
+
 export const showOnlyOptions = [
-  new OptionItem('Print Content', ContentTypeName.PrintContent),
-  new OptionItem('Included in EoD', 'true'),
-  new OptionItem('On Ticker', 'On Ticker'),
-  new OptionItem('Commentary', 'Commentary'),
-  new OptionItem('Top Story', 'Top Story'),
+  new OptionItem('Print Content', ShowOnlyValues.PrintContent),
+  new OptionItem('Included in EoD', ShowOnlyValues.IncludedInEod),
+  new OptionItem('On Ticker', ShowOnlyValues.PrintContent),
+  new OptionItem('Commentary', ShowOnlyValues.Commentary),
+  new OptionItem('Top Story', ShowOnlyValues.TopStory),
 ];

--- a/app/editor/src/features/content/form/constants/showOnlyOptions.ts
+++ b/app/editor/src/features/content/form/constants/showOnlyOptions.ts
@@ -1,0 +1,10 @@
+import { ContentTypeName } from 'hooks';
+import { OptionItem } from 'tno-core';
+
+export const showOnlyOptions = [
+  new OptionItem('Print Content', ContentTypeName.PrintContent),
+  new OptionItem('Included in EoD', 'true'),
+  new OptionItem('On Ticker', 'On Ticker'),
+  new OptionItem('Commentary', 'Commentary'),
+  new OptionItem('Top Story', 'Top Story'),
+];

--- a/app/editor/src/features/content/list-view/interfaces/IContentListFilter.ts
+++ b/app/editor/src/features/content/list-view/interfaces/IContentListFilter.ts
@@ -16,6 +16,7 @@ export interface IContentListFilter {
   userId: number | '';
   timeFrame: number | '';
   // Actions
+  showOnly?: string;
   onTicker: string;
   commentary: string;
   topStory: string;

--- a/app/editor/src/features/content/tool-bar/ContentFormToolBar.tsx
+++ b/app/editor/src/features/content/tool-bar/ContentFormToolBar.tsx
@@ -47,7 +47,6 @@ export const ContentFormToolBar: React.FC<IContentFormToolBarProps> = ({
     // Return a function to disconnect the event listener
     return () => window.removeEventListener('resize', calcWidth);
   }, []);
-  console.log(width);
   return (
     <ToolBar variant="dark">
       <StatusSection status={status} />

--- a/app/editor/src/features/content/tool-bar/ContentFormToolBar.tsx
+++ b/app/editor/src/features/content/tool-bar/ContentFormToolBar.tsx
@@ -3,8 +3,10 @@ import { ToolBarSection } from 'components/tool-bar';
 import { ToolBar } from 'components/tool-bar/styled';
 import { useFormikContext } from 'formik';
 import { ContentTypeName, IActionModel } from 'hooks';
+import React from 'react';
 import { FaCalendarTimes } from 'react-icons/fa';
 import { useLookup } from 'store/hooks';
+import { Row, Show } from 'tno-core';
 
 import { IContentForm } from '../form/interfaces';
 import { ActionSection, AlertSection, StatusSection } from './sections/form';
@@ -22,27 +24,65 @@ export const ContentFormToolBar: React.FC<IContentFormToolBarProps> = ({
 }) => {
   const [{ licenses }] = useLookup();
   const { setFieldValue, values } = useFormikContext<IContentForm>();
+  const [width, setWidth] = React.useState(window.innerWidth);
+
+  // recalculates the width of the screen when the screen is resized
+  React.useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const calcWidth = () => {
+      setWidth(window.innerWidth);
+    };
+
+    window.addEventListener('resize', calcWidth);
+
+    // This is likely unnecessary, as the initial state should capture
+    // the size, however if a resize occurs between initial state set by
+    // React and before the event listener is attached, this
+    // will just make sure it captures that.
+    calcWidth();
+
+    // Return a function to disconnect the event listener
+    return () => window.removeEventListener('resize', calcWidth);
+  }, []);
+  console.log(width);
   return (
     <ToolBar variant="dark">
       <StatusSection status={status} />
       <AlertSection />
       <ActionSection contentType={contentType} determineActions={determineActions} />
-      <ToolBarSection
-        children={
-          <ToggleGroup
-            defaultSelected={licenses
-              .find((l) => l.id === values.licenseId)
-              ?.name.replace(/expire/i, '')
-              .toLowerCase()}
-            options={licenses.map((l) => ({
-              label: l.name.toUpperCase().replace(/expire/i, ''),
-              onClick: () => setFieldValue('licenseId', Number(l.id)),
-            }))}
-          />
-        }
-        label="LICENCE EXPIRY"
-        icon={<FaCalendarTimes />}
-      />
+      <Show visible={width > 1800}>
+        <ToolBarSection
+          children={
+            <ToggleGroup
+              defaultSelected={licenses
+                .find((l) => l.id === values.licenseId)
+                ?.name.replace(/expire/i, '')
+                .toLowerCase()}
+              options={licenses.map((l) => ({
+                label: l.name.toUpperCase().replace(/expire/i, ''),
+                onClick: () => setFieldValue('licenseId', Number(l.id)),
+              }))}
+            />
+          }
+          label="LICENCE EXPIRY"
+          icon={<FaCalendarTimes />}
+        />
+      </Show>
+      <Show visible={width <= 1800}>
+        <ToolBarSection
+          children={
+            <Row>
+              <div className="white-bg">
+                {licenses.find((l) => l.id === values.licenseId)?.name}
+              </div>
+            </Row>
+          }
+          label="LICENCE EXPIRY"
+        />
+      </Show>
     </ToolBar>
   );
 };

--- a/app/editor/src/features/content/tool-bar/sections/filter/ShowOnlySection.tsx
+++ b/app/editor/src/features/content/tool-bar/sections/filter/ShowOnlySection.tsx
@@ -1,9 +1,14 @@
 import { ToolBarSection } from 'components/tool-bar';
+import { showOnlyOptions } from 'features/content/form/constants/showOnlyOptions';
 import { IContentListFilter } from 'features/content/list-view/interfaces';
 import { ContentTypeName } from 'hooks';
+import React from 'react';
 import { FaEye } from 'react-icons/fa';
 import { useContent } from 'store/hooks';
-import { Checkbox, Col, Row } from 'tno-core';
+import { Checkbox, Col, FieldSize, Row, Select, Show } from 'tno-core';
+
+import { InputOption } from './InputOption';
+import { checkLatestShowOnlyEntry, getSelectedOptions } from './utils';
 
 export interface IShowOnlySectionProps {
   onChange: (filter: IContentListFilter) => void;
@@ -16,84 +21,140 @@ export interface IShowOnlySectionProps {
  */
 export const ShowOnlySection: React.FC<IShowOnlySectionProps> = ({ onChange }) => {
   const [{ filter }] = useContent();
+  const [width, setWidth] = React.useState(window.innerWidth);
+
+  // recalculates the width of the screen when the screen is resized
+  React.useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const calcWidth = () => {
+      setWidth(window.innerWidth);
+    };
+
+    window.addEventListener('resize', calcWidth);
+
+    // This is likely unnecessary, as the initial state should capture
+    // the size, however if a resize occurs between initial state set by
+    // React and before the event listener is attached, this
+    // will just make sure it captures that.
+    calcWidth();
+
+    // Return a function to disconnect the event listener
+    return () => window.removeEventListener('resize', calcWidth);
+  }, []);
 
   return (
     <ToolBarSection
       children={
         <Col>
-          <Row>
-            <Checkbox
-              name="isPrintContent"
-              label="Print Content"
-              tooltip="Newspaper content without audio/video"
-              checked={filter.contentType === ContentTypeName.PrintContent}
-              onChange={(e) => {
-                onChange({
-                  ...filter,
-                  pageIndex: 0,
-                  contentType: e.target.checked ? ContentTypeName.PrintContent : undefined,
-                });
+          <Show visible={width <= 1847}>
+            <Select
+              className="select"
+              name="showOnly"
+              placeholder="Show Only"
+              isMulti
+              closeMenuOnSelect={false}
+              hideSelectedOptions={false}
+              options={showOnlyOptions}
+              width={FieldSize.Medium}
+              defaultValue={getSelectedOptions(filter)}
+              components={{
+                Option: InputOption,
+              }}
+              onChange={(newValues: any, { action }) => {
+                if (!newValues.length)
+                  onChange({
+                    ...filter,
+                    showOnly: '',
+                    onTicker: '',
+                    commentary: '',
+                    topStory: '',
+                    includedInCategory: false,
+                    contentType: undefined,
+                  });
+                else {
+                  checkLatestShowOnlyEntry(newValues, onChange, filter);
+                }
               }}
             />
-            <Checkbox
-              name="includedInCategory"
-              label="Included in EoD"
-              tooltip="Content included in Event of the Day"
-              value={filter.includedInCategory}
-              checked={filter.includedInCategory}
-              onChange={(e) => {
-                onChange({
-                  ...filter,
-                  pageIndex: 0,
-                  includedInCategory: e.target.checked,
-                });
-              }}
-            />
-            <Checkbox
-              name="ticker"
-              label="On Ticker"
-              value="On Ticker"
-              tooltip="Content identified as on ticker"
-              checked={filter.onTicker !== ''}
-              onChange={(e) => {
-                onChange({
-                  ...filter,
-                  pageIndex: 0,
-                  onTicker: e.target.checked ? e.target.value : '',
-                });
-              }}
-            />
-          </Row>
-          <Row>
-            <Checkbox
-              name="commentary"
-              label="Commentary"
-              value="Commentary"
-              tooltip="Content identified as commentary"
-              checked={filter.commentary !== ''}
-              onChange={(e) => {
-                onChange({
-                  ...filter,
-                  pageIndex: 0,
-                  commentary: e.target.checked ? e.target.value : '',
-                });
-              }}
-            />
-            <Checkbox
-              name="topStory"
-              label="Top Story"
-              value="Top Story"
-              tooltip="Content identified as a top story"
-              checked={filter.topStory !== ''}
-              onChange={(e) => {
-                onChange({
-                  ...filter,
-                  pageIndex: 0,
-                  topStory: e.target.checked ? e.target.value : '',
-                });
-              }}
-            />
-          </Row>
+          </Show>
+          <Show visible={width > 1847}>
+            <Row>
+              <Checkbox
+                name="isPrintContent"
+                label="Print Content"
+                tooltip="Newspaper content without audio/video"
+                checked={filter.contentType === ContentTypeName.PrintContent}
+                onChange={(e) => {
+                  onChange({
+                    ...filter,
+                    pageIndex: 0,
+                    contentType: e.target.checked ? ContentTypeName.PrintContent : undefined,
+                  });
+                }}
+              />
+              <Checkbox
+                name="includedInCategory"
+                label="Included in EoD"
+                tooltip="Content included in Event of the Day"
+                value={filter.includedInCategory}
+                checked={filter.includedInCategory}
+                onChange={(e) => {
+                  onChange({
+                    ...filter,
+                    pageIndex: 0,
+                    includedInCategory: e.target.checked,
+                  });
+                }}
+              />
+              <Checkbox
+                name="ticker"
+                label="On Ticker"
+                value="On Ticker"
+                tooltip="Content identified as on ticker"
+                checked={filter.onTicker !== ''}
+                onChange={(e) => {
+                  onChange({
+                    ...filter,
+                    pageIndex: 0,
+                    onTicker: e.target.checked ? e.target.value : '',
+                  });
+                }}
+              />
+            </Row>
+            <Row>
+              <Checkbox
+                name="commentary"
+                label="Commentary"
+                value="Commentary"
+                tooltip="Content identified as commentary"
+                checked={filter.commentary !== ''}
+                onChange={(e) => {
+                  onChange({
+                    ...filter,
+                    pageIndex: 0,
+                    commentary: e.target.checked ? e.target.value : '',
+                  });
+                }}
+              />
+              <Checkbox
+                name="topStory"
+                label="Top Story"
+                value="Top Story"
+                tooltip="Content identified as a top story"
+                checked={filter.topStory !== ''}
+                onChange={(e) => {
+                  onChange({
+                    ...filter,
+                    pageIndex: 0,
+                    topStory: e.target.checked ? e.target.value : '',
+                  });
+                }}
+              />
+            </Row>
+          </Show>
         </Col>
       }
       label="SHOW ONLY"

--- a/app/editor/src/features/content/tool-bar/sections/filter/ShowOnlySection.tsx
+++ b/app/editor/src/features/content/tool-bar/sections/filter/ShowOnlySection.tsx
@@ -58,7 +58,7 @@ export const ShowOnlySection: React.FC<IShowOnlySectionProps> = ({ onChange }) =
               closeMenuOnSelect={false}
               hideSelectedOptions={false}
               options={showOnlyOptions}
-              width={FieldSize.Medium}
+              width={FieldSize.Small}
               defaultValue={getSelectedOptions(filter)}
               components={{
                 Option: InputOption,
@@ -106,20 +106,6 @@ export const ShowOnlySection: React.FC<IShowOnlySectionProps> = ({ onChange }) =
                     ...filter,
                     pageIndex: 0,
                     includedInCategory: e.target.checked,
-                  });
-                }}
-              />
-              <Checkbox
-                name="ticker"
-                label="On Ticker"
-                value="On Ticker"
-                tooltip="Content identified as on ticker"
-                checked={filter.onTicker !== ''}
-                onChange={(e) => {
-                  onChange({
-                    ...filter,
-                    pageIndex: 0,
-                    onTicker: e.target.checked ? e.target.value : '',
                   });
                 }}
               />

--- a/app/editor/src/features/content/tool-bar/sections/filter/utils/checkLatestShowOnlyEntry.ts
+++ b/app/editor/src/features/content/tool-bar/sections/filter/utils/checkLatestShowOnlyEntry.ts
@@ -30,13 +30,6 @@ export const checkLatestShowOnlyEntry = (
         includedInCategory: true,
       });
       break;
-    case ShowOnlyValues.OnTicker:
-      onChange({
-        ...filter,
-        pageIndex: 0,
-        onTicker: ShowOnlyValues.OnTicker,
-      });
-      break;
     case ShowOnlyValues.Commentary:
       onChange({
         ...filter,

--- a/app/editor/src/features/content/tool-bar/sections/filter/utils/checkLatestShowOnlyEntry.ts
+++ b/app/editor/src/features/content/tool-bar/sections/filter/utils/checkLatestShowOnlyEntry.ts
@@ -1,0 +1,51 @@
+import { IContentListFilter } from 'features/content/list-view/interfaces';
+import { ContentTypeName } from 'hooks';
+import { IOptionItem } from 'tno-core';
+
+/**
+ * Function that checks the latest entry in the array of selected options and sets the filter accordingly
+ * @param newValues the current array of selected options
+ * @param onChange the function to perform on change of the filter
+ * @param filter the filter to be updated
+ */
+export const checkLatestShowOnlyEntry = (
+  newValues: IOptionItem[],
+  onChange: (filter: IContentListFilter) => void,
+  filter: IContentListFilter,
+) => {
+  if (newValues[newValues.length - 1].value === ContentTypeName.PrintContent) {
+    onChange({
+      ...filter,
+      pageIndex: 0,
+      contentType: ContentTypeName.PrintContent,
+    });
+  }
+  if ((newValues[newValues.length - 1].label as string).includes('EoD')) {
+    onChange({
+      ...filter,
+      pageIndex: 0,
+      includedInCategory: true,
+    });
+  }
+  if ((newValues[newValues.length - 1].label as string).includes('Ticker')) {
+    onChange({
+      ...filter,
+      pageIndex: 0,
+      onTicker: 'On Ticker',
+    });
+  }
+  if ((newValues[newValues.length - 1].label as string).includes('Commentary')) {
+    onChange({
+      ...filter,
+      pageIndex: 0,
+      commentary: 'Commentary',
+    });
+  }
+  if ((newValues[newValues.length - 1].label as string).includes('Top Story')) {
+    onChange({
+      ...filter,
+      pageIndex: 0,
+      topStory: 'Top Story',
+    });
+  }
+};

--- a/app/editor/src/features/content/tool-bar/sections/filter/utils/checkLatestShowOnlyEntry.ts
+++ b/app/editor/src/features/content/tool-bar/sections/filter/utils/checkLatestShowOnlyEntry.ts
@@ -1,3 +1,4 @@
+import { ShowOnlyValues } from 'features/content/form/constants/ShowOnlyValues';
 import { IContentListFilter } from 'features/content/list-view/interfaces';
 import { ContentTypeName } from 'hooks';
 import { IOptionItem } from 'tno-core';
@@ -13,39 +14,42 @@ export const checkLatestShowOnlyEntry = (
   onChange: (filter: IContentListFilter) => void,
   filter: IContentListFilter,
 ) => {
-  if (newValues[newValues.length - 1].value === ContentTypeName.PrintContent) {
-    onChange({
-      ...filter,
-      pageIndex: 0,
-      contentType: ContentTypeName.PrintContent,
-    });
-  }
-  if ((newValues[newValues.length - 1].label as string).includes('EoD')) {
-    onChange({
-      ...filter,
-      pageIndex: 0,
-      includedInCategory: true,
-    });
-  }
-  if ((newValues[newValues.length - 1].label as string).includes('Ticker')) {
-    onChange({
-      ...filter,
-      pageIndex: 0,
-      onTicker: 'On Ticker',
-    });
-  }
-  if ((newValues[newValues.length - 1].label as string).includes('Commentary')) {
-    onChange({
-      ...filter,
-      pageIndex: 0,
-      commentary: 'Commentary',
-    });
-  }
-  if ((newValues[newValues.length - 1].label as string).includes('Top Story')) {
-    onChange({
-      ...filter,
-      pageIndex: 0,
-      topStory: 'Top Story',
-    });
+  // convert to switch statement
+  switch (newValues[newValues.length - 1].value) {
+    case ShowOnlyValues.PrintContent:
+      onChange({
+        ...filter,
+        pageIndex: 0,
+        contentType: ContentTypeName.PrintContent,
+      });
+      break;
+    case ShowOnlyValues.IncludedInEod:
+      onChange({
+        ...filter,
+        pageIndex: 0,
+        includedInCategory: true,
+      });
+      break;
+    case ShowOnlyValues.OnTicker:
+      onChange({
+        ...filter,
+        pageIndex: 0,
+        onTicker: ShowOnlyValues.OnTicker,
+      });
+      break;
+    case ShowOnlyValues.Commentary:
+      onChange({
+        ...filter,
+        pageIndex: 0,
+        commentary: ShowOnlyValues.Commentary,
+      });
+      break;
+    case ShowOnlyValues.TopStory:
+      onChange({
+        ...filter,
+        pageIndex: 0,
+        topStory: ShowOnlyValues.TopStory,
+      });
+      break;
   }
 };

--- a/app/editor/src/features/content/tool-bar/sections/filter/utils/getSelectedOptions.ts
+++ b/app/editor/src/features/content/tool-bar/sections/filter/utils/getSelectedOptions.ts
@@ -1,0 +1,15 @@
+import { showOnlyOptions } from 'features/content/form/constants/showOnlyOptions';
+import { IContentListFilter } from 'features/content/list-view/interfaces';
+import { ContentTypeName } from 'hooks';
+import { IOptionItem } from 'tno-core';
+
+// the below function helps sync between the checkboxes and the select dropdown when the screen size is changed for the show only section of the content tool bar
+export const getSelectedOptions = (filter: IContentListFilter) => {
+  const selectedOptions: IOptionItem[] = [];
+  if (filter.contentType === ContentTypeName.PrintContent) selectedOptions.push(showOnlyOptions[0]);
+  if (filter.includedInCategory) selectedOptions.push(showOnlyOptions[1]);
+  if (filter.onTicker) selectedOptions.push(showOnlyOptions[2]);
+  if (filter.commentary) selectedOptions.push(showOnlyOptions[3]);
+  if (filter.topStory) selectedOptions.push(showOnlyOptions[4]);
+  return selectedOptions;
+};

--- a/app/editor/src/features/content/tool-bar/sections/filter/utils/index.ts
+++ b/app/editor/src/features/content/tool-bar/sections/filter/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './checkLatestShowOnlyEntry';
+export * from './getSelectedOptions';


### PR DESCRIPTION
- content list view filter toolbar now changes the Show Only section to a multi-select if screen real-estate is minimal. will sync up with existing values from checkboxes
- license options hidden on the content form toolbar if space is minimal 

**Sync example:**
![persist-resize](https://user-images.githubusercontent.com/15724124/216138440-1e0185be-cec5-460e-808a-19943bc4e787.gif)

**Resize example:** 
![resize-toolbar](https://user-images.githubusercontent.com/15724124/216137800-dcb4fb09-b8cc-46a2-a59d-34f9dba4dec8.gif)
