### PR TITLE
TNO-736 Add FFmpeg to API

### DIFF
--- a/api/net/Dockerfile.openshift
+++ b/api/net/Dockerfile.openshift
@@ -1,5 +1,10 @@
 ARG BUILD_CONFIGURATION=Release
 FROM image-registry.apps.silver.devops.gov.bc.ca/9b301c-tools/aspnet:7.0 AS base
+
+RUN apt-get update && apt-get -y upgrade
+RUN apt -y install curl libc6-dev libgdiplus ffmpeg
+RUN apt-get clean
+
 EXPOSE 443 8080
 
 # Copy csproj and restore as distinct layers

--- a/libs/net/kafka/KafkaListener`.cs
+++ b/libs/net/kafka/KafkaListener`.cs
@@ -201,6 +201,14 @@ public class KafkaListener<TKey, TValue> : IKafkaListener<TKey, TValue>, IDispos
                 _logger.LogWarning("Unexpected consume containing no message");
             }
         }
+        catch (ConsumeException ex)
+        {
+            // No need to thro
+            if (ex.Message.Contains("Subscribed topic not available:"))
+                _logger.LogWarning(ex, "Subscribed topic not available: {topic}: Broker: Unknown topic or partition", this.Consumer?.Subscription);
+            else
+                HandleException(ex);
+        }
         catch (Exception ex)
         {
             HandleException(ex);

--- a/openshift/kustomize/api/build/overlays/jmf/kustomization.yaml
+++ b/openshift/kustomize/api/build/overlays/jmf/kustomization.yaml
@@ -19,4 +19,4 @@ patches:
         value: https://github.com/fosol/tno.git
       - op: replace
         path: /spec/source/git/ref
-        value: dev
+        value: tno-736

--- a/openshift/kustomize/api/overlays/dev/kustomization.yaml
+++ b/openshift/kustomize/api/overlays/dev/kustomization.yaml
@@ -50,16 +50,16 @@ patches:
         value: 3
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/cpu
-        value: 20m
-      - op: replace
-        path: /spec/template/spec/containers/0/resources/requests/memory
-        value: 100Mi
-      - op: replace
-        path: /spec/template/spec/containers/0/resources/limits/cpu
         value: 100m
       - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 150Mi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 300m
+      - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 200Mi
+        value: 300Mi
       - op: replace
         path: /spec/triggers/1/imageChangeParams/from/name
         value: api:dev

--- a/openshift/kustomize/api/overlays/prod/kustomization.yaml
+++ b/openshift/kustomize/api/overlays/prod/kustomization.yaml
@@ -50,16 +50,16 @@ patches:
         value: 3
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/cpu
-        value: 20m
-      - op: replace
-        path: /spec/template/spec/containers/0/resources/requests/memory
-        value: 100Mi
-      - op: replace
-        path: /spec/template/spec/containers/0/resources/limits/cpu
         value: 100m
       - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 150Mi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 300m
+      - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 200Mi
+        value: 300Mi
       - op: replace
         path: /spec/triggers/1/imageChangeParams/from/name
         value: api:prod

--- a/openshift/kustomize/api/overlays/test/kustomization.yaml
+++ b/openshift/kustomize/api/overlays/test/kustomization.yaml
@@ -50,16 +50,16 @@ patches:
         value: 3
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/cpu
-        value: 20m
-      - op: replace
-        path: /spec/template/spec/containers/0/resources/requests/memory
-        value: 100Mi
-      - op: replace
-        path: /spec/template/spec/containers/0/resources/limits/cpu
         value: 100m
       - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 150Mi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 300m
+      - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 200Mi
+        value: 300Mi
       - op: replace
         path: /spec/triggers/1/imageChangeParams/from/name
         value: api:test

--- a/openshift/kustomize/services/capture/overlays/dev/kustomization.yaml
+++ b/openshift/kustomize/services/capture/overlays/dev/kustomization.yaml
@@ -26,16 +26,16 @@ patches:
         value: 1
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/cpu
-        value: 20m
+        value: 50m
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/memory
-        value: 125Mi
+        value: 150Mi
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/cpu
         value: 100m
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 200Mi
+        value: 300Mi
       - op: replace
         path: /spec/triggers/1/imageChangeParams/from/name
         value: capture-service:dev

--- a/openshift/kustomize/services/capture/overlays/prod/kustomization.yaml
+++ b/openshift/kustomize/services/capture/overlays/prod/kustomization.yaml
@@ -26,16 +26,16 @@ patches:
         value: 1
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/cpu
-        value: 20m
+        value: 50m
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/memory
-        value: 125Mi
+        value: 150Mi
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/cpu
         value: 100m
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 200Mi
+        value: 300Mi
       - op: replace
         path: /spec/triggers/1/imageChangeParams/from/name
         value: capture-service:prod

--- a/openshift/kustomize/services/capture/overlays/test/kustomization.yaml
+++ b/openshift/kustomize/services/capture/overlays/test/kustomization.yaml
@@ -26,16 +26,16 @@ patches:
         value: 1
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/cpu
-        value: 20m
+        value: 50m
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/memory
-        value: 125Mi
+        value: 150Mi
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/cpu
         value: 100m
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 200Mi
+        value: 300Mi
       - op: replace
         path: /spec/triggers/1/imageChangeParams/from/name
         value: capture-service:test

--- a/services/net/filecopy/FileCopyManager.cs
+++ b/services/net/filecopy/FileCopyManager.cs
@@ -271,8 +271,9 @@ public class FileCopyManager : ServiceManager<FileCopyOptions>
                     var localDirectory = Path.GetDirectoryName(localPath) ?? throw new ConfigurationException("Local path is invalid");
                     if (!Directory.Exists(localDirectory)) Directory.CreateDirectory(localDirectory);
 
-                    this.Logger.LogInformation("Copying remote file. Path: {path}", remotePath);
+                    this.Logger.LogInformation("File copy started. Path: {path}", remotePath);
                     SftpHelper.CopyFile(client, remotePath, localPath);
+                    this.Logger.LogInformation("File copy completed. Path: {path}", remotePath);
 
                     await UpdateWorkOrderAsync(request, WorkOrderStatus.Completed);
                 }


### PR DESCRIPTION
Surprisingly FFmpeg was never released to Openshift on the API.  I have now added it to the appropriate `Dockerfile`.

I have also updated the resource requirements for the Capture and API pods.