### PR TITLE
Product filter bugs

### DIFF
--- a/app/editor/src/features/content/tool-bar/sections/filter/InputOption.tsx
+++ b/app/editor/src/features/content/tool-bar/sections/filter/InputOption.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { components } from 'react-select';
 
+import * as styled from './styled';
+
+/** Custom option for react-select component adding a checkbox and label as the selection item */
 export const InputOption: React.FC<any> = ({
   getStyles,
   Icon,
@@ -20,12 +23,13 @@ export const InputOption: React.FC<any> = ({
   let bg = 'transparent';
   if (isFocused) bg = '#eee';
   if (isActive) bg = '#B2D4FF';
+  if (isSelected) bg = '#2293e9';
 
   const style = {
     alignItems: 'center',
-    backgroundColor: bg,
-    color: 'inherit',
+    color: isSelected ? 'white' : 'inherit',
     display: 'flex ',
+    backgroundColor: bg,
   };
 
   const props = {
@@ -36,6 +40,13 @@ export const InputOption: React.FC<any> = ({
     style,
   };
 
+  /** ensures that the element is unchecked in the menu when the item is removed from the selection */
+  React.useEffect(() => {
+    if (!isSelected) {
+      (document.getElementById(children) as HTMLInputElement).checked = false;
+    }
+  }, [isSelected, children]);
+
   return (
     <components.Option
       {...rest}
@@ -45,8 +56,13 @@ export const InputOption: React.FC<any> = ({
       getStyles={getStyles}
       innerProps={props}
     >
-      <input type="checkbox" defaultChecked={isSelected} />
-      {children}
+      <input type="checkbox" id={children} defaultChecked={isSelected} />
+      <styled.SelectLabel
+        className="label"
+        onClick={() => document.getElementById(children)?.click()}
+      >
+        {children}
+      </styled.SelectLabel>
     </components.Option>
   );
 };

--- a/app/editor/src/features/content/tool-bar/sections/filter/styled/SelectLabel.tsx
+++ b/app/editor/src/features/content/tool-bar/sections/filter/styled/SelectLabel.tsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const SelectLabel = styled.div`
+  height: 100%;
+  width: 100%;
+`;

--- a/app/editor/src/features/content/tool-bar/sections/filter/styled/index.ts
+++ b/app/editor/src/features/content/tool-bar/sections/filter/styled/index.ts
@@ -1,1 +1,2 @@
 export * from './DateRangeSection';
+export * from './SelectLabel';


### PR DESCRIPTION
- can now click anywhere in row to toggle the checkbox state
- when removing tags the checkbox will now correctly uncheck
- row highlights when item is selected for easier identification (can remove if we want)

![product-filter-fix](https://user-images.githubusercontent.com/15724124/228394062-235ad8df-cacb-4f72-b3b3-fbf061db10ee.gif)
