### PR TITLE
TNO-1113 Fix delete content

### DIFF
--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -138,10 +138,11 @@ export const ContentForm: React.FC<IContentFormProps> = ({
           setContentType(content.contentType);
         } else {
           toast.error('Content requested could not be found.');
+          navigate('/contents');
         }
       });
     },
-    [getContent, findWorkOrders],
+    [getContent, findWorkOrders, navigate],
   );
 
   const onWorkOrder = React.useCallback(

--- a/app/editor/src/store/hooks/useAjaxWrapper.ts
+++ b/app/editor/src/store/hooks/useAjaxWrapper.ts
@@ -39,7 +39,7 @@ export const useAjaxWrapper = () => {
           else if (typeof data === 'string' && !!data) message = data;
           else if (!!data?.error) {
             message = `${data?.error}`;
-            detail = data?.details;
+            detail = message.trim() !== data?.details?.trim() ? data?.details : undefined;
           } else if (!!data?.errors) {
             message = Object.entries(data.errors)
               .map((p) => p.toString())


### PR DESCRIPTION
Updated the delete content process so that the Indexing Service will no longer make a request for the content before attempting to delete it.

This does require changing the key we use in Elasticsearch.  Which means I need to delete the index and rebuild it.