### PR TITLE
TNO-1041 Add SignalR back-plane

### DIFF
--- a/api/net/Areas/Admin/Controllers/WorkOrderController.cs
+++ b/api/net/Areas/Admin/Controllers/WorkOrderController.cs
@@ -13,6 +13,7 @@ using TNO.DAL.Models;
 using TNO.DAL.Services;
 using TNO.Entities.Models;
 using TNO.Keycloak;
+using TNO.Models.Extensions;
 
 namespace TNO.API.Areas.Admin.Controllers;
 

--- a/api/net/Areas/Editor/Controllers/WorkOrderController.cs
+++ b/api/net/Areas/Editor/Controllers/WorkOrderController.cs
@@ -243,7 +243,6 @@ public class WorkOrderController : ControllerBase
                         workOrder.Status = WorkOrderStatus.Failed;
                         workOrder.Note = "Remote file request to Kafka failed";
                         workOrder = _workOrderService.UpdateAndSave(workOrder);
-                        await _hub.Clients.All.SendAsync("WorkOrder", new WorkOrderMessageModel(workOrder, _serializerOptions));
                         throw new BadRequestException("Remote file request failed");
                     }
                     return new JsonResult(new WorkOrderMessageModel(workOrder, _serializerOptions));

--- a/api/net/Program.cs
+++ b/api/net/Program.cs
@@ -31,6 +31,7 @@ using TNO.API.SignalR;
 using TNO.API.Helpers;
 using TNO.API.Elasticsearch;
 using Nest;
+using TNO.Kafka.SignalR;
 
 DotNetEnv.Env.Load();
 var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
@@ -167,6 +168,8 @@ builder.Services.AddAuthentication(options =>
             }
         };
     });
+
+builder.Services.AddKafkaHubBackplane(config);
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddTransient<IConfigureOptions<SwaggerGenOptions>, TNO.API.Config.Swagger.ConfigureSwaggerOptions>();

--- a/api/net/SignalR/WorkOrderHub.cs
+++ b/api/net/SignalR/WorkOrderHub.cs
@@ -4,8 +4,9 @@ using Microsoft.AspNetCore.SignalR;
 namespace TNO.API.SignalR;
 
 /// <summary>
-/// The WorkOrderHub class
+/// The WorkOrderHub class, provides the SignalR hub to control messages.
 /// </summary>
