### PR TITLE
Content Scroll - Bug Fix

### DIFF
--- a/app/editor/src/features/content/list-view/ContentListView.tsx
+++ b/app/editor/src/features/content/list-view/ContentListView.tsx
@@ -142,9 +142,6 @@ export const ContentListView: React.FC = () => {
   const handleRowClick = (row: TRow<IContentModel>) => {
     setContentType(row.original.contentType);
     navigate(`/contents/combined/${row.original.id}`);
-    document.getElementById('bottom-pane')?.scrollIntoView({
-      behavior: 'smooth',
-    });
   };
 
   return (

--- a/app/editor/src/hooks/useCombinedView.ts
+++ b/app/editor/src/hooks/useCombinedView.ts
@@ -16,6 +16,9 @@ export const useCombinedView = (contentType?: ContentTypeName) => {
 
   React.useEffect(() => {
     setCombined((pathname.match('/combined/')?.length ?? 0) > 0);
+    document.getElementById('bottom-pane')?.scrollIntoView({
+      behavior: 'smooth',
+    });
   }, [pathname]);
   React.useEffect(() => {
     setFormType(type);


### PR DESCRIPTION
Previously at the beginning of a user's session the page would not scroll as the element was not yet in existence. Have moved the logic to the `useCombinedView` hook to listen for changes in the pathname.