### PR TITLE
Add filter to reindex

### DIFF
--- a/api/net/Areas/Editor/Controllers/ContentController.cs
+++ b/api/net/Areas/Editor/Controllers/ContentController.cs
@@ -101,11 +101,11 @@ public class ContentController : ControllerBase
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType(typeof(IPaged<ContentModel>), (int)HttpStatusCode.OK)]
     [SwaggerOperation(Tags = new[] { "Content" })]
-    public IActionResult Find()
+    public IActionResult FindWithDatabase()
     {
         var uri = new Uri(this.Request.GetDisplayUrl());
         var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
-        var result = _contentService.Find(new ContentFilter(query));
+        var result = _contentService.FindWithDatabase(new ContentFilter(query));
         var page = new Paged<ContentModel>(result.Items.Select(i => new ContentModel(i)), result.Page, result.Quantity, result.Total);
         return new JsonResult(page);
     }

--- a/api/net/Areas/Editor/Controllers/MorningReportController.cs
+++ b/api/net/Areas/Editor/Controllers/MorningReportController.cs
@@ -80,7 +80,7 @@ public class MorningReportController : ControllerBase
     [SwaggerOperation(Tags = new[] { "Morning-Report" })]
     public async Task<IActionResult> UpdateContentAsync(ContentListModel model)
     {
-        var items = _contentService.Find(new ContentFilter()
+        var items = _contentService.FindWithDatabase(new ContentFilter()
         {
             Quantity = model.ContentIds.Count(),
             ContentIds = model.ContentIds.ToArray()

--- a/api/net/Program.cs
+++ b/api/net/Program.cs
@@ -272,20 +272,21 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.UseDeveloperExceptionPage();
-    app.UseSwagger(options =>
-    {
-        options.RouteTemplate = config.GetValue<string>("Swagger:RouteTemplate");
-    });
-    app.UseSwaggerUI(options =>
-    {
-        var apiVersionProvider = app.Services.GetRequiredService<IApiVersionDescriptionProvider>();
-        foreach (var description in apiVersionProvider.ApiVersionDescriptions)
-        {
-            options.SwaggerEndpoint(String.Format(config.GetValue<string>("Swagger:EndpointPath") ?? "", description.GroupName), description.GroupName);
-        }
-        options.RoutePrefix = config.GetValue<string>("Swagger:RoutePrefix");
-    });
 }
+
+app.UseSwagger(options =>
+{
+    options.RouteTemplate = config.GetValue<string>("Swagger:RouteTemplate");
+});
+app.UseSwaggerUI(options =>
+{
+    var apiVersionProvider = app.Services.GetRequiredService<IApiVersionDescriptionProvider>();
+    foreach (var description in apiVersionProvider.ApiVersionDescriptions)
+    {
+        options.SwaggerEndpoint(String.Format(config.GetValue<string>("Swagger:EndpointPath") ?? "", description.GroupName), description.GroupName);
+    }
+    options.RoutePrefix = config.GetValue<string>("Swagger:RoutePrefix");
+});
 
 app.UsePathBase(config.GetValue<string>("BaseUrl"));
 app.UseForwardedHeaders();

--- a/libs/net/dal/Services/ContentService.cs
+++ b/libs/net/dal/Services/ContentService.cs
@@ -1,7 +1,6 @@
 using System.Linq.Expressions;
 using System.Security.Claims;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Nest;
 using TNO.DAL.Extensions;
@@ -31,7 +30,6 @@ public class ContentService : BaseService<Content, long>, IContentService
     public ContentService(TNOContext dbContext,
         ClaimsPrincipal principal,
         IServiceProvider serviceProvider,
-        IConfiguration config,
         IElasticClient client,
         ILogger<ContentService> logger) : base(dbContext, principal, serviceProvider, logger)
     {
@@ -46,7 +44,7 @@ public class ContentService : BaseService<Content, long>, IContentService
     /// <param name="filter">Filter to apply to the query.</param>
     /// <param name="asNoTracking">Whether to load into context or not</param>
     /// <returns>A page of content items that match the filter.</returns>
-    public IPaged<Content> Find(ContentFilter filter, bool asNoTracking = true)
+    public IPaged<Content> FindWithDatabase(ContentFilter filter, bool asNoTracking = true)
     {
         var query = this.Context.Contents
             .Include(c => c.Product)
@@ -357,7 +355,8 @@ public class ContentService : BaseService<Content, long>, IContentService
             filterQueries.Add(s => s.Match(m => m.Field(p => p.Status).Query(filter.Status.Value.ToString())));
         }
 
-        var response = await _client.SearchAsync<Content>(s => {
+        var response = await _client.SearchAsync<Content>(s =>
+        {
             var result = s
                 .Pretty()
                 .Index(_client.ConnectionSettings.DefaultIndex)

--- a/libs/net/dal/Services/Interfaces/IContentService.cs
+++ b/libs/net/dal/Services/Interfaces/IContentService.cs
@@ -7,7 +7,7 @@ namespace TNO.DAL.Services;
 
 public interface IContentService : IBaseService<Content, long>
 {
-    IPaged<Content> Find(ContentFilter filter, bool asNoTracking = true);
+    IPaged<Content> FindWithDatabase(ContentFilter filter, bool asNoTracking = true);
     Task<IPaged<Content>> FindWithElasticsearchAsync(ContentFilter filter);
     Content? FindByUid(string uid, string? source);
 }

--- a/libs/net/reports/CBRAReport.cs
+++ b/libs/net/reports/CBRAReport.cs
@@ -72,7 +72,7 @@ public class CBRAReport
             UpdatedStartOn = utcFrom,
             UpdatedEndOn = utcTo
         };
-        var page = contentService.Find(filter); // TODO: Asking for a page isn't ideal.
+        var page = contentService.FindWithDatabase(filter); // TODO: Asking for a page isn't ideal.
 
         // TODO: This is horrible, but hibernate is a mess. Need to make this more
         // performant.

--- a/openshift/kustomize/tekton/base/pipelines/buildah-main.yaml
+++ b/openshift/kustomize/tekton/base/pipelines/buildah-main.yaml
@@ -302,6 +302,7 @@ spec:
       runAfter:
         - deploy-api
         - deploy-editor
+        - deploy-subscriber
       taskRef:
         name: oc-patch-route
         kind: Task
@@ -316,6 +317,7 @@ spec:
     - name: maintenance-off-subscriber
       runAfter:
         - deploy-api
+        - deploy-editor
         - deploy-subscriber
       taskRef:
         name: oc-patch-route


### PR DESCRIPTION
Currently the reindex endpoint attempts to reindex everything.  However, this timeout quickly.  This update provides a way to apply query parameter filter which will allow reindexing smaller subsets.

Also adding swagger to all builds instead of just development.