### PR TITLE
WYSIWYG font size consistency

### DIFF
--- a/app/editor/src/components/form/wysiwyg/styled/Wysiwyg.tsx
+++ b/app/editor/src/components/form/wysiwyg/styled/Wysiwyg.tsx
@@ -26,10 +26,8 @@ export const Wysiwyg = styled.div<IWysiwygProps>`
   .ql-editor {
     min-height: 25rem;
     height: ${(props) => props.hasHeight && '43rem'};
-    p {
-      font-family: ${(props) => props.theme.css?.bcSans};
-      font-size: 1rem;
-    }
+    font-family: ${(props) => props.theme.css?.bcSans};
+    font-size: 1rem;
   }
   .raw-editor {
     margin: 0;


### PR DESCRIPTION
Not a hard one at all.
<img width="465" alt="image" src="https://user-images.githubusercontent.com/15724124/220976384-9cce92ab-a56f-44eb-8ebf-2423715e3058.png">
