### PR TITLE
Save without publish bug

### DIFF
--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -676,6 +676,7 @@ export const ContentForm: React.FC<IContentFormProps> = ({
                     variant={ButtonVariant.secondary}
                     disabled={props.isSubmitting}
                     onClick={() => setSavePressed(true)}
+                    type="submit"
                   >
                     Save without publishing
                   </Button>


### PR DESCRIPTION
Looks like a small bug was introduced when rearranging the buttons. This will now correctly trigger the submission 