### PR TITLE
TNO-1065: Hide NLP options for editors

### DIFF
--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -36,6 +36,7 @@ import {
   Area,
   Button,
   ButtonVariant,
+  Claim,
   Col,
   FieldSize,
   FormikHidden,
@@ -48,6 +49,7 @@ import {
   Show,
   Tab,
   Tabs,
+  useKeycloakWrapper,
 } from 'tno-core';
 import { hasErrors } from 'utils';
 
@@ -75,6 +77,7 @@ export interface IContentFormProps {
 export const ContentForm: React.FC<IContentFormProps> = ({
   contentType: initContentType = ContentTypeName.Snippet,
 }) => {
+  const keycloak = useKeycloakWrapper();
   const navigate = useNavigate();
   const [{ userInfo }] = useApp();
   const { id } = useParams();
@@ -654,7 +657,13 @@ export const ContentForm: React.FC<IContentFormProps> = ({
                         Transcribe
                       </Button>
                     </Show>
-                    <Show visible={!!props.values.id && props.values.body.length > 0}>
+                    <Show
+                      visible={
+                        !!props.values.id &&
+                        props.values.body.length > 0 &&
+                        keycloak.hasClaim(Claim.administrator)
+                      }
+                    >
                       <Button
                         onClick={() =>
                           isWorkOrderStatus(

--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -36,7 +36,6 @@ import {
   Area,
   Button,
   ButtonVariant,
-  Claim,
   Col,
   FieldSize,
   FormikHidden,
@@ -49,7 +48,6 @@ import {
   Show,
   Tab,
   Tabs,
-  useKeycloakWrapper,
 } from 'tno-core';
 import { hasErrors } from 'utils';
 
@@ -77,7 +75,6 @@ export interface IContentFormProps {
 export const ContentForm: React.FC<IContentFormProps> = ({
   contentType: initContentType = ContentTypeName.Snippet,
 }) => {
-  const keycloak = useKeycloakWrapper();
   const navigate = useNavigate();
   const [{ userInfo }] = useApp();
   const { id } = useParams();
@@ -657,30 +654,7 @@ export const ContentForm: React.FC<IContentFormProps> = ({
                         Transcribe
                       </Button>
                     </Show>
-                    <Show
-                      visible={
-                        !!props.values.id &&
-                        props.values.body.length > 0 &&
-                        keycloak.hasClaim(Claim.administrator)
-                      }
-                    >
-                      <Button
-                        onClick={() =>
-                          isWorkOrderStatus(
-                            form.workOrders,
-                            WorkOrderTypeName.NaturalLanguageProcess,
-                            [WorkOrderStatusName.Completed],
-                          )
-                            ? toggleNLP()
-                            : handleNLP(props.values)
-                        }
-                        variant={ButtonVariant.action}
-                        disabled={props.isSubmitting}
-                        tooltip="Request Natural Language Processing"
-                      >
-                        NLP
-                      </Button>
-                    </Show>
+
                     <Button
                       onClick={toggleDelete}
                       variant={ButtonVariant.danger}

--- a/app/editor/src/features/content/form/ContentSummaryForm.tsx
+++ b/app/editor/src/features/content/form/ContentSummaryForm.tsx
@@ -13,13 +13,11 @@ import { useModal } from 'hooks/modal';
 import _ from 'lodash';
 import moment from 'moment';
 import React from 'react';
-import { TbLanguage } from 'react-icons/tb';
 import { useContent, useLookup } from 'store/hooks';
 import { filterEnabled } from 'store/hooks/lookup/utils';
 import {
   Button,
   ButtonVariant,
-  Claim,
   Col,
   FieldSize,
   FormikDatePicker,
@@ -219,15 +217,6 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
             </Show>
           </Row>
         </Col>
-        <Show visible={keycloak.hasClaim(Claim.administrator)}>
-          <div className="vl" />
-          <Col className="transcription-section">
-            <label className="label">Create Labels</label>
-            <Button>
-              <TbLanguage className="nlp-button" /> START NLP
-            </Button>
-          </Col>
-        </Show>
         <div className="vl" />
         <Col>
           <FormikSelect

--- a/app/editor/src/features/content/form/ContentSummaryForm.tsx
+++ b/app/editor/src/features/content/form/ContentSummaryForm.tsx
@@ -19,6 +19,7 @@ import { filterEnabled } from 'store/hooks/lookup/utils';
 import {
   Button,
   ButtonVariant,
+  Claim,
   Col,
   FieldSize,
   FormikDatePicker,
@@ -218,13 +219,15 @@ export const ContentSummaryForm: React.FC<IContentSummaryFormProps> = ({
             </Show>
           </Row>
         </Col>
-        <div className="vl" />
-        <Col className="transcription-section">
-          <label className="label">Create Labels</label>
-          <Button>
-            <TbLanguage className="nlp-button" /> START NLP
-          </Button>
-        </Col>
+        <Show visible={keycloak.hasClaim(Claim.administrator)}>
+          <div className="vl" />
+          <Col className="transcription-section">
+            <label className="label">Create Labels</label>
+            <Button>
+              <TbLanguage className="nlp-button" /> START NLP
+            </Button>
+          </Col>
+        </Show>
         <div className="vl" />
         <Col>
           <FormikSelect


### PR DESCRIPTION
Hide the NLP options for editors as they have been confusing and are not yet required