### PR TITLE
Fix Tekton build

### DIFF
--- a/api/net/Dockerfile
+++ b/api/net/Dockerfile
@@ -34,13 +34,15 @@ RUN chmod +x /app/entrypoint.sh
 RUN mkdir /data
 VOLUME /data
 RUN chgrp -R 0 /data && \
-    chmod -R g=u /data
+    chmod -R g=u /data && \
+    chown -R 1001 /data
 
 # This volume is the local storage for capture A/V files.
 RUN mkdir /av
 VOLUME /av
 RUN chgrp -R 0 /av && \
-    chmod -R g=u /av
+    chmod -R g=u /av && \
+    chown -R 1001 /av
 
 # USER appuser
 USER 1001

--- a/api/net/Dockerfile.openshift
+++ b/api/net/Dockerfile.openshift
@@ -34,13 +34,15 @@ RUN chmod +x /app/entrypoint.sh
 RUN mkdir /data
 VOLUME /data
 RUN chgrp -R 0 /data && \
-    chmod -R g=u /data
+    chmod -R g=u /data && \
+    chown -R 1001 /av
 
 # This volume is the local storage for capture A/V files.
 RUN mkdir /av
 VOLUME /av
 RUN chgrp -R 0 /av && \
-    chmod -R g=u /av
+    chmod -R g=u /av && \
+    chown -R 1001 /av
 
 # USER appuser
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/libs/net/Dockerfile
+++ b/libs/net/Dockerfile
@@ -11,8 +11,8 @@ RUN dotnet tool install --global dotnet-ef
 
 WORKDIR /src
 COPY . .
-RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-    fix_permissions "/src" "/tmp"
+# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+#     fix_permissions "/src" "/tmp"
 RUN dotnet restore
 RUN chmod -R 0777 /src
 RUN mkdir /.local

--- a/openshift/kustomize/services/transcription/overlays/dev/kustomization.yaml
+++ b/openshift/kustomize/services/transcription/overlays/dev/kustomization.yaml
@@ -19,16 +19,16 @@ patches:
         value: 1
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/cpu
-        value: 20m
+        value: 50m
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/memory
-        value: 80Mi
+        value: 100Mi
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/cpu
-        value: 75m
+        value: 300m
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 150Mi
+        value: 300Mi
       - op: replace
         path: /spec/triggers/1/imageChangeParams/from/name
         value: transcription-service:dev

--- a/openshift/kustomize/services/transcription/overlays/prod/kustomization.yaml
+++ b/openshift/kustomize/services/transcription/overlays/prod/kustomization.yaml
@@ -19,16 +19,16 @@ patches:
         value: 1
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/cpu
-        value: 20m
+        value: 50m
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/memory
-        value: 80Mi
+        value: 100Mi
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/cpu
-        value: 75m
+        value: 300m
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 150Mi
+        value: 300Mi
       - op: replace
         path: /spec/triggers/1/imageChangeParams/from/name
         value: transcription-service:prod

--- a/openshift/kustomize/services/transcription/overlays/test/kustomization.yaml
+++ b/openshift/kustomize/services/transcription/overlays/test/kustomization.yaml
@@ -19,16 +19,16 @@ patches:
         value: 1
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/cpu
-        value: 20m
+        value: 50m
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/memory
-        value: 80Mi
+        value: 100Mi
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/cpu
-        value: 75m
+        value: 300m
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 150Mi
+        value: 300Mi
       - op: replace
         path: /spec/triggers/1/imageChangeParams/from/name
         value: transcription-service:test

--- a/openshift/kustomize/tekton/base/pipelines/buildah-api.yaml
+++ b/openshift/kustomize/tekton/base/pipelines/buildah-api.yaml
@@ -56,6 +56,9 @@ spec:
     - name: owasp-settings
       description: |
         mounts /zap/wrk to store generated configs and results.
+    - name: build
+      description: |
+        Pipeline build volume
 
   tasks:
     - name: wait
@@ -101,6 +104,8 @@ spec:
       workspaces:
         - name: source
           workspace: source
+        - name: build
+          workspace: build
 
     - name: deploy-api
       runAfter:

--- a/openshift/kustomize/tekton/base/pipelines/buildah-db-migration.yaml
+++ b/openshift/kustomize/tekton/base/pipelines/buildah-db-migration.yaml
@@ -38,6 +38,10 @@ spec:
     - description: |
         Pipeline configuration file.
       name: conditions
+    - name: build
+      description: |
+        Pipeline build volume
+
   tasks:
     - name: wait
       params:
