### PR TITLE
TNO-1186: Hitting search wipes toggle group state

### DIFF
--- a/app/editor/src/features/content/tool-bar/sections/filter/AdvancedSearchSection.tsx
+++ b/app/editor/src/features/content/tool-bar/sections/filter/AdvancedSearchSection.tsx
@@ -33,6 +33,11 @@ export const AdvancedSearchSection: React.FC<IAdvancedSearchSectionProps> = () =
   const [filter, setFilter] = React.useState(oFilter);
   const [filterAdvanced, setFilterAdvanced] = React.useState(oFilterAdvanced);
 
+  // keep the filter in sync with the store
+  React.useEffect(() => {
+    setFilter(oFilter);
+  }, [oFilter]);
+
   const onChange = React.useCallback(() => {
     storeFilter({ ...filter, pageIndex: 0 });
     storeFilterAdvanced(filterAdvanced);


### PR DESCRIPTION
Previously there was a bug that would occur when the user hits the "search" button in the Advanced Search Section of the toolbar.  The filter state used in the advanced search section would be out of sync with the Redux store causing it to revert the toggle group's state.