+[AllowAnonymous]
 [Authorize]
 public class WorkOrderHub : Hub
 {

--- a/api/net/appsettings.Development.json
+++ b/api/net/appsettings.Development.json
@@ -17,6 +17,9 @@
   "Kafka": {
     "Producer": {
       "BootstrapServers": "host.docker.internal:40102"
+    },
+    "Consumer": {
+      "BootstrapServers": "host.docker.internal:40102"
     }
   },
   "ElasticSearch": {

--- a/api/net/appsettings.Staging.json
+++ b/api/net/appsettings.Staging.json
@@ -17,6 +17,9 @@
   "Kafka": {
     "Producer": {
       "BootstrapServers": "kafka-broker-0.kafka-headless:9092,kafka-broker-1.kafka-headless:9092,kafka-broker-2.kafka-headless:9092"
+    },
+    "Consumer": {
+      "BootstrapServers": "kafka-broker-0.kafka-headless:9092,kafka-broker-1.kafka-headless:9092,kafka-broker-2.kafka-headless:9092"
     }
   },
   "SignalR": {

--- a/api/net/appsettings.json
+++ b/api/net/appsettings.json
@@ -62,6 +62,7 @@
     "NLPTopic": "nlp",
     "FileRequestTopic": "file-request",
     "NotificationTopic": "notify",
+    "HubTopic": "hub",
     "Producer": {
       "ClientId": "API",
       "BootstrapServers": "kafka-broker-0.kafka-headless:9092,kafka-broker-1.kafka-headless:9092,kafka-broker-2.kafka-headless:9092",
@@ -71,6 +72,13 @@
       "MessageSendMaxRetries": 10000000,
       "BatchSize": 16384,
       "LingerMs": 1
+    },
+    "Consumer": {
+      "GroupId": "API",
+      "BootstrapServers": "kafka-broker-0.kafka-headless:9092,kafka-broker-1.kafka-headless:9092,kafka-broker-2.kafka-headless:9092",
+      "AutoOffsetReset": "Earliest",
+      "MaxInFlight": 5,
+      "EnableAutoCommit": true
     }
   },
   "ElasticSearch": {

--- a/libs/net/core/Extensions/IEnumerableExtensions.cs
+++ b/libs/net/core/Extensions/IEnumerableExtensions.cs
@@ -40,5 +40,29 @@ public static class IEnumerableExtensions
         return items;
     }
 
+    /// <summary>
+    /// Removes all null values from enumerable.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="items"></param>
+    /// <returns></returns>
+    public static IEnumerable<T> WhereIsNotNull<T>(this IEnumerable<T> items)
+    {
+        return items.Where(i => i != null);
+    }
 
+    /// <summary>
+    /// Append the 'add' items to a copy of the specified 'list'.
+    /// This method does not change the original list.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="list"></param>
+    /// <param name="add"></param>
+    /// <returns></returns>
+    public static IList<T> AppendRange<T>(this IEnumerable<T> list, IEnumerable<T> add)
+    {
+        var result = new List<T>(list);
+        result.AddRange(add);
+        return result;
+    }
 }

--- a/libs/net/kafka/Config/KafkaHubConfig.cs
+++ b/libs/net/kafka/Config/KafkaHubConfig.cs
@@ -1,0 +1,36 @@
+using Confluent.Kafka;
+
+namespace TNO.Kafka;
+
+/// <summary>
+/// KafkaHubConfig class, provides a way to configure the Kafka Hub back-plane.
+/// </summary>
+public class KafkaHubConfig
+{
+    #region Properties
+    /// <summary>
+    /// get/set - Kafka admin client configuration.
+    /// </summary>
+    public AdminClientConfig AdminClient { get; set; } = new AdminClientConfig();
+
+    /// <summary>
+    /// get/set - Kafka consumer configuration.
+    /// </summary>
+    public ConsumerConfig Consumer { get; set; } = new ConsumerConfig();
+
+    /// <summary>
+    /// get/set - Kafka producer configuration.
+    /// </summary>
+    public ProducerConfig Producer { get; set; } = new ProducerConfig();
+
+    /// <summary>
+    /// get/set - Kafka hub topic to subscribe and push to.
+    /// </summary>
+    public string HubTopic { get; set; } = "";
+
+    /// <summary>
+    /// get/set - Number of milliseconds to delay after an exception occurs while consuming messages.
+    /// </summary>
+    public int ConsumerExceptionDelayMs { get; set; } = 1000;
+    #endregion
+}

--- a/libs/net/kafka/Extensions/ServiceCollectionExtensions.cs
+++ b/libs/net/kafka/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using Confluent.Kafka;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using TNO.Kafka.SignalR;
 
 namespace TNO.Kafka;
 
@@ -20,5 +22,37 @@ public static class ServiceCollectionExtensions
         return services
             .Configure<ProducerConfig>(config.GetSection("Kafka:Producer"))
             .AddScoped<IKafkaMessenger, KafkaMessenger>();
+    }
+
+    /// <summary>
+    /// Add the KafkaListener to the service collection with the default configuration.
+    /// </summary>
+    /// <typeparam name="TKey"></typeparam>
+    /// <typeparam name="TValue"></typeparam>
+    /// <param name="services"></param>
+    /// <param name="config"></param>
+    /// <returns></returns>
+    public static IServiceCollection AddKafkaListener(this IServiceCollection services, IConfiguration config)
+    {
+        return services
+            .Configure<ConsumerConfig>(config.GetSection("Kafka:Consumer"))
+            .AddScoped(typeof(IKafkaListener<,>), typeof(KafkaListener<,>));
+    }
+
+    /// <summary>
+    /// Add the KafkaHub to the service collection with the default configuration.
+    /// </summary>
+    /// <typeparam name="THub"></typeparam>
+    /// <param name="services"></param>
+    /// <param name="config"></param>
+    /// <returns></returns>
+    public static IServiceCollection AddKafkaHubBackplane(this IServiceCollection services, IConfiguration config)
+    {
+        return services
+            .Configure<KafkaHubConfig>(config.GetSection("Kafka"))
+            .Configure<ConsumerConfig>(config.GetSection("Kafka:Consumer"))
+            .Configure<ProducerConfig>(config.GetSection("Kafka:Producer"))
+            .AddSingleton<IUserIdProvider, HubUsernameProvider>()
+            .AddSingleton(typeof(HubLifetimeManager<>), typeof(KafkaHubLifetimeManager<>));
     }
 }

--- a/libs/net/kafka/Serializers/DefaultJsonSerializer.cs
+++ b/libs/net/kafka/Serializers/DefaultJsonSerializer.cs
@@ -16,7 +16,7 @@ public class DefaultJsonSerializer<T> : ISerializer<T>, IDeserializer<T>
 
     #region Constructors
     /// <summary>
-    /// Creates a new instandce of a DefaultJsonSerializer object, initializes with specified parameters.
+    /// Creates a new instance of a DefaultJsonSerializer object, initializes with specified parameters.
     /// </summary>
     /// <param name="options"></param>
     public DefaultJsonSerializer(IOptions<JsonSerializerOptions> options)
@@ -25,7 +25,7 @@ public class DefaultJsonSerializer<T> : ISerializer<T>, IDeserializer<T>
     }
 
     /// <summary>
-    /// Creates a new instandce of a DefaultJsonSerializer object, initializes with specified parameters.
+    /// Creates a new instance of a DefaultJsonSerializer object, initializes with specified parameters.
     /// </summary>
     /// <param name="options"></param>
     public DefaultJsonSerializer(JsonSerializerOptions options)

