### PR TITLE
TNO-1221 Add Commentary Default Expiry Value

### DIFF
--- a/app/editor/src/features/content/form/ContentActions.tsx
+++ b/app/editor/src/features/content/form/ContentActions.tsx
@@ -1,4 +1,5 @@
 import { getIn, useFormikContext } from 'formik';
+import moment from 'moment';
 import React from 'react';
 import { FaHourglassHalf } from 'react-icons/fa';
 import { useLookup } from 'store/hooks';
@@ -124,6 +125,10 @@ export const ContentActions: React.FC<IContentActionsProps> = ({
               onChange={(e) => {
                 const checked = e.currentTarget.checked;
                 if (!checked) setFieldValue(field('value', index), '');
+                else {
+                  const weekDay = moment(values.publishedOn).weekday();
+                  setFieldValue(field('value', index), `${weekDay === 0 || weekDay === 6 ? 3 : 5}`);
+                }
                 setHidden(
                   hidden.map((h) => {
                     if (h.id === a.id) return { ...h, value: checked };


### PR DESCRIPTION
Weekdays the commentary expiry value will default to 3 hours and weekends will be 5 hours.

> I still need to integrate with Canada's free API for holidays so that it will default to 5 hours on holidays.

![image](https://user-images.githubusercontent.com/3180256/235391252-8a6e1831-e4fa-4424-a256-f2e0e880cb8c.png)
