### PR TITLE
TNO-804 Add service account authorization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,15 +125,26 @@ refresh: ## Stop, build, and start all containers or the one specified (args: n=
 	@make build $(if $(n),n=$(n),) $(if $(p),p=$(p),)
 	@make up $(if $(n),n=$(n),) $(if $(p),p=$(p),)
 
+refresh-keycloak: ## Stop, build, drop DB and recreate
+	$(info Stop, build, drop DB and recreate)
+	@make stop n=keycloak
+	@./tools/scripts/docker-remove.sh keycloak
+	@./tools/scripts/refresh-keycloak.sh
+	@make build n=keycloak
+	@make up n=keycloak
+
 remove: ## Remove all containers
 	$(info Remove all containers)
 	@docker-compose rm -sv
 
 renew: ## Refresh all relevant services that were impacted by prior Pull Request.
 	$(info Refresh all relevant services that were impacted by prior Pull Request.)
+	@make refresh-keycloak
 	@make db-update
 	@make refresh n=api
-	@make refresh n=editor
+	@make refresh n=indexing
+	@make build n=content
+	@make build n=syndication
 
 ##############################################################################
 # Database Commands

--- a/api/net/Areas/Editor/Controllers/ContentController.cs
+++ b/api/net/Areas/Editor/Controllers/ContentController.cs
@@ -23,14 +23,14 @@ using System.Web;
 using System.Text.Json;
 using TNO.API.SignalR;
 using Microsoft.AspNetCore.SignalR;
+using TNO.Keycloak;
 
 namespace TNO.API.Areas.Editor.Controllers;
 
 /// <summary>
 /// ContentController class, provides Content endpoints for the api.
 /// </summary>
