### PR TITLE
Fix advanced source filter

### DIFF
--- a/app/editor/src/features/content/list-view/constants/fieldTypes.ts
+++ b/app/editor/src/features/content/list-view/constants/fieldTypes.ts
@@ -2,7 +2,7 @@ import { OptionItem } from 'tno-core';
 
 export const fieldTypes = [
   new OptionItem('Headline', 'headline'),
-  new OptionItem('Source', 'sourceId'),
+  new OptionItem('Source', 'sourceIds'),
   new OptionItem('Byline', 'byline'),
   new OptionItem('Section', 'section'),
   new OptionItem('Page', 'pageName'),

--- a/app/editor/src/features/content/morning-reports/components/AdvancedFilter.tsx
+++ b/app/editor/src/features/content/morning-reports/components/AdvancedFilter.tsx
@@ -89,7 +89,7 @@ export const AdvancedFilter: React.FC<IAdvancedFilterProps> = ({
             checked={
               !!frontPageProduct && filter.productIds?.includes(frontPageProduct.id) === true
             }
-            tooltip="Content identified as commentary"
+            tooltip="Content identified as a Front Page"
             onChange={(e) => {
               if (!!frontPageProduct)
                 onFilterChange({

--- a/app/editor/src/features/content/tool-bar/sections/filter/AdvancedSearchSection.tsx
+++ b/app/editor/src/features/content/tool-bar/sections/filter/AdvancedSearchSection.tsx
@@ -61,7 +61,7 @@ export const AdvancedSearchSection: React.FC<IAdvancedSearchSectionProps> = () =
               setFilterAdvanced({ ...filterAdvanced, fieldType: value.value, searchTerm: '' });
             }}
           />
-          <Show visible={filterAdvanced.fieldType === 'sourceId'}>
+          <Show visible={filterAdvanced.fieldType === 'sourceIds'}>
             <Select
               name="searchTerm"
               width={FieldSize.Medium}
@@ -80,15 +80,13 @@ export const AdvancedSearchSection: React.FC<IAdvancedSearchSectionProps> = () =
                   });
                 }
               }}
-              options={[new OptionItem('', 0) as IOptionItem].concat([
-                ...filterEnabledOptions(sourceOptions, filterAdvanced.searchTerm),
-              ])}
+              options={filterEnabledOptions(sourceOptions, filterAdvanced.searchTerm)}
               value={sourceOptions.find(
                 (s) => String(s.value) === String(filterAdvanced.searchTerm),
               )}
             />
           </Show>
-          <Show visible={filterAdvanced.fieldType !== 'sourceId'}>
+          <Show visible={filterAdvanced.fieldType !== 'sourceIds'}>
             <Text
               name="searchTerm"
               width={FieldSize.Small}


### PR DESCRIPTION
This fixes a bug I introduced in the advanced search when selecting a source.

![image](https://user-images.githubusercontent.com/3180256/228687604-934a532d-0710-4857-8ffb-73bace4d2010.png)
