### PR TITLE
TNO-1058: Content scrolling

### DIFF
--- a/app/editor/src/features/content/list-view/ContentListView.tsx
+++ b/app/editor/src/features/content/list-view/ContentListView.tsx
@@ -142,6 +142,9 @@ export const ContentListView: React.FC = () => {
   const handleRowClick = (row: TRow<IContentModel>) => {
     setContentType(row.original.contentType);
     navigate(`/contents/combined/${row.original.id}`);
+    document.getElementById('bottom-pane')?.scrollIntoView({
+      behavior: 'smooth',
+    });
   };
 
   return (
@@ -166,7 +169,7 @@ export const ContentListView: React.FC = () => {
         </Row>
         <Show visible={combined}>
           <hr />
-          <Row className="bottom-pane">
+          <Row className="bottom-pane" id="bottom-pane">
             <ContentForm contentType={contentType} />
           </Row>
         </Show>

--- a/app/editor/src/features/content/list-view/constants/columns.tsx
+++ b/app/editor/src/features/content/list-view/constants/columns.tsx
@@ -1,5 +1,5 @@
 import { ContentStatusName, ContentTypeName, IContentModel } from 'hooks/api-editor';
-import { FaFeather } from 'react-icons/fa';
+import { FaExternalLinkAlt, FaFeather, FaInfoCircle } from 'react-icons/fa';
 import { Column, UseSortByColumnOptions } from 'react-table';
 import { CellCheckbox, CellDate, CellEllipsis, Show } from 'tno-core';
 import { formatIdirUsername } from 'utils/formatIdir';
@@ -11,7 +11,7 @@ export const columns: (Column<IContentModel> & UseSortByColumnOptions<IContentMo
     id: 'id',
     Header: 'Headline',
     accessor: 'headline',
-    width: 5,
+    width: 4,
     Cell: (cell) => (
       <CellEllipsis data-for="main-tooltip" data-tip={cell.value} className="headline">
         <Show
@@ -85,6 +85,16 @@ export const columns: (Column<IContentModel> & UseSortByColumnOptions<IContentMo
           <CellCheckbox checked={value} />
         </div>
       );
+    },
+  },
+  {
+    id: 'newTab',
+    Header: () => <FaInfoCircle data-for="main-tooltip" data-tip="Open snippet in new tab" />,
+    disableSortBy: true,
+    width: 1,
+    accessor: (row) => row.id,
+    Cell: ({ value }: { value: number }) => {
+      return <FaExternalLinkAlt onClick={() => window.open(`/contents/${value}`, '_blank')} />;
     },
   },
 ];


### PR DESCRIPTION
- new icon on content list view rows to open snippets in new tabs (header as hover tooltip to save space/ as per discussion with Bobbi)
- now when clicking a row on the content list view it will scroll the content form into view (see GIF below)
![content-scroll](https://user-images.githubusercontent.com/15724124/221719179-bbcbde81-874d-4d86-aec8-a4c4ac41f28a.gif)
