### PR TITLE
TNO-1078 Replace work order table

### DIFF
--- a/api/net/Areas/Admin/Controllers/WorkOrderController.cs
+++ b/api/net/Areas/Admin/Controllers/WorkOrderController.cs
@@ -77,7 +77,7 @@ public class WorkOrderController : ControllerBase
         var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
         var result = _workOrderService.Find(new WorkOrderFilter(query));
         var items = result.Items.Select(ds => new WorkOrderModel(ds, _serializerOptions));
-        var page = new Paged<WorkOrderModel>(items, result.Page, result.Quantity, items.Count());
+        var page = new Paged<WorkOrderModel>(items, result.Page, result.Quantity, result.Total);
         return new JsonResult(page);
     }
 

--- a/app/editor/src/features/admin/topics/styled/TopicList.tsx
+++ b/app/editor/src/features/admin/topics/styled/TopicList.tsx
@@ -9,6 +9,10 @@ export const TopicList = styled.div`
   .form-page {
     display: flex;
     gap: 1em;
+
+    div[role='rowgroup'] {
+      max-height: unset;
+    }
   }
 
   .filter-bar {

--- a/app/editor/src/features/admin/work-orders/WorkOrderForm.tsx
+++ b/app/editor/src/features/admin/work-orders/WorkOrderForm.tsx
@@ -23,6 +23,7 @@ import {
   OptionItem,
   Row,
   Show,
+  Text,
   useModal,
   WorkOrderStatusName,
 } from 'tno-core';
@@ -119,14 +120,14 @@ export const WorkOrderForm: React.FC = () => {
             <Show visible={!!values.configuration.contentId}>
               <Row>
                 <Col flex="1 1 0">
-                  <FormikText name="content.headline" label="Content Headline" disabled>
+                  <Text name="content.headline" label="Content Headline" disabled>
                     <Button
                       variant={ButtonVariant.secondary}
                       onClick={() => goToContent(values.configuration.contentId!)}
                     >
                       Go
                     </Button>
-                  </FormikText>
+                  </Text>
                 </Col>
               </Row>
             </Show>

--- a/app/editor/src/features/admin/work-orders/constants/columns.tsx
+++ b/app/editor/src/features/admin/work-orders/constants/columns.tsx
@@ -1,47 +1,45 @@
 import moment from 'moment';
-import { Column, UseFiltersColumnOptions, UseSortByColumnOptions } from 'react-table';
-import { CellEllipsis, IWorkOrderModel } from 'tno-core';
+import { CellEllipsis, ITableHookColumn, IWorkOrderModel } from 'tno-core';
 
-export const columns: (Column<IWorkOrderModel> &
-  UseSortByColumnOptions<IWorkOrderModel> &
-  UseFiltersColumnOptions<IWorkOrderModel>)[] = [
+export const getColumns = (
+  onClickOpen?: (contentId: number) => void,
+): ITableHookColumn<IWorkOrderModel>[] => [
   {
-    id: 'id',
-    Header: 'Type',
-    accessor: 'workType',
+    label: 'Type',
+    name: 'workType',
     width: 2,
-    Cell: ({ value }) => <span>{value.replace(/([A-Z])/g, ' $1')}</span>,
+    cell: (cell) => <span>{cell.original.workType.replace(/([A-Z])/g, ' $1')}</span>,
   },
   {
-    Header: 'Content',
-    accessor: 'configuration',
+    label: 'Content',
+    name: 'configuration',
     width: 4,
-    Cell: ({ value }) => <CellEllipsis>{value?.contentId}</CellEllipsis>,
+    cell: (cell) => <CellEllipsis>{JSON.stringify(cell.original.configuration)}</CellEllipsis>,
   },
   {
-    Header: 'Submitted',
-    accessor: 'createdOn',
+    label: 'Submitted',
+    name: 'createdOn',
     width: 2,
-    Cell: ({ value }) => {
-      const created = moment(value);
+    cell: (cell) => {
+      const created = moment(cell.original.createdOn);
       const text = created.isValid() ? created.format('MM/DD/YYYY HH:mm:ss') : '';
       return <div className="center">{text}</div>;
     },
   },
   {
-    Header: 'Updated',
-    accessor: 'updatedOn',
+    label: 'Updated',
+    name: 'updatedOn',
     width: 2,
-    Cell: ({ value }) => {
-      const created = moment(value);
+    cell: (cell) => {
+      const created = moment(cell.original.updatedOn);
       const text = created.isValid() ? created.format('MM/DD/YYYY HH:mm:ss') : '';
       return <div className="center">{text}</div>;
     },
   },
   {
-    Header: 'Status',
-    accessor: 'status',
+    label: 'Status',
+    name: 'status',
     width: 1,
-    Cell: ({ value }) => <span>{value.replace(/([A-Z])/g, ' $1')}</span>,
+    cell: (cell) => <span>{cell.original.status.replace(/([A-Z])/g, ' $1')}</span>,
   },
 ];

--- a/app/editor/src/features/admin/work-orders/constants/defaultWorkOrder.ts
+++ b/app/editor/src/features/admin/work-orders/constants/defaultWorkOrder.ts
@@ -3,6 +3,7 @@ import { IWorkOrderModel, WorkOrderStatusName, WorkOrderTypeName } from 'tno-cor
 export const defaultWorkOrder: IWorkOrderModel = {
   id: 0,
   description: '',
+  requestorId: 0,
   workType: WorkOrderTypeName.Transcription,
   status: WorkOrderStatusName.Submitted,
   note: '',

--- a/libs/net/dal/Services/TopicService.cs
+++ b/libs/net/dal/Services/TopicService.cs
@@ -24,7 +24,7 @@ public class TopicService : BaseService<Topic, int>, ITopicService
     {
         return this.Context.Topics
             .AsNoTracking()
-            .OrderBy(a => a.TopicType)
+            .OrderByDescending(a => a.TopicType)
             .ThenBy(a => a.SortOrder)
             .ThenBy(a => a.Name).ToArray();
     }


### PR DESCRIPTION
Work orders admin page now uses the new FlexTable component and correctly pages.
Fix topic admin table to sort proactive topics first.

![image](https://user-images.githubusercontent.com/3180256/235455608-ed88c7b4-93f0-47ed-8a8a-ad6afbc087e5.png)

![image](https://user-images.githubusercontent.com/3180256/235455586-ee1a9cd9-d13f-40e3-9aad-cab4844d83b3.png)
