### PR TITLE
Fix services

### DIFF
--- a/libs/net/dal/TNO.DAL.csproj
+++ b/libs/net/dal/TNO.DAL.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetEnv" Version="2.4.0" />
+    <PackageReference Include="DotNetEnv" Version="2.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.2" />

--- a/libs/net/services/Runners/BaseService.cs
+++ b/libs/net/services/Runners/BaseService.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using DotNetEnv.Configuration;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -47,9 +48,10 @@ public abstract class BaseService
     /// <param name="args"></param>
     public BaseService(string[] args)
     {
-        DotNetEnv.Env.Load();
+        DotNetEnv.Env.Load($"{Environment.CurrentDirectory}{Path.DirectorySeparatorChar}.env");
         var builder = WebApplication.CreateBuilder(args);
-        this.Configuration = Configure(builder, args).Build();
+        this.Configuration = Configure(builder, args)
+            .Build();
         ConfigureServices(builder.Services);
         this.App = builder.Build();
         Console.OutputEncoding = Encoding.UTF8;

--- a/openshift/kustomize/tekton/base/pipeline-runs/buildah-service.yaml
+++ b/openshift/kustomize/tekton/base/pipeline-runs/buildah-service.yaml
@@ -52,7 +52,7 @@ spec:
           resources:
             requests:
               storage: 5Gi
-          storageClassName: netapp-file-standard
+          storageClassName: netapp-block-standard
           volumeMode: Filesystem
     - name: owasp-settings
       emptyDir: {}

--- a/openshift/kustomize/tekton/base/tasks/build-component.yaml
+++ b/openshift/kustomize/tekton/base/tasks/build-component.yaml
@@ -56,7 +56,7 @@ spec:
         capabilities:
           add:
             - SETFCAP
-            - NET_BIND_SERVICE
+        runAsUser: 0
       workingDir: $(workspaces.source.path)
       env:
         - name: IMAGE_REGISTRY_USER

--- a/openshift/kustomize/tekton/base/tasks/buildah.yaml
+++ b/openshift/kustomize/tekton/base/tasks/buildah.yaml
@@ -48,7 +48,7 @@ spec:
         capabilities:
           add:
             - SETFCAP
-            - NET_BIND_SERVICE
+        runAsUser: 0
       workingDir: $(workspaces.source.path)
       env:
         - name: IMAGE_REGISTRY_USER

--- a/openshift/kustomize/tekton/base/triggers/template.yaml
+++ b/openshift/kustomize/tekton/base/triggers/template.yaml
@@ -64,7 +64,7 @@ spec:
                 resources:
                   requests:
                     storage: 20Gi
-                storageClassName: netapp-file-standard
+                storageClassName: netapp-block-standard
                 volumeMode: Filesystem
           - name: owasp-settings
             emptyDir: {}

--- a/services/net/capture/Dockerfile
+++ b/services/net/capture/Dockerfile
@@ -15,8 +15,8 @@ COPY services/net/command services/net/command
 COPY services/net/capture services/net/capture
 COPY libs/net libs/net
 
-# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-#     fix_permissions "/app" "/tmp"
+RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+    fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/capture
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/clip/Dockerfile
+++ b/services/net/clip/Dockerfile
@@ -15,8 +15,8 @@ COPY services/net/command services/net/command
 COPY services/net/clip services/net/clip
 COPY libs/net libs/net
 
-# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-#     fix_permissions "/app" "/tmp"
+RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+    fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/clip
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/command/Dockerfile
+++ b/services/net/command/Dockerfile
@@ -12,8 +12,9 @@ USER 0
 WORKDIR /src
 COPY services/net/command services/net/command
 COPY libs/net libs/net
-# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-#     fix_permissions "/app" "/tmp"
+
+RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+    fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/command
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/content/Dockerfile
+++ b/services/net/content/Dockerfile
@@ -12,8 +12,9 @@ USER 0
 WORKDIR /src
 COPY services/net/content services/net/content
 COPY libs/net libs/net
-# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-#     fix_permissions "/app" "/tmp"
+
+RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+    fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/content
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/filecopy/Dockerfile
+++ b/services/net/filecopy/Dockerfile
@@ -12,8 +12,9 @@ USER 0
 WORKDIR /src
 COPY services/net/filecopy services/net/filecopy
 COPY libs/net libs/net
-# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-#     fix_permissions "/app" "/tmp"
+
+RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+    fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/filecopy
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/filemonitor/Dockerfile
+++ b/services/net/filemonitor/Dockerfile
@@ -15,8 +15,8 @@ COPY services/net/filemonitor services/net/filemonitor
 COPY libs/net libs/net
 RUN if [ ! -d services/net/filemonitor/keys ]; then mkdir services/net/filemonitor/keys; fi
 
-# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-#     fix_permissions "/app" "/tmp"
+RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+    fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/filemonitor
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/image/Dockerfile
+++ b/services/net/image/Dockerfile
@@ -15,8 +15,8 @@ COPY services/net/image services/net/image
 COPY libs/net libs/net
 RUN if [ ! -d services/net/image/keys ]; then mkdir services/net/image/keys; fi
 
-# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-#     fix_permissions "/app" "/tmp"
+RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+    fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/image
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/indexing/Dockerfile
+++ b/services/net/indexing/Dockerfile
@@ -14,8 +14,8 @@ WORKDIR /src
 COPY services/net/indexing services/net/indexing
 COPY libs/net libs/net
 
-# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-#     fix_permissions "/app" "/tmp"
+RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+    fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/indexing
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/nlp/Dockerfile
+++ b/services/net/nlp/Dockerfile
@@ -14,8 +14,8 @@ WORKDIR /src
 COPY services/net/nlp services/net/nlp
 COPY libs/net libs/net
 
-# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-#     fix_permissions "/app" "/tmp"
+RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+    fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/nlp
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/syndication/Dockerfile
+++ b/services/net/syndication/Dockerfile
@@ -14,8 +14,8 @@ WORKDIR /src
 COPY services/net/syndication services/net/syndication
 COPY libs/net libs/net
 
-# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-#     fix_permissions "/app" "/tmp"
+RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+    fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/syndication
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/services/net/transcription/Dockerfile
+++ b/services/net/transcription/Dockerfile
@@ -12,8 +12,9 @@ USER 0
 WORKDIR /src
 COPY services/net/transcription services/net/transcription
 COPY libs/net libs/net
-# RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
-#     fix_permissions "/app" "/tmp"
+
+RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
+    fix_permissions "/app" "/tmp"
 
 WORKDIR /src/services/net/transcription
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build

--- a/tools/import/etl/TNO.Tools.Import.ETL.csproj
+++ b/tools/import/etl/TNO.Tools.Import.ETL.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetEnv" Version="2.4.0" />
+    <PackageReference Include="DotNetEnv" Version="2.5.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />


### PR DESCRIPTION
The library that loads `.env` files had a breaking change that resulted in not loading the config.

In my efforts to debug Openshift DevOps issues a change to the Dockerfiles has been rolledback.

Templates have been updated to support the latest security requirements and space limitations.