--- a/libs/net/kafka/SignalR/HubEvent.cs
+++ b/libs/net/kafka/SignalR/HubEvent.cs
@@ -1,0 +1,57 @@
+namespace TNO.Kafka.SignalR;
+
+public enum HubEvent
+{
+    /// <summary>
+    /// Called when a connection is started.
+    /// </summary>
+    Connected,
+    /// <summary>
+    /// Called when a connection is finished.
+    /// </summary>
+    Disconnected,
+    /// <summary>
+    /// Sends an invocation message to the specified connection.
+    /// </summary>
+    SendConnection,
+    /// <summary>
+    /// Sends an invocation message to the specified connections.
+    /// </summary>
+    SendConnections,
+    /// <summary>
+    /// Sends an invocation message to all hub connections.
+    /// </summary>
+    SendAll,
+    /// <summary>
+    /// Sends an invocation message to all hub connections excluding the specified connections.
+    /// </summary>
+    SendAllExcept,
+    /// <summary>
+    /// Adds a connection to the specified group.
+    /// </summary>
+    AddToGroup,
+    /// <summary>
+    /// Removes a connection from the specified group.
+    /// </summary>
+    RemoveFromGroup,
+    /// <summary>
+    /// Sends an invocation message to the specified group.
+    /// </summary>
+    SendGroup,
+    /// <summary>
+    /// Sends an invocation message to the specified group excluding the specified connections.
+    /// </summary>
+    SendGroupExcept,
+    /// <summary>
+    /// Sends an invocation message to the specified groups.
+    /// </summary>
+    SendGroups,
+    /// <summary>
+    /// Sends an invocation message to the specified user.
+    /// </summary>
+    SendUser,
+    /// <summary>
+    /// Sends an invocation message to the specified users.
+    /// </summary>
+    SendUsers
+}

--- a/libs/net/kafka/SignalR/HubUsernameProvider.cs
+++ b/libs/net/kafka/SignalR/HubUsernameProvider.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.SignalR;
+using TNO.Core.Extensions;
+
+namespace TNO.Kafka.SignalR;
+
+/// <summary>
+/// HubUsernameProvider class, provides a way to extract the username to uniquely identify the user.
+/// </summary>
+public class HubUsernameProvider : IUserIdProvider
+{
+    /// <summary>
+    /// Extract the username from the connection.
+    /// </summary>
+    /// <param name="connection"></param>
+    /// <returns></returns>
+    public string? GetUserId(HubConnectionContext connection)
+    {
+        return connection.User?.GetUsername();
+    }
+}

