### PR TITLE
TNO-1140 Fix content filter state

### DIFF
--- a/app/editor/src/features/content/list-view/ContentListView.tsx
+++ b/app/editor/src/features/content/list-view/ContentListView.tsx
@@ -48,8 +48,10 @@ export const ContentListView: React.FC = () => {
 
   React.useEffect(() => {
     // Extract query string values and place them into redux store.
-    storeFilter(queryToFilter(filter, window.location.search));
-    storeFilterAdvanced(queryToFilterAdvanced(filterAdvanced, window.location.search));
+    if (!!window.location.search) {
+      storeFilter(queryToFilter(filter, window.location.search));
+      storeFilterAdvanced(queryToFilterAdvanced(filterAdvanced, window.location.search));
+    }
     // Only want this to run on the first load.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -85,6 +87,14 @@ export const ContentListView: React.FC = () => {
     return hub.listen(HubMethodName.WorkOrder, onWorkOrder);
   }, [onWorkOrder, hub]);
 
+  React.useEffect(() => {
+    // Required because the first time this page is loaded directly the user has not been set.
+    // Don't make a request until the user has been set.
+    if (userId !== '' && filter.userId === '') {
+      storeFilter({ ...filter, userId });
+    }
+  }, [userId, filter, storeFilter]);
+
   const fetch = React.useCallback(
     async (filter: IContentListFilter & Partial<IContentListAdvancedFilter>) => {
       try {
@@ -104,14 +114,6 @@ export const ContentListView: React.FC = () => {
     },
     [findContent],
   );
-
-  React.useEffect(() => {
-    // Required because the first time this page is loaded directly the user has not been set.
-    // Don't make a request until the user has been set.
-    if (userId !== '' && filter.userId === '') {
-      storeFilter({ ...filter, userId });
-    }
-  }, [userId, filter, storeFilter]);
 
   React.useEffect(() => {
     if (isReady) {

--- a/app/editor/src/features/content/morning-report/AdvancedMorningReport.tsx
+++ b/app/editor/src/features/content/morning-report/AdvancedMorningReport.tsx
@@ -29,16 +29,22 @@ export interface IAdvancedSearchSectionProps {
  */
 export const AdvancedMorningReport: React.FC<IAdvancedSearchSectionProps> = ({ onSearch }) => {
   const [{ morningReportFilter, filterAdvanced, filter }, { storeFilterAdvanced }] = useContent();
+
   const search = fromQueryString(window.location.search);
+
   /** initialize advanced search section with query values or new */
   React.useEffect(() => {
-    storeFilterAdvanced({
-      ...filterAdvanced,
-      fieldType: search.fieldType ?? fieldTypes[0].value,
-      searchTerm: search.searchTerm ?? '',
-    });
+    if (!!window.location.search) {
+      storeFilterAdvanced({
+        ...filterAdvanced,
+        fieldType: search.fieldType ?? fieldTypes[0].value,
+        searchTerm: search.searchTerm ?? '',
+      });
+    }
+    // Only load the URL parameters the first time.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
   return (
     <ToolBarSection
       children={

--- a/app/editor/src/features/content/tool-bar/ContentToolBar.tsx
+++ b/app/editor/src/features/content/tool-bar/ContentToolBar.tsx
@@ -23,6 +23,7 @@ export interface IContentToolBarProps {
 export const ContentToolBar: React.FC<IContentToolBarProps> = ({ onSearch }) => {
   const [{ filter, filterAdvanced }, { storeFilter, storeFilterAdvanced }] = useContent();
   const search = fromQueryString(window.location.search);
+
   // extract every value from window.location.search that is productIds
   // and put into an array
   const extractProductIds = (search: string) => {
@@ -33,12 +34,14 @@ export const ContentToolBar: React.FC<IContentToolBarProps> = ({ onSearch }) => 
   };
 
   React.useEffect(() => {
-    if (!!search.productIds) extractProductIds(search.productIds);
-    Object.keys(search).forEach(function (key) {
-      if (key in filterAdvanced && search[key] !== undefined) {
-        storeFilterAdvanced({ ...filterAdvanced, [key]: search[key] });
-      }
-    });
+    if (!!window.location.search) {
+      if (!!search.productIds) extractProductIds(search.productIds);
+      Object.keys(search).forEach(function (key) {
+        if (key in filterAdvanced && search[key] !== undefined) {
+          storeFilterAdvanced({ ...filterAdvanced, [key]: search[key] });
+        }
+      });
+    }
     // parse productIds for each one and put into array
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -47,6 +50,7 @@ export const ContentToolBar: React.FC<IContentToolBarProps> = ({ onSearch }) => 
     storeFilter(filter);
     replaceQueryParams({ ...filter, ...filterAdvanced }, { includeEmpty: false });
   };
+
   // pass filter and filter advanced so we don't lose the advanced filter when we change the filter
   const onAdvancedFilterChange = (advancedFilter: IContentListAdvancedFilter) => {
     storeFilterAdvanced(advancedFilter);

--- a/app/editor/src/features/content/tool-bar/sections/filter/FilterContentSection.tsx
+++ b/app/editor/src/features/content/tool-bar/sections/filter/FilterContentSection.tsx
@@ -40,23 +40,23 @@ export const FilterContentSection: React.FC<IFilterContentSectionProps> = ({
   const [productOptions, setProductOptions] = React.useState<IOptionItem[]>([]);
   const [userOptions, setUserOptions] = React.useState<IOptionItem[]>([]);
   const [{ userInfo }] = useApp();
-  const search = fromQueryString(window.location.search);
 
+  const search = fromQueryString(window.location.search);
   const timeFrames = [
     { label: 'TODAY', value: 0 },
     { label: '24 HRS', value: 1 },
     { label: '48 HRS', value: 2 },
     { label: 'ALL', value: 3 },
   ];
-  const timeFrameSelected = timeFrames[search.timeFrame ?? 0].label;
+  const timeFrameSelected = timeFrames[search.timeFrame ?? filter.timeFrame].label;
 
   const usersSelections = [
     { label: 'ALL CONTENT', value: 0 },
     { label: 'MY CONTENT', value: userInfo?.id ?? 0 },
   ];
   const usersSelected =
-    usersSelections.find((i) => (+i.value === +search.userId ? +search.userId : 0))?.label ??
-    'ALL CONTENT';
+    usersSelections.find((i) => (+i.value === +search.userId ? +search.userId : filter.userId))
+      ?.label ?? 'ALL CONTENT';
 
   React.useEffect(() => {
     setUserOptions(getUserOptions(users.filter((u) => !u.isSystemAccount)));


### PR DESCRIPTION
Content List filter was getting reset when navigating to different pages.  It will now maintain state.

Note that there is a new issue introduced with the latest Morning Report page filter changes.  Specifically with the Advanced Search, the source value is displayed even though this shared component no longer should display it.

![image](https://user-images.githubusercontent.com/3180256/225351536-e8a990f9-3c3d-404c-aa8e-2d8eb9aadec0.png)