-// [ClientRoleAuthorize(ClientRole.Editor)]
-[Authorize]
+[ClientRoleAuthorize(ClientRole.Editor)]
 [ApiController]
 [Area("editor")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Editor/Controllers/LookupController.cs
+++ b/api/net/Areas/Editor/Controllers/LookupController.cs
@@ -11,7 +11,7 @@ using TNO.Core.Exceptions;
 using TNO.DAL.Services;
 using TNO.CSS;
 using TNO.CSS.Config;
-using Microsoft.AspNetCore.Authorization;
+using TNO.Keycloak;
 
 namespace TNO.API.Areas.Editor.Controllers;
 
@@ -19,8 +19,7 @@ namespace TNO.API.Areas.Editor.Controllers;
 /// LookupController class, provides Lookup endpoints for the api.
 /// The purpose is to reduce the number of AJAX requests to fetch separate lookup values.
 /// </summary>
-// [ClientRoleAuthorize(ClientRole.Editor, ClientRole.Administrator)]
-[Authorize]
+[ClientRoleAuthorize(ClientRole.Editor, ClientRole.Administrator)]
 [ApiController]
 [Area("editor")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Kafka/Controllers/ProducerController.cs
+++ b/api/net/Areas/Kafka/Controllers/ProducerController.cs
@@ -1,20 +1,19 @@
 using System.Net;
 using System.Net.Mime;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Kafka.Models;
 using TNO.API.Models;
 using TNO.Kafka;
 using TNO.Kafka.Models;
+using TNO.Keycloak;
 
 namespace TNO.API.Areas.Admin.Controllers;
 
 /// <summary>
 /// ProducerController class, provides Kafka producer endpoints for the api.
 /// </summary>
-// [ClientRoleAuthorize(ClientRole.Administrator)]
-[Authorize]
+[ClientRoleAuthorize(ClientRole.Administrator)]
 [ApiController]
 [Area("kafka")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Services/Controllers/ConnectionController.cs
+++ b/api/net/Areas/Services/Controllers/ConnectionController.cs
@@ -1,21 +1,20 @@
 using System.Net;
 using System.Net.Mime;
 using System.Text.Json;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Services.Models.Ingest;
 using TNO.API.Models;
 using TNO.DAL.Services;
+using TNO.Keycloak;
 
 namespace TNO.API.Areas.Services.Controllers;
 
 /// <summary>
 /// ConnectionController class, provides Connection endpoints for the api.
 /// </summary>
-// [ClientRoleAuthorize(ClientRole.Administrator)]
-[Authorize]
+[ClientRoleAuthorize(ClientRole.Administrator)]
 [ApiController]
 [Area("services")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Services/Controllers/ContentController.cs
+++ b/api/net/Areas/Services/Controllers/ContentController.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Net.Mime;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
@@ -17,14 +16,14 @@ using TNO.DAL.Services;
 using TNO.Entities;
 using TNO.Kafka;
 using TNO.Kafka.Models;
+using TNO.Keycloak;
 
 namespace TNO.API.Areas.Services.Controllers;
 
 /// <summary>
 /// ContentController class, provides Content endpoints for the api.
 /// </summary>
-// [ClientRoleAuthorize(ClientRole.Administrator)]
-[Authorize]
+[ClientRoleAuthorize(ClientRole.Administrator)]
 [ApiController]
 [Area("services")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Services/Controllers/ContentReferenceController.cs
+++ b/api/net/Areas/Services/Controllers/ContentReferenceController.cs
@@ -1,19 +1,18 @@
 using System.Net;
 using System.Net.Mime;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Services.Models.ContentReference;
 using TNO.API.Models;
 using TNO.DAL.Services;
+using TNO.Keycloak;
 
 namespace TNO.API.Areas.Services.Controllers;
 
 /// <summary>
 /// ContentReferenceController class, provides ContentReference endpoints for the api.
 /// </summary>
-// [ClientRoleAuthorize(ClientRole.Administrator)]
-[Authorize]
+[ClientRoleAuthorize(ClientRole.Administrator)]
 [ApiController]
 [Area("services")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Services/Controllers/DataLocationController.cs
+++ b/api/net/Areas/Services/Controllers/DataLocationController.cs
@@ -1,21 +1,20 @@
 using System.Net;
 using System.Net.Mime;
 using System.Text.Json;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Services.Models.DataLocation;
 using TNO.API.Models;
 using TNO.DAL.Services;
+using TNO.Keycloak;
 
 namespace TNO.API.Areas.Services.Controllers;
 
 /// <summary>
 /// DataLocationController class, provides DataLocation endpoints for the api.
 /// </summary>
-// [ClientRoleAuthorize(ClientRole.Administrator)]
-[Authorize]
+[ClientRoleAuthorize(ClientRole.Administrator)]
 [ApiController]
 [Area("services")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Services/Controllers/IngestController.cs
+++ b/api/net/Areas/Services/Controllers/IngestController.cs
@@ -1,21 +1,20 @@
 using System.Net;
 using System.Net.Mime;
 using System.Text.Json;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Services.Models.Ingest;
 using TNO.API.Models;
 using TNO.DAL.Services;
+using TNO.Keycloak;
 
 namespace TNO.API.Areas.Services.Controllers;
 
 /// <summary>
 /// IngestController class, provides Ingest endpoints for the api.
 /// </summary>
-// [ClientRoleAuthorize(ClientRole.Administrator)]
-[Authorize]
+[ClientRoleAuthorize(ClientRole.Administrator)]
 [ApiController]
 [Area("services")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Services/Controllers/SourceController.cs
+++ b/api/net/Areas/Services/Controllers/SourceController.cs
@@ -1,21 +1,20 @@
 using System.Net;
 using System.Net.Mime;
 using System.Text.Json;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Services.Models.Ingest;
 using TNO.API.Models;
 using TNO.DAL.Services;
+using TNO.Keycloak;
 
 namespace TNO.API.Areas.Services.Controllers;
 
 /// <summary>
 /// SourceController class, provides Source endpoints for the api.
 /// </summary>
-// [ClientRoleAuthorize(ClientRole.Administrator)]
-[Authorize]
+[ClientRoleAuthorize(ClientRole.Administrator)]
 [ApiController]
 [Area("services")]
 [ApiVersion("1.0")]

--- a/api/net/Areas/Services/Controllers/WorkOrderController.cs
+++ b/api/net/Areas/Services/Controllers/WorkOrderController.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using System.Net.Mime;
 using System.Text.Json;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Options;
@@ -11,14 +10,14 @@ using TNO.API.Models;
 using TNO.API.Models.SignalR;
 using TNO.API.SignalR;
 using TNO.DAL.Services;
+using TNO.Keycloak;
 
 namespace TNO.API.Areas.Services.Controllers;
 
 /// <summary>
 /// WorkOrderController class, provides WorkOrder endpoints for the api.
 /// </summary>
-// [ClientRoleAuthorize(ClientRole.Administrator)]
-[Authorize]
+[ClientRoleAuthorize(ClientRole.Administrator)]
 [ApiController]
 [Area("services")]
 [ApiVersion("1.0")]

--- a/auth/keycloak/config/realm-export.json
+++ b/auth/keycloak/config/realm-export.json
@@ -271,6 +271,27 @@
       "security-admin-console" : [ ],
       "admin-cli" : [ ],
       "tno-service-account" : [ {
+        "id" : "66489a9d-ea44-408e-b3c8-d1b4568640af",
+        "name" : "admin",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c8c6977e-55e0-4146-a38c-8420c5761b6c",
+        "attributes" : { }
+      }, {
+        "id" : "87db2286-ff9d-4660-aff2-fe94e1edf2da",
+        "name" : "editor",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c8c6977e-55e0-4146-a38c-8420c5761b6c",
+        "attributes" : { }
+      }, {
+        "id" : "cfbc592c-b7ab-4b10-bbb7-d2add53ee263",
+        "name" : "subscriber",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c8c6977e-55e0-4146-a38c-8420c5761b6c",
+        "attributes" : { }
+      }, {
         "id" : "741d1896-609e-4e60-88d4-f9ede9773865",
         "name" : "uma_protection",
         "composite" : false,
@@ -475,7 +496,7 @@
     "clientRoles" : {
       "realm-management" : [ "realm-admin" ],
       "tno-app" : [ "editor", "administrator" ],
-      "tno-service-account" : [ "uma_protection" ]
+      "tno-service-account" : [ "admin", "editor", "subscriber", "uma_protection" ]
     },
     "notBefore" : 0,
     "groups" : [ ]
@@ -748,7 +769,7 @@
     "frontchannelLogout" : false,
     "protocol" : "openid-connect",
     "attributes" : {
-      "access.token.lifespan" : "3600",
+      "access.token.lifespan" : "300",
       "saml.force.post.binding" : "false",
       "saml.multivalued.roles" : "false",
       "oauth2.device.authorization.grant.enabled" : "false",
@@ -976,6 +997,21 @@
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : -1,
     "protocolMappers" : [ {
+      "id" : "bc8272a0-17a5-4048-bbe0-80f30dfd94c3",
+      "name" : "client-roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "client-roles",
+        "jsonType.label" : "String",
+        "usermodel.clientRoleMapping.clientId" : "tno-service-account"
+      }
+    }, {
       "id" : "bbd4d7dd-5a2f-4ca5-ac08-9f3241b6fa2c",
       "name" : "Client ID",
       "protocol" : "openid-connect",

--- a/services/net/filemonitor/FilemonitorAction.cs
+++ b/services/net/filemonitor/FilemonitorAction.cs
@@ -488,16 +488,15 @@ public class FileMonitorAction : IngestAction<FileMonitorOptions>
                 if (text != null)
                 {
                     var entries = text.Split(ingest.GetConfigurationValue(Fields.Item)).Where(t => !String.IsNullOrWhiteSpace(t)).Select(t => t.Trim());
-                    var code = "";
 
                     // Iterate over the list of stories and add a new item to the articles list for each story.
                     foreach (var entry in entries)
                     {
                         // Single line mode prevents matching on "\n\n", so replace this with a meaningful field delimiter.
                         var papername = GetFmsData(entry, Fields.PaperName, ingest);
-                        code = string.IsNullOrEmpty(code) ? GetItemSourceCode(ingest, papername, sources) : code;
+                        var code = GetItemSourceCode(ingest, papername, sources);
 
-                        if (!string.IsNullOrEmpty(code)) // This is a valid newspaper source
+                        if (!String.IsNullOrEmpty(code)) // This is a valid newspaper source
                         {
                             var productId = await GetProductIdAsync(ingest, code, sources);
                             var item = new SourceContent(

--- a/tools/scripts/refresh-keycloak.sh
+++ b/tools/scripts/refresh-keycloak.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "Drop and refresh keycloak database"
+. ./tools/scripts/variables.sh
+docker exec -i tno-database bash -c "psql -U \$POSTGRES_USER \$POSTGRES_DB -c 'DROP DATABASE IF EXISTS $keycloakDbName;' -c 'CREATE DATABASE $keycloakDbName;';"
+


### PR DESCRIPTION
Keycloak Gold realm CSS tool now support roles for service accounts.

This allows us to secure our endpoints so that both service accounts and users follow the same permission processes.

You will need to run `make renew` to update Keycloak with the appropriate service account roles.

Won't know if it all works until it's deployed to DEV.  Locally it appears to work correctly.