--- a/libs/net/kafka/SignalR/KafkaHubLifetimeManager`.cs
+++ b/libs/net/kafka/SignalR/KafkaHubLifetimeManager`.cs
@@ -1,0 +1,495 @@
+using System.Text.Json;
+using Confluent.Kafka;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.SignalR.Protocol;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using TNO.Core.Extensions;
+using TNO.Kafka.Serializers;
+
+namespace TNO.Kafka.SignalR;
+
+/// <summary>
+/// KafkaHubLifetimeManager class, provides a Kafka back-plane to support clusters.
+/// All messages are routed to Kafka.
+/// This hub is a Kafka consumer and will action the message once it consumes it.
+/// </summary>
+/// <typeparam name="THub"></typeparam>
+public class KafkaHubLifetimeManager<THub> : DefaultHubLifetimeManager<THub>, IDisposable
+    where THub : Hub
+{
+    #region Variables
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly KafkaHubConfig _kafkaConfig;
+    private readonly JsonSerializerOptions _serializerConfig;
+    private readonly ILogger _logger;
+    private bool disposed = false;
+    private readonly CancellationTokenSource _cancellationTokenSource;
+    private Task? _consumingTask;
+    #endregion
+
+    #region Properties
+    /// <summary>
+    /// get - The Kafka consumer.
+    /// </summary>
+    protected IConsumer<string, KafkaHubMessage> Consumer { get; private set; }
+
+    /// <summary>
+    /// get - The Kafka producer.
+    /// </summary>
+    protected IProducer<string, KafkaHubMessage> Producer { get; private set; }
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    /// Creates a new instance of a KafkaHubLifetimeManager object, initializes with specified parameters.
+    /// </summary>
+    /// <param name="httpContextAccessor"></param>
+    /// <param name="kafkaOptions"></param>
+    /// <param name="serializerOptions"></param>
+    /// <param name="logger"></param>
+    public KafkaHubLifetimeManager(
+        IHttpContextAccessor httpContextAccessor,
+        IOptions<KafkaHubConfig> kafkaOptions,
+        IOptions<JsonSerializerOptions> serializerOptions,
+        ILogger<KafkaHubLifetimeManager<THub>> logger)
+        : this(httpContextAccessor, kafkaOptions, null, serializerOptions, logger)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of a KafkaHubLifetimeManager object, initializes with specified parameters.
+    /// </summary>
+    /// <param name="httpContextAccessor"></param>
+    /// <param name="kafkaOptions"></param>
+    /// <param name="hubOptions"></param>
+    /// <param name="serializerOptions"></param>
+    /// <param name="logger"></param>
+    public KafkaHubLifetimeManager(
+        IHttpContextAccessor httpContextAccessor,
+        IOptions<KafkaHubConfig> kafkaOptions,
+        IOptions<HubOptions<THub>>? hubOptions,
+        IOptions<JsonSerializerOptions> serializerOptions,
+        ILogger<KafkaHubLifetimeManager<THub>> logger)
+        : base(logger)
+    {
+        _cancellationTokenSource = new CancellationTokenSource();
+        _httpContextAccessor = httpContextAccessor;
+        _serializerConfig = serializerOptions.Value;
+        _kafkaConfig = kafkaOptions.Value;
+        _logger = logger;
+        this.Consumer = BuildConsumer();
+        this.Consumer.Subscribe(_kafkaConfig.HubTopic);
+        StartConsuming(_cancellationTokenSource.Token);
+
+        this.Producer = BuildProducer();
+    }
+    #endregion
+
+    #region Methods
+    /// <summary>
+    /// Dispose KafkaHubLifetimeManager.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Dispose KafkaHubLifetimeManager.
+    /// </summary>
+    /// <param name="disposing"></param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposed)
+        {
+            if (disposing)
+            {
+                this.Consumer.Unsubscribe();
+                if (_consumingTask != null)
+                {
+                    _cancellationTokenSource.Cancel();
+                    if (_consumingTask.IsCompleted)
+                        _consumingTask.Dispose();
+                }
+                _cancellationTokenSource.Dispose();
+                this.Consumer.Dispose();
+            }
+            disposed = true;
+        }
+    }
+
+    /// <summary>
+    /// Create a Kafka key for each message.
+    /// Default is the user's email address with a prefix.
+    /// </summary>
+    /// <param name="prefix"></param>
+    /// <returns></returns>
+    protected string CreateKey(string prefix)
+    {
+        return $"{prefix}-{_httpContextAccessor.HttpContext?.User.GetEmail() ?? "anonymous"}";
+    }
+
+    /// <summary>
+    /// Creates a new Kafka message containing the hub event message.
+    /// </summary>
+    /// <param name="hubEvent"></param>
+    /// <param name="methodName"></param>
+    /// <param name="args"></param>
+    /// <param name="excludedConnectionIds"></param>
+    /// <returns></returns>
+    protected Message<string, KafkaHubMessage> CreateMessage(HubEvent hubEvent, string methodName, object?[] args, IReadOnlyList<string>? excludedConnectionIds = null)
+    {
+        return CreateMessage(hubEvent, "", methodName, args, excludedConnectionIds);
+    }
+
+    /// <summary>
+    /// Creates a new Kafka message containing the hub event message.
+    /// </summary>
+    /// <param name="hubEvent"></param>
+    /// <param name="groupName"></param>
+    /// <param name="methodName"></param>
+    /// <param name="args"></param>
+    /// <param name="excludedConnectionIds"></param>
+    /// <returns></returns>
+    protected Message<string, KafkaHubMessage> CreateMessage(HubEvent hubEvent, string groupName, string methodName, object?[] args, IReadOnlyList<string>? excludedConnectionIds = null)
+    {
+        return CreateMessage(hubEvent, new String[] { groupName }, methodName, args, excludedConnectionIds);
+    }
+
+    /// <summary>
+    /// Creates a new Kafka message containing the hub event message.
+    /// </summary>
+    /// <param name="hubEvent"></param>
+    /// <param name="groupNames"></param>
+    /// <param name="methodName"></param>
+    /// <param name="args"></param>
+    /// <param name="excludedConnectionIds"></param>
+    /// <returns></returns>
+    protected Message<string, KafkaHubMessage> CreateMessage(HubEvent hubEvent, IEnumerable<string> groupNames, string methodName, object?[] args, IReadOnlyList<string>? excludedConnectionIds = null)
+    {
+        return new Message<string, KafkaHubMessage>()
+        {
+            Key = CreateKey(methodName),
+            Value = new KafkaHubMessage(hubEvent, groupNames, new InvocationMessage(methodName, args), excludedConnectionIds)
+        };
+    }
+
+    #region Hub Event Methods
+    /// <summary>
+    /// Invoke the connection for the specified 'connectionId' and 'methodName'.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="connectionId"></param>
+    /// <param name="methodName"></param>
+    /// <param name="args"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public override Task<T> InvokeConnectionAsync<T>(string connectionId, string methodName, object?[] args, CancellationToken cancellationToken)
+    {
+        return base.InvokeConnectionAsync<T>(connectionId, methodName, args, cancellationToken);
+    }
+
+    /// <summary>
+    /// On connected inform the hub.
+    /// </summary>
+    /// <param name="connection"></param>
+    /// <returns></returns>
+    public override Task OnConnectedAsync(HubConnectionContext connection)
+    {
+        return base.OnConnectedAsync(connection);
+    }
+
+    /// <summary>
+    /// On disconnected inform the hub.
+    /// </summary>
+    /// <param name="connection"></param>
+    /// <returns></returns>
+    public override Task OnDisconnectedAsync(HubConnectionContext connection)
+    {
+        return base.OnDisconnectedAsync(connection);
+    }
+
+    /// <summary>
+    /// Set the connection results for the specified 'connectionId'.
+    /// </summary>
+    /// <param name="connectionId"></param>
+    /// <param name="result"></param>
+    /// <returns></returns>
+    public override Task SetConnectionResultAsync(string connectionId, CompletionMessage result)
+    {
+        return base.SetConnectionResultAsync(connectionId, result);
+    }
+
+    /// <summary>
+    /// Send a connection message for the specified 'connectionId' and 'methodName'.
+    /// </summary>
+    /// <param name="connectionId"></param>
+    /// <param name="methodName"></param>
+    /// <param name="args"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public override Task SendConnectionAsync(string connectionId, string methodName, object?[] args, CancellationToken cancellationToken = default)
+    {
+        return base.SendConnectionAsync(connectionId, methodName, args, cancellationToken);
+    }
+
+    /// <summary>
+    /// Send a connection message for all the specified 'connectionIds' and 'methodName'.
+    /// </summary>
+    /// <param name="connectionIds"></param>
+    /// <param name="methodName"></param>
+    /// <param name="args"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public override Task SendConnectionsAsync(IReadOnlyList<string> connectionIds, string methodName, object?[] args, CancellationToken cancellationToken = default)
+    {
+        return base.SendConnectionsAsync(connectionIds, methodName, args, cancellationToken);
+    }
+
+    /// <summary>
+    /// Send message to Kafka back-plane.
+    /// </summary>
+    /// <param name="methodName"></param>
+    /// <param name="args"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public override async Task SendAllAsync(string methodName, object?[] args, CancellationToken cancellationToken = default)
+    {
+        var message = CreateMessage(HubEvent.SendAll, methodName, args);
+        await this.Producer.ProduceAsync(_kafkaConfig.HubTopic, message, cancellationToken);
+    }
+
+    /// <summary>
+    /// Send message to Kafka back-plane.
+    /// </summary>
+    /// <param name="methodName"></param>
+    /// <param name="args"></param>
+    /// <param name="excludedConnectionIds"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public override async Task SendAllExceptAsync(string methodName, object?[] args, IReadOnlyList<string> excludedConnectionIds, CancellationToken cancellationToken = default)
+    {
+        var message = CreateMessage(HubEvent.SendAllExcept, methodName, args, excludedConnectionIds);
+        await this.Producer.ProduceAsync(_kafkaConfig.HubTopic, message, cancellationToken);
+    }
+
+    /// <summary>
+    /// Add specified 'connectionId' to the 'groupName'.
+    /// </summary>
+    /// <param name="connectionId"></param>
+    /// <param name="groupName"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public override Task AddToGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default)
+    {
+        return base.AddToGroupAsync(connectionId, groupName, cancellationToken);
+    }
+
+    /// <summary>
+    /// Remove the specified 'connectionId' from the 'groupName'.
+    /// </summary>
+    /// <param name="connectionId"></param>
+    /// <param name="groupName"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public override Task RemoveFromGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default)
+    {
+        return base.RemoveFromGroupAsync(connectionId, groupName, cancellationToken);
+    }
+
+    /// <summary>
+    /// Send message to Kafka back-plane.
+    /// </summary>
+    /// <param name="groupName"></param>
+    /// <param name="methodName"></param>
+    /// <param name="args"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public override async Task SendGroupAsync(string groupName, string methodName, object?[] args, CancellationToken cancellationToken = default)
+    {
+        var message = CreateMessage(HubEvent.SendGroup, groupName, methodName, args);
+        await this.Producer.ProduceAsync(_kafkaConfig.HubTopic, message, cancellationToken);
+    }
+
+    /// <summary>
+    /// Send message to Kafka back-plane.
+    /// </summary>
+    /// <param name="groupName"></param>
+    /// <param name="methodName"></param>
+    /// <param name="args"></param>
+    /// <param name="excludedConnectionIds"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public override async Task SendGroupExceptAsync(string groupName, string methodName, object?[] args, IReadOnlyList<string> excludedConnectionIds, CancellationToken cancellationToken = default)
+    {
+        var message = CreateMessage(HubEvent.SendGroupExcept, groupName, methodName, args, excludedConnectionIds);
+        await this.Producer.ProduceAsync(_kafkaConfig.HubTopic, message, cancellationToken);
+    }
+
+    /// <summary>
+    /// Send message to Kafka back-plane.
+    /// </summary>
+    /// <param name="groupNames"></param>
+    /// <param name="methodName"></param>
+    /// <param name="args"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public override async Task SendGroupsAsync(IReadOnlyList<string> groupNames, string methodName, object?[] args, CancellationToken cancellationToken = default)
+    {
+        var message = CreateMessage(HubEvent.SendGroups, groupNames, methodName, args, null);
+        await this.Producer.ProduceAsync(_kafkaConfig.HubTopic, message, cancellationToken);
+    }
+
+    /// <summary>
+    /// Send message to Kafka back-plane.
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <param name="methodName"></param>
+    /// <param name="args"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public override async Task SendUserAsync(string userId, string methodName, object?[] args, CancellationToken cancellationToken = default)
+    {
+        var message = CreateMessage(HubEvent.SendUser, userId, methodName, args);
+        await this.Producer.ProduceAsync(_kafkaConfig.HubTopic, message, cancellationToken);
+    }
+
+    /// <summary>
+    /// Send message to Kafka back-plane.
+    /// </summary>
+    /// <param name="userIds"></param>
+    /// <param name="methodName"></param>
+    /// <param name="args"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public override async Task SendUsersAsync(IReadOnlyList<string> userIds, string methodName, object?[] args, CancellationToken cancellationToken = default)
+    {
+        var message = CreateMessage(HubEvent.SendUsers, userIds, methodName, args, null);
+        await this.Producer.ProduceAsync(_kafkaConfig.HubTopic, message, cancellationToken);
+    }
+    #endregion
+
+    #region Kafka Producer Methods
+    /// <summary>
+    /// Build a Kafka producer with configured options.
+    /// </summary>
+    /// <returns></returns>
+    protected IProducer<string, KafkaHubMessage> BuildProducer()
+    {
+        var builder = new ProducerBuilder<string, KafkaHubMessage>(_kafkaConfig.Producer);
+        builder.SetKeySerializer(new DefaultJsonSerializer<string>(_serializerConfig));
+        builder.SetValueSerializer(new DefaultJsonSerializer<KafkaHubMessage>(_serializerConfig));
+        return builder.Build();
+    }
+    #endregion
+
+    #region Kafka Consumer Methods
+    /// <summary>
+    /// Build a Kafka consumer with configured options.
+    /// </summary>
+    /// <returns></returns>
+    protected IConsumer<string, KafkaHubMessage> BuildConsumer()
+    {
+        var builder = new ConsumerBuilder<string, KafkaHubMessage>(_kafkaConfig.Consumer);
+        builder.SetKeyDeserializer(new DefaultJsonSerializer<string>(_serializerConfig));
+        builder.SetValueDeserializer(new DefaultJsonSerializer<KafkaHubMessage>(_serializerConfig));
+        return builder.Build();
+    }
+
+    /// <summary>
+    /// Start consuming messages from Kafka.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    private void StartConsuming(CancellationToken cancellationToken)
+    {
+        _consumingTask = Task.Run(async () =>
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    var result = this.Consumer.Consume(cancellationToken);
+                    if (result == null)
+                        continue;
+
+                    await ConsumeMessageAsync(result, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Kafka consumer failed");
+                    await Task.Delay(_kafkaConfig.ConsumerExceptionDelayMs);
+                }
+            }
+        }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Handle messages received from Kafka consumer.
+    /// Pass all messages to inherited Hub message handle so that each instance of the hub will communicate to users connected to it.
+    /// </summary>
+    /// <param name="consumeResult"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    protected async Task ConsumeMessageAsync(ConsumeResult<string, KafkaHubMessage> consumeResult, CancellationToken cancellationToken)
+    {
+        var model = consumeResult.Message.Value;
+        var message = model.Message;
+        _logger.LogDebug("Message received for {event}:{target}", model.HubEvent, message.Target);
+        switch (model.HubEvent)
+        {
+            case HubEvent.SendAll:
+                await base.SendAllAsync(message.Target, message.Arguments, cancellationToken);
+                break;
+            case HubEvent.SendAllExcept:
+                await base.SendAllExceptAsync(
+                    message.Target,
+                    message.Arguments,
+                    model.ExcludedConnectionIds ?? throw new InvalidOperationException("Message missing excluded connection ids."),
+                    cancellationToken);
+                break;
+            case HubEvent.SendGroup:
+                await base.SendGroupAsync(
+                    model.Identifiers?.First() ?? throw new InvalidOperationException("Message missing group name."),
+                    message.Target,
+                    message.Arguments,
+                    cancellationToken);
+                break;
+            case HubEvent.SendGroupExcept:
+                await base.SendGroupExceptAsync(
+                    model.Identifiers?.First() ?? throw new InvalidOperationException("Message missing group name."),
+                    message.Target,
+                    message.Arguments,
+                    model.ExcludedConnectionIds ?? throw new InvalidOperationException("Message missing excluded connection ids."),
+                    cancellationToken);
+                break;
+            case HubEvent.SendGroups:
+                await base.SendGroupsAsync(
+                    model.Identifiers ?? throw new InvalidOperationException("Message missing group names."),
+                    message.Target,
+                    message.Arguments,
+                    cancellationToken);
+                break;
+            case HubEvent.SendUser:
+                await base.SendUserAsync(
+                    model.Identifiers?.First() ?? throw new InvalidOperationException("Message missing user id."),
+                    message.Target,
+                    message.Arguments,
+                    cancellationToken);
+                break;
+            case HubEvent.SendUsers:
+                await base.SendUsersAsync(
+                    model.Identifiers ?? throw new InvalidOperationException("Message missing user ids."),
+                    message.Target,
+                    message.Arguments,
+                    cancellationToken);
+                break;
+            default:
+                throw new NotImplementedException("Hub event is not implemented.");
+        }
+    }
+    #endregion
+    #endregion
+}

