### PR TITLE
Fix console warning for draggable component

### DIFF
--- a/app/editor/src/components/form/tags/DraggableTagList.tsx
+++ b/app/editor/src/components/form/tags/DraggableTagList.tsx
@@ -16,10 +16,11 @@ export interface IDraggableTagListProps {
  */
 export const DraggableTagList: React.FC<IDraggableTagListProps> = ({ showList, setShowList }) => {
   const [{ tags }] = useLookup();
+  const nodeRef = React.useRef(null);
 
   return (
-    <Draggable>
-      <div>
+    <Draggable nodeRef={nodeRef}>
+      <div ref={nodeRef}>
         <Show visible={showList}>
           <Col className="tag-list" id="tag-list">
             <Row className="tag-list-header">

--- a/app/editor/src/features/content/form/MediaSummary.tsx
+++ b/app/editor/src/features/content/form/MediaSummary.tsx
@@ -37,7 +37,7 @@ export const MediaSummary: React.FC<IMediaSummaryProps> = ({
   const [, { download }] = useContent();
 
   return (
-    <styled.MediaSummary className="test">
+    <styled.MediaSummary>
       <Col className="media">
         <Upload
           contentType={contentType}

--- a/app/editor/src/features/content/form/MediaSummary.tsx
+++ b/app/editor/src/features/content/form/MediaSummary.tsx
@@ -65,7 +65,7 @@ export const MediaSummary: React.FC<IMediaSummaryProps> = ({
       </Col>
       <Col className="summary">
         <Wysiwyg label="Summary" required fieldName="summary" expandModal={setShowExpandModal} />
-        <Row>
+        <Row wrap="nowrap">
           <Tags />
           <ToningGroup fieldName="tonePools" />
         </Row>


### PR DESCRIPTION
Fixed the warning by following [this](https://github.com/react-grid-layout/react-draggable/blob/v4.4.2/lib/DraggableCore.js#L159-L171).

"If running in React Strict mode, ReactDOM.findDOMNode() is deprecated. Unfortunately, in order for <Draggable> to work properly, we need raw access to the underlying DOM node. If you want to avoid the warning, pass a `nodeRef`..."
