### PR TITLE
TNO-1122: Validation

### DIFF
--- a/app/editor/src/components/form/toning/ToningGroup.tsx
+++ b/app/editor/src/components/form/toning/ToningGroup.tsx
@@ -1,5 +1,5 @@
 import { useFormikContext } from 'formik';
-import { IContentModel } from 'hooks';
+import { IContentModel, useLookupOptions } from 'hooks';
 import React from 'react';
 import { Col, Error, Row } from 'tno-core';
 
@@ -11,7 +11,9 @@ export interface IToningGroupProps {
 
 export const ToningGroup: React.FC<IToningGroupProps> = ({ fieldName }) => {
   const toningOptions = [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5];
-  const { values, setFieldValue, touched } = useFormikContext<IContentModel>();
+  const [{ tonePools }] = useLookupOptions();
+  const defaultTonePool = tonePools.find((t) => t.name === 'Default');
+  const { values, setFieldValue, touched, errors } = useFormikContext<IContentModel>();
   const [active, setActive] = React.useState<number>();
   React.useEffect(() => {
     if (values.tonePools?.length && values.tonePools[0].value) setActive(values.tonePools[0].value);
@@ -47,8 +49,10 @@ export const ToningGroup: React.FC<IToningGroupProps> = ({ fieldName }) => {
               key={option}
               onClick={() => {
                 setActive(option);
-                setFieldValue('tonePool', option);
-                setFieldValue('tone', option);
+                setFieldValue(
+                  fieldName,
+                  !!defaultTonePool ? [{ ...defaultTonePool, value: option }] : [],
+                );
               }}
             >
               {option}
@@ -56,7 +60,7 @@ export const ToningGroup: React.FC<IToningGroupProps> = ({ fieldName }) => {
           </Col>
         ))}
       </Row>
-      <Error error={!active && active !== 0 && touched[fieldName] ? 'Toning is required' : ''} />
+      <Error error={!!fieldName && touched[fieldName] ? errors[fieldName] : ''} />
     </styled.ToningGroup>
   );
 };

--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -87,8 +87,7 @@ export const ContentForm: React.FC<IContentFormProps> = ({
   const { isShowing: showDeleteModal, toggle: toggleDelete } = useModal();
   const { isShowing: showTranscribeModal, toggle: toggleTranscribe } = useModal();
   const { isShowing: showNLPModal, toggle: toggleNLP } = useModal();
-  const [{ sources, tonePools, series, sourceOptions, productOptions }, { getSeries }] =
-    useLookupOptions();
+  const [{ sources, series, sourceOptions, productOptions }, { getSeries }] = useLookupOptions();
   const { combined, formType } = useCombinedView(initContentType);
   const hub = useApiHub();
   useTooltips();
@@ -187,9 +186,6 @@ export const ContentForm: React.FC<IContentFormProps> = ({
         values.contentType = contentType;
         values.ownerId = userId;
       }
-
-      const defaultTonePool = tonePools.find((t) => t.name === 'Default');
-      values.tonePools = !!defaultTonePool ? [{ ...defaultTonePool, value: +values.tone }] : [];
 
       const model = toModel(values);
       contentResult = !form.id ? await addContent(model) : await updateContent(model);
@@ -474,6 +470,7 @@ export const ContentForm: React.FC<IContentFormProps> = ({
                                 ''
                               }
                               label="Product"
+                              width={FieldSize.Small}
                               options={productOptions}
                               required
                             />

--- a/app/editor/src/features/content/form/constants/defaultFormValues.ts
+++ b/app/editor/src/features/content/form/constants/defaultFormValues.ts
@@ -29,7 +29,6 @@ export const defaultFormValues = (contentType: ContentTypeName): IContentForm =>
     categories: [],
     tags: [],
     labels: [],
-    tone: '',
     tonePools: [],
     timeTrackings: [],
     fileReferences: [],

--- a/app/editor/src/features/content/form/interfaces/IContentForm.ts
+++ b/app/editor/src/features/content/form/interfaces/IContentForm.ts
@@ -11,7 +11,6 @@ import {
   ITimeTrackingModel,
   IWorkOrderModel,
 } from 'hooks/api-editor';
-import { IOptionItem } from 'tno-core';
 
 export interface IContentForm {
   id: number;

--- a/app/editor/src/features/content/form/interfaces/IContentForm.ts
+++ b/app/editor/src/features/content/form/interfaces/IContentForm.ts
@@ -37,8 +37,6 @@ export interface IContentForm {
   categories: IContentCategoryModel[];
   tags: IContentTagModel[];
   labels: IContentLabelModel[];
-  tone: number | '';
-  tonePool?: IOptionItem;
   tonePools: IContentTonePoolModel[];
   timeTrackings: ITimeTrackingModel[];
   fileReferences: IFileReferenceModel[];

--- a/app/editor/src/features/content/form/utils/toForm.ts
+++ b/app/editor/src/features/content/form/utils/toForm.ts
@@ -40,10 +40,6 @@ export function toForm(model: IContentModel): IContentForm {
     categories: model.categories ?? [],
     tags: model.tags ?? [],
     labels: model.labels ?? [],
-    tone: defaultTonePool?.value ?? '',
-    tonePool: defaultTonePool
-      ? new OptionItem(`${defaultTonePool.value}`, defaultTonePool.value)
-      : undefined,
     tonePools: model.tonePools ?? [],
     timeTrackings: model.timeTrackings ?? [],
     fileReferences: model.fileReferences ?? [],

--- a/app/editor/src/features/content/form/utils/toForm.ts
+++ b/app/editor/src/features/content/form/utils/toForm.ts
@@ -1,6 +1,5 @@
 import { IContentModel } from 'hooks/api-editor';
 import moment from 'moment';
-import { OptionItem } from 'tno-core';
 
 import { IContentForm } from '../interfaces';
 
@@ -12,7 +11,6 @@ import { IContentForm } from '../interfaces';
 export function toForm(model: IContentModel): IContentForm {
   // return form values in valid API format on submit of ContentForm
   // not utilized properly right now - update coming
-  const defaultTonePool = model.tonePools?.find((t) => t.name === 'Default');
   return {
     id: model.id,
     uid: model.uid ?? '',

--- a/app/editor/src/features/content/validation/ContentFormSchema.ts
+++ b/app/editor/src/features/content/validation/ContentFormSchema.ts
@@ -3,7 +3,7 @@ import { array, date, number, object, string } from 'yup';
 
 export const ContentFormSchema = object().shape(
   {
-    productId: number().required('Product is a required field.').notOneOf([0]),
+    productId: number().required('Product is required.').notOneOf([0], 'Product is required.'),
     sourceId: number().when('tempSource', {
       is: undefined,
       then: number().required('Either source or other source is required.'),

--- a/app/editor/src/features/content/validation/ContentFormSchema.ts
+++ b/app/editor/src/features/content/validation/ContentFormSchema.ts
@@ -1,28 +1,43 @@
 import { ContentTypeName } from 'hooks';
-import { date, number, object, string } from 'yup';
+import { array, date, number, object, string } from 'yup';
 
-export const ContentFormSchema = object().shape({
-  // TODO: Either 'otherSource' or 'sourceId' is required.
-  otherSource: string().required('Source is a required field.'),
-  // TODO: sourceId: number().required('Source is a required field.'),
-  productId: number().required('Product designation is a required field.'),
-  publishedOn: date().required('Published On is a required field.'),
-  // TODO: Summary should not be empty.
-  // summary: string().required('Summary is a required field.'),
-  summary: string().when('contentType', {
-    is: ContentTypeName.Snippet,
-    then: string().trim().required('Summary is a required field.'),
-  }),
-  body: string().when('contentType', {
-    is: (value: ContentTypeName) =>
-      value !== ContentTypeName.Snippet && value !== ContentTypeName.Image,
-    then: string().trim().required('Summary is a required field.'),
-  }),
-  // TODO: Headline should not be empty.
-  headline: string().required('Headline is a required field.'),
-  tone: number().when('contentType', {
-    is: (value: ContentTypeName) => value !== ContentTypeName.Image,
-    then: number().required('Tone is a required field.'),
-  }),
-  // TODO: validation for print content.
-});
+export const ContentFormSchema = object().shape(
+  {
+    productId: number().required('Product is a required field.').notOneOf([0]),
+    sourceId: number().when('tempSource', {
+      is: undefined,
+      then: number().required('Either source or other source is required.'),
+    }),
+    tempSource: string().when('sourceId', {
+      is: undefined,
+      then: string().trim().required('Either source or other source is required.'),
+    }),
+    publishedOn: date().required('Published On is a required field.'),
+    // TODO: Summary should not be empty.
+    summary: string().when('contentType', {
+      is: ContentTypeName.Snippet,
+      then: string().trim().required('Summary is a required field.'),
+    }),
+    body: string().when('contentType', {
+      is: (value: ContentTypeName) =>
+        value !== ContentTypeName.Snippet && value !== ContentTypeName.Image,
+      then: string().trim().required('Summary is a required field.'),
+    }),
+    // TODO: Headline should not be empty.
+    headline: string().required('Headline is a required field.'),
+    tonePools: array().when('contentType', {
+      is: (value: ContentTypeName) => value !== ContentTypeName.Image,
+      then: array().min(1, 'Tone is a required field.'),
+    }),
+    // TODO: validation for print content.
+    section: string().when('contentType', {
+      is: (value: ContentTypeName) => value === ContentTypeName.PrintContent,
+      then: string().trim().required('Section is a required field.'),
+    }),
+    byline: string().when('contentType', {
+      is: (value: ContentTypeName) => value === ContentTypeName.PrintContent,
+      then: string().trim().required('Byline is a required field.'),
+    }),
+  },
+  [['sourceId', 'tempSource']],
+);


### PR DESCRIPTION
Cleaned up toning validation, we had some unnecessary placeholder fields for tone. Now the component will directly change `toningPools` instead of going through various variables.  

Also added some print content validation, as well as the conditional validation of `otherSource/source` as it was a quick add.