--- a/libs/net/kafka/SignalR/KafkaHubMessage.cs
+++ b/libs/net/kafka/SignalR/KafkaHubMessage.cs
@@ -1,0 +1,76 @@
+using Microsoft.AspNetCore.SignalR.Protocol;
+
+namespace TNO.Kafka.SignalR;
+
+/// <summary>
+/// KafkaHubMessage class, provides a serializable message for the Kafka hub back-plane.
+/// </summary>
+public class KafkaHubMessage
+{
+    #region Properties
+    /// <summary>
+    /// get/set - The hub event that occurred.
+    /// </summary>
+    public HubEvent HubEvent { get; set; }
+
+    /// <summary>
+    /// get/set - The user Id or group name to send the message to.
+    /// </summary>
+    public string[]? Identifiers { get; set; }
+
+    /// <summary>
+    /// get/set - The message to send.
+    /// </summary>
+    public KafkaInvocationMessage Message { get; set; } = default!;
+
+    /// <summary>
+    /// get/set - Exclude the following connection ids when broadcasting this message.
+    /// </summary>
+    public string[]? ExcludedConnectionIds { get; set; }
+    #endregion
+
+    #region Constructor
+    /// <summary>
+    /// Creates a new instance of a KafakHubMessage object.
+    /// </summary>
+    public KafkaHubMessage() { }
+
+    /// <summary>
+    /// Creates a new instance of a KafakHubMessage object, initializes with specified parameters.
+    /// </summary>
+    /// <param name="hubEvent"></param>
+    /// <param name="message"></param>
+    /// <param name="excludedConnectionIds"></param>
+    public KafkaHubMessage(HubEvent hubEvent, InvocationMessage message, IEnumerable<string>? excludedConnectionIds = null)
+    {
+        this.HubEvent = hubEvent;
+        this.Message = new KafkaInvocationMessage(message);
+        this.ExcludedConnectionIds = excludedConnectionIds?.ToArray();
+    }
+
+    /// <summary>
+    /// Creates a new instance of a KafakHubMessage object, initializes with specified parameters.
+    /// </summary>
+    /// <param name="hubEvent"></param>
+    /// <param name="identifier"></param>
+    /// <param name="message"></param>
+    /// <param name="excludedConnectionIds"></param>
+    public KafkaHubMessage(HubEvent hubEvent, string identifier, InvocationMessage message, IEnumerable<string>? excludedConnectionIds = null)
+        : this(hubEvent, new[] { identifier }, message, excludedConnectionIds)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of a KafakHubMessage object, initializes with specified parameters.
+    /// </summary>
+    /// <param name="hubEvent"></param>
+    /// <param name="identifiers"></param>
+    /// <param name="message"></param>
+    /// <param name="excludedConnectionIds"></param>
+    public KafkaHubMessage(HubEvent hubEvent, IEnumerable<string> identifiers, InvocationMessage message, IEnumerable<string>? excludedConnectionIds = null)
+        : this(hubEvent, message, excludedConnectionIds)
+    {
+        this.Identifiers = identifiers.ToArray();
+    }
+    #endregion
+}

