### PR TITLE
Fix API

### DIFF
--- a/api/net/appsettings.Development.json
+++ b/api/net/appsettings.Development.json
@@ -22,9 +22,6 @@
       "BootstrapServers": "host.docker.internal:40102"
     }
   },
-  "Elastic": {
-    "Url": "http://host.docker.internal:40003"
-  },
   "SignalR": {
     "EnableDetailedErrors": true
   }

--- a/libs/net/core/Converters/Int32ToStringJsonConverter.cs
+++ b/libs/net/core/Converters/Int32ToStringJsonConverter.cs
@@ -6,12 +6,6 @@ namespace TNO.Core.Converters
     public class Int32ToStringJsonConverter : JsonConverter<string>
     {
         #region Methods
-        public override bool CanConvert(Type typeToConvert)
-        {
-            return typeToConvert == typeof(string)
-                   || typeToConvert == typeof(int);
-        }
-
         public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             var value = reader.TokenType switch

--- a/tools/scripts/gen-env-files.sh
+++ b/tools/scripts/gen-env-files.sh
@@ -198,7 +198,7 @@ ConnectionStrings__TNO=Host=host.docker.internal:$portDatabase;Database=$dbName;
 DB_POSTGRES_USERNAME=$dbUser
 DB_POSTGRES_PASSWORD=$password
 
-Elastic__Url=host.docker.internal:$portElastic
+# Elastic__Url=host.docker.internal:$portElastic
 ELASTIC_USERNAME=$elasticUser
 ELASTIC_PASSWORD=$password
 


### PR DESCRIPTION
Resolving bugs introduced with prior PR.  

For some reason the API was also having issues using the `host.docker.internal` domain name.  I've updated the config to use the container name instead.  However, if you are running the API locally you will need to override this appropriately.