@@ -62,6 +66,7 @@ spec:
           workspace: source
         - name: output
           workspace: conditions
+
     - name: build-db-migration
       params:
         - name: COMPONENT
@@ -82,6 +87,9 @@ spec:
           workspace: source
         - name: conditions
           workspace: conditions
+        - name: build
+          workspace: build
+
     - name: maintenance-on-editor
       params:
         - name: PROJECT
@@ -95,6 +103,7 @@ spec:
       taskRef:
         kind: Task
         name: oc-patch-route
+
     - name: maintenance-on-subscriber
       params:
         - name: PROJECT
@@ -108,6 +117,7 @@ spec:
       taskRef:
         kind: Task
         name: oc-patch-route
+
     - name: db-migration
       params:
         - name: DB_SECRET_NAME
@@ -129,6 +139,7 @@ spec:
       workspaces:
         - name: conditions
           workspace: conditions
+
     - name: maintenance-off-editor
       params:
         - name: PROJECT
@@ -142,6 +153,7 @@ spec:
       taskRef:
         kind: Task
         name: oc-patch-route
+
     - name: maintenance-off-subscriber
       params:
         - name: PROJECT

--- a/openshift/kustomize/tekton/base/pipelines/buildah-editor.yaml
+++ b/openshift/kustomize/tekton/base/pipelines/buildah-editor.yaml
@@ -58,6 +58,9 @@ spec:
     - name: conditions
       description: |
         Pipeline configuration file.
+    - name: build
+      description: |
+        Pipeline build volume
     - name: owasp-settings
       description: |
         mounts /zap/wrk to store generated configs and results.
@@ -110,6 +113,8 @@ spec:
           workspace: source
         - name: conditions
           workspace: conditions
+        - name: build
+          workspace: build
 
     - name: maintenance-on
       runAfter:

--- a/openshift/kustomize/tekton/base/pipelines/buildah-main.yaml
+++ b/openshift/kustomize/tekton/base/pipelines/buildah-main.yaml
@@ -63,6 +63,9 @@ spec:
     - name: conditions
       description: |
         Pipeline configuration file.
+    - name: build
+      description: |
+        Pipeline build volume
     - name: owasp-settings
       description: |
         mounts /zap/wrk to store generated configs and results.
@@ -113,6 +116,8 @@ spec:
           workspace: source
         - name: conditions
           workspace: conditions
+        - name: build
+          workspace: build
 
     - name: build-editor
       taskRef:
@@ -136,6 +141,8 @@ spec:
           workspace: source
         - name: conditions
           workspace: conditions
+        - name: build
+          workspace: build
 
     - name: build-subscriber
       taskRef:
@@ -159,6 +166,8 @@ spec:
           workspace: source
         - name: conditions
           workspace: conditions
+        - name: build
+          workspace: build
 
     - name: build-api
       taskRef:
@@ -182,6 +191,8 @@ spec:
           workspace: source
         - name: conditions
           workspace: conditions
+        - name: build
+          workspace: build
 
     - name: maintenance-on-editor
       runAfter:

--- a/openshift/kustomize/tekton/base/pipelines/buildah-service.yaml
+++ b/openshift/kustomize/tekton/base/pipelines/buildah-service.yaml
@@ -58,6 +58,9 @@ spec:
     - name: conditions
       description: |
         Pipeline configuration file.
+    - name: build
+      description: |
+        Pipeline build volume
 
   tasks:
     - name: wait
@@ -103,6 +106,8 @@ spec:
       workspaces:
         - name: source
           workspace: source
+        - name: build
+          workspace: build
 
     - name: deploy-service
       runAfter:

--- a/openshift/kustomize/tekton/base/pipelines/buildah-services.yaml
+++ b/openshift/kustomize/tekton/base/pipelines/buildah-services.yaml
@@ -53,6 +53,9 @@ spec:
     - name: conditions
       description: |
         Pipeline configuration file.
+    - name: build
+      description: |
+        Pipeline build volume
 
   tasks:
     - name: git
@@ -92,6 +95,8 @@ spec:
           workspace: source
         - name: conditions
           workspace: conditions
+        - name: build
+          workspace: build
 
     - name: deploy-syndication
       runAfter:
@@ -131,6 +136,8 @@ spec:
           workspace: source
         - name: conditions
           workspace: conditions
+        - name: build
+          workspace: build
 
     - name: deploy-capture
       runAfter:
@@ -170,6 +177,8 @@ spec:
           workspace: source
         - name: conditions
           workspace: conditions
+        - name: build
+          workspace: build
 
     - name: deploy-clip
       runAfter:
@@ -209,6 +218,8 @@ spec:
           workspace: source
         - name: conditions
           workspace: conditions
+        - name: build
+          workspace: build
 
     - name: deploy-filemonitor
       runAfter:
@@ -248,6 +259,8 @@ spec:
           workspace: source
         - name: conditions
           workspace: conditions
+        - name: build
+          workspace: build
 
     - name: deploy-image
       runAfter:
@@ -287,6 +300,8 @@ spec:
           workspace: source
         - name: conditions
           workspace: conditions
+        - name: build
+          workspace: build
 
     - name: deploy-content
       runAfter:
@@ -326,6 +341,8 @@ spec:
           workspace: source
         - name: conditions
           workspace: conditions
+        - name: build
+          workspace: build
 
     - name: deploy-indexing
       runAfter:
@@ -365,6 +382,8 @@ spec:
           workspace: source
         - name: conditions
           workspace: conditions
+        - name: build
+          workspace: build
 
     - name: deploy-transcription
       runAfter:
@@ -404,6 +423,8 @@ spec:
           workspace: source
         - name: conditions
           workspace: conditions
+        - name: build
+          workspace: build
 
     - name: deploy-nlp
       runAfter:
@@ -416,6 +437,47 @@ spec:
           value: $(params.PROJECT_SHORTNAME)
         - name: IMAGE
           value: nlp-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+        - name: ENV
+          value: $(params.DEPLOY_TO)
+
+    - name: build-filecopy
+      taskRef:
+        name: build-component
+        kind: Task
+      runAfter:
+        - git
+      params:
+        - name: COMPONENT
+          value: filecopy
+        - name: CONTEXT
+          value: $(params.CONTEXT)
+        - name: DOCKERFILE
+          value: $(params.CONTEXT)/services/net/filecopy/Dockerfile
+        - name: IMAGE
+          value: filecopy-service
+        - name: IMAGE_TAG
+          value: $(params.IMAGE_TAG)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: conditions
+          workspace: conditions
+        - name: build
+          workspace: build
+
+    - name: deploy-filecopy
+      runAfter:
+        - build-filecopy
+      taskRef:
+        name: oc-deploy-with-tag
+        kind: Task
+      params:
+        - name: PROJECT_SHORTNAME
+          value: $(params.PROJECT_SHORTNAME)
+        - name: IMAGE
+          value: filecopy-service
         - name: IMAGE_TAG
           value: $(params.IMAGE_TAG)
         - name: ENV

--- a/openshift/kustomize/tekton/base/pipelines/buildah-subscriber.yaml
+++ b/openshift/kustomize/tekton/base/pipelines/buildah-subscriber.yaml
@@ -58,6 +58,9 @@ spec:
     - name: conditions
       description: |
         Pipeline configuration file.
+    - name: build
+      description: |
+        Pipeline build volume
     - name: owasp-settings
       description: |
         mounts /zap/wrk to store generated configs and results.

--- a/openshift/kustomize/tekton/base/tasks/build-component.yaml
+++ b/openshift/kustomize/tekton/base/tasks/build-component.yaml
@@ -47,6 +47,8 @@ spec:
     - name: source
     - name: conditions
       mountPath: /data
+    - name: build
+      mountPath: /var/lib/containers/storage/vfs/dir
   steps:
     - name: build
       image: image-registry.apps.silver.devops.gov.bc.ca/9b301c-tools/buildah:latest
@@ -72,7 +74,7 @@ spec:
           cpu: 250m
         limits:
           memory: 2560Mi
-          cpu: 500m
+          cpu: 1000m
       script: |
         #!/usr/bin/env bash
         set -xe

--- a/openshift/kustomize/tekton/base/tasks/buildah.yaml
+++ b/openshift/kustomize/tekton/base/tasks/buildah.yaml
@@ -39,6 +39,8 @@ spec:
       default: vfs
   workspaces:
     - name: source
+    - name: build
+      mountPath: /var/lib/containers/storage/vfs/dir
   steps:
     - name: build
       image: image-registry.apps.silver.devops.gov.bc.ca/9b301c-tools/buildah:latest
@@ -64,7 +66,7 @@ spec:
           cpu: 250m
         limits:
           memory: 2560Mi
-          cpu: 500m
+          cpu: 1000m
       script: |
         #!/usr/bin/env bash
         set -xe