--- a/libs/net/kafka/SignalR/KafkaInvocationMessage.cs
+++ b/libs/net/kafka/SignalR/KafkaInvocationMessage.cs
@@ -1,0 +1,61 @@
+using Microsoft.AspNetCore.SignalR.Protocol;
+
+namespace TNO.Kafka.SignalR;
+
+/// <summary>
+/// KafkaInvocationMessage class, provides a serializable model to pass invocation messages to the Kafka back-plane.
+/// </summary>
+public class KafkaInvocationMessage
+{
+    #region Properties
+    /// <summary>
+    /// get/set - The invocation Id.
+    /// </summary>
+    public string? InvocationId { get; set; }
+
+    /// <summary>
+    /// get/set - The target (or method name).
+    /// </summary>
+    public string Target { get; set; } = "";
+
+    /// <summary>
+    /// get/set - Array of arguments sent with the message.
+    /// </summary>
+    public object?[] Arguments { get; set; } = Array.Empty<object>();
+
+    /// <summary>
+    /// get/set - An array of stream Ids.
+    /// </summary>
+    public string[]? StreamIds { get; set; }
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    /// Creates a new instance of a KafkaInvocationMessage object.
+    /// </summary>
+    public KafkaInvocationMessage() { }
+
+    /// <summary>
+    /// Creates a new instance of a KafkaInvocationMessage object, initializes with specified parameters.
+    /// </summary>
+    /// <param name="message"></param>
+    public KafkaInvocationMessage(InvocationMessage message)
+    {
+        this.InvocationId = message.InvocationId;
+        this.Target = message.Target;
+        this.Arguments = message.Arguments;
+        this.StreamIds = message.StreamIds;
+    }
+    #endregion
+
+    #region Methods
+    /// <summary>
+    /// Convert serialized object to invocation message.
+    /// </summary>
+    /// <param name="obj"></param>
+    public static implicit operator InvocationMessage(KafkaInvocationMessage obj)
+    {
+        return new InvocationMessage(obj.InvocationId, obj.Target, obj.Arguments, obj.StreamIds);
+    }
+    #endregion
+}

