### PR TITLE
TNO-1039: Only show time log entry for snippets

### DIFF
--- a/app/editor/src/features/content/form/ContentSummaryForm.tsx
+++ b/app/editor/src/features/content/form/ContentSummaryForm.tsx
@@ -307,7 +307,7 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
             </Button>
           </Row>
 
-          <Show visible={contentType !== ContentTypeName.Image}>
+          <Show visible={contentType === ContentTypeName.Snippet}>
             <Row className="multi-group">
               <TimeLogSection
                 toggle={toggle}


### PR DESCRIPTION
Prep time is only needed for TV, Talk Radio and Radio News (Audio/Visual (Snippet) form.) 