### PR TITLE
TNO-1015: Time overwritten bug

### DIFF
--- a/app/editor/src/features/content/form/ContentSummaryForm.tsx
+++ b/app/editor/src/features/content/form/ContentSummaryForm.tsx
@@ -184,6 +184,12 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
               }
               value={!!values.publishedOn ? moment(values.publishedOn).format('MMM D, yyyy') : ''}
               onChange={(date) => {
+                if (!!values.publishedOnTime) {
+                  const hours = values.publishedOnTime?.split(':');
+                  if (!!hours && !!date) {
+                    date.setHours(Number(hours[0]), Number(hours[1]), Number(hours[2]));
+                  }
+                }
                 setFieldValue('publishedOn', moment(date).format('MMM D, yyyy HH:mm:ss'));
               }}
             />


### PR DESCRIPTION
Ensure that the user inputted time is not overwritten if the date is changed. Previously changing the date after entering a time would overwrite it to the created on time.