--- a/openshift/kustomize/api/base/kustomization.yaml
+++ b/openshift/kustomize/api/base/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 resources:
   - pvc.yaml
   - config-map.yaml
-  - deploy.yaml
+  - statefulset.yaml
   - service.yaml
   - route.yaml
 

--- a/openshift/kustomize/api/base/statefulset.yaml
+++ b/openshift/kustomize/api/base/statefulset.yaml
@@ -1,12 +1,11 @@
 ---
-# How the app will be deployed to the pod.
-kind: DeploymentConfig
-apiVersion: apps.openshift.io/v1
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
   name: api
   namespace: default
   annotations:
-    description: Defines how to deploy api
+    description: Deploy API
   labels:
     name: api
     part-of: tno
@@ -14,20 +13,19 @@ metadata:
     component: api
     managed-by: kustomize
     created-by: jeremy.foster
+    cluster: api-cluster
 spec:
+  serviceName: api
   replicas: 3
-  test: false
-  selector:
-    part-of: tno
-    component: api
-  strategy:
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
     rollingParams:
       intervalSeconds: 1
       maxSurge: 25%
       maxUnavailable: 25%
       timeoutSeconds: 600
       updatePeriodSeconds: 1
-    type: Rolling
   triggers:
     - type: ConfigChange
     - type: ImageChange