--- a/openshift/kustomize/tekton/base/triggers/template.yaml
+++ b/openshift/kustomize/tekton/base/triggers/template.yaml
@@ -56,5 +56,15 @@ spec:
                     storage: 50Mi
                 storageClassName: netapp-file-standard
                 volumeMode: Filesystem
+          - name: build
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 20Gi
+                storageClassName: netapp-file-standard
+                volumeMode: Filesystem
           - name: owasp-settings
             emptyDir: {}

--- a/services/net/capture/Dockerfile
+++ b/services/net/capture/Dockerfile
@@ -15,8 +15,8 @@ COPY services/net/command services/net/command
 COPY services/net/capture services/net/capture
 COPY libs/net libs/net
 
-RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-    fix_permissions "/app" "/tmp"
+# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+#     fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/capture
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/clip/Dockerfile
+++ b/services/net/clip/Dockerfile
@@ -15,8 +15,8 @@ COPY services/net/command services/net/command
 COPY services/net/clip services/net/clip
 COPY libs/net libs/net
 
-RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-    fix_permissions "/app" "/tmp"
+# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+#     fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/clip
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/command/Dockerfile
+++ b/services/net/command/Dockerfile
@@ -12,8 +12,8 @@ USER 0
 WORKDIR /src
 COPY services/net/command services/net/command
 COPY libs/net libs/net
-RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-    fix_permissions "/app" "/tmp"
+# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+#     fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/command
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/content/Dockerfile
+++ b/services/net/content/Dockerfile
@@ -12,8 +12,8 @@ USER 0
 WORKDIR /src
 COPY services/net/content services/net/content
 COPY libs/net libs/net
-RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-    fix_permissions "/app" "/tmp"
+# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+#     fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/content
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/filecopy/Dockerfile
+++ b/services/net/filecopy/Dockerfile
@@ -12,8 +12,8 @@ USER 0
 WORKDIR /src
 COPY services/net/filecopy services/net/filecopy
 COPY libs/net libs/net
-RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-    fix_permissions "/app" "/tmp"
+# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+#     fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/filecopy
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/filemonitor/Dockerfile
+++ b/services/net/filemonitor/Dockerfile
@@ -15,8 +15,8 @@ COPY services/net/filemonitor services/net/filemonitor
 COPY libs/net libs/net
 RUN if [ ! -d services/net/filemonitor/keys ]; then mkdir services/net/filemonitor/keys; fi
 
-RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-    fix_permissions "/app" "/tmp"
+# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+#     fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/filemonitor
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/image/Dockerfile
+++ b/services/net/image/Dockerfile
@@ -15,8 +15,8 @@ COPY services/net/image services/net/image
 COPY libs/net libs/net
 RUN if [ ! -d services/net/image/keys ]; then mkdir services/net/image/keys; fi
 
-RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-    fix_permissions "/app" "/tmp"
+# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+#     fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/image
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/indexing/Dockerfile
+++ b/services/net/indexing/Dockerfile
@@ -14,8 +14,8 @@ WORKDIR /src
 COPY services/net/indexing services/net/indexing
 COPY libs/net libs/net
 
-RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-    fix_permissions "/app" "/tmp"
+# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+#     fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/indexing
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/nlp/Dockerfile
+++ b/services/net/nlp/Dockerfile
@@ -14,8 +14,8 @@ WORKDIR /src
 COPY services/net/nlp services/net/nlp
 COPY libs/net libs/net
 
-RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-    fix_permissions "/app" "/tmp"
+# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+#     fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/nlp
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/syndication/Dockerfile
+++ b/services/net/syndication/Dockerfile
@@ -14,8 +14,8 @@ WORKDIR /src
 COPY services/net/syndication services/net/syndication
 COPY libs/net libs/net
 
-RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-    fix_permissions "/app" "/tmp"
+# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+#     fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/syndication
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/transcription/Dockerfile
+++ b/services/net/transcription/Dockerfile
@@ -12,8 +12,8 @@ USER 0
 WORKDIR /src
 COPY services/net/transcription services/net/transcription
 COPY libs/net libs/net
-RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-    fix_permissions "/app" "/tmp"
+# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+#     fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/transcription
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build


### PR DESCRIPTION
Running into additional issues building any of the services in Openshift.  The Buildah Tekton Task originally was failing because it ran out of space.  However, after mapping to a volume with more space the new error is related to permissions.  Which would imply another Openshift 4.11 security change.

Also increased resources for a few pods.