@@ -39,17 +37,32 @@ spec:
           kind: ImageStreamTag
           namespace: 9b301c-tools
           name: api:dev
+  selector:
+    matchLabels:
+      statefulset: api-cluster
   template:
     metadata:
-      name: api
       labels:
         part-of: tno
         component: api
+        statefulset: api-cluster
     spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
+      schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 30
+      serviceAccountName: tno
+      terminationGracePeriodSeconds: 0
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: statefulset
+                    operator: In
+                    values:
+                      - api-cluster
+              topologyKey: "kubernetes.io/hostname"
       volumes:
         - name: file-storage
           persistentVolumeClaim:
@@ -134,11 +147,10 @@ spec:
                   name: api
                   key: CSS_SECRET
 
-            - name: KAFKA_BOOTSTRAP_SERVERS
+            - name: Kafka__Consumer__GroupId
               valueFrom:
-                configMapKeyRef:
-                  name: api
-                  key: KAFKA_BOOTSTRAP_SERVERS
+                fieldRef:
+                  fieldPath: metadata.name
 
             - name: ConnectionStrings__TNO
               valueFrom:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -173,6 +173,7 @@ services:
     profiles:
       - all
       - service
+      - main
     restart: "no"
     container_name: tno-indexing
     build:

--- a/services/net/clip/ClipManager.cs
+++ b/services/net/clip/ClipManager.cs
@@ -37,11 +37,11 @@ public class ClipManager : IngestManager<ClipIngestActionManager, ClipOptions>
     public override async Task<IEnumerable<IngestModel>> GetIngestsAsync()
     {
         var ingests = await base.GetIngestsAsync();
-        var serviceType = !String.IsNullOrWhiteSpace(this.Options.ServiceType) ? this.Options.ServiceType : "clip";
         var hostname = System.Environment.GetEnvironmentVariable("HOSTNAME");
+        var serviceTypes = this.Options.GetServiceTypes();
 
         return ingests.Where(i =>
-            i.GetConfigurationValue("serviceType") == serviceType &&
+            (!serviceTypes.Any() || serviceTypes.Any(st => st == i.GetConfigurationValue("serviceType"))) &&
             (String.IsNullOrWhiteSpace(i.GetConfigurationValue("hostname")) ||
                 i.GetConfigurationValue("hostname") == hostname) &&
             (String.IsNullOrWhiteSpace(this.Options.DataLocation) ||


### PR DESCRIPTION
SignalR maintains state locally and is unaware of other instances of the API that may be running.  When running the API as a cluster (more than one pod) it requires a SignalR backpane to support broadcasting messages to every pod.  A Kafka Hub backpane has been created to support clusters.

All messages sent to the Hub will be initially published to Kafka.  The API is now a Kafka Consumer which will then receive the latest message and send it to the appropriate user now mater which pod they are connected to.

For all this to work the API will need to be reconfigured as a statefulset so that each pod will have a consistent and different Kafka Consumer Group ID.  Otherwise they would not all receive each message, or they would end generating new Group ID values that would result in receiving all messages again.

In addition, we are now able to send messages directly to a single user instead of broadcasting to all users.

## Highlights

- Fixed bug with Clip Service
- Added Indexing Service to `make up p=main` because we are now using Elasticsearch for results
- Update your API with `make refresh n=api` once this PR is merged