### PR TITLE
TNO-1077 Add headline to work order

### DIFF
--- a/app/editor/src/features/admin/work-orders/WorkOrderForm.tsx
+++ b/app/editor/src/features/admin/work-orders/WorkOrderForm.tsx
@@ -23,7 +23,6 @@ import {
   OptionItem,
   Row,
   Show,
-  Text,
   useModal,
   WorkOrderStatusName,
 } from 'tno-core';
@@ -120,14 +119,14 @@ export const WorkOrderForm: React.FC = () => {
             <Show visible={!!values.configuration.contentId}>
               <Row>
                 <Col flex="1 1 0">
-                  <Text name="content.headline" label="Content Headline" disabled>
+                  <FormikText name="configuration.headline" label="Content Headline" disabled>
                     <Button
                       variant={ButtonVariant.secondary}
                       onClick={() => goToContent(values.configuration.contentId!)}
                     >
                       Go
                     </Button>
-                  </Text>
+                  </FormikText>
                 </Col>
               </Row>
             </Show>

--- a/app/editor/src/features/admin/work-orders/WorkOrderList.tsx
+++ b/app/editor/src/features/admin/work-orders/WorkOrderList.tsx
@@ -86,7 +86,7 @@ export const WorkOrderList = () => {
       <WorkOrderListFilter />
       <FlexboxTable
         rowId="id"
-        columns={getColumns()}
+        columns={getColumns((contentId) => navigate(`/contents/${contentId}`))}
         data={page.items}
         manualPaging={true}
         pageIndex={workOrderFilter.pageIndex}

--- a/app/editor/src/features/admin/work-orders/constants/columns.tsx
+++ b/app/editor/src/features/admin/work-orders/constants/columns.tsx
@@ -14,7 +14,20 @@ export const getColumns = (
     label: 'Content',
     name: 'configuration',
     width: 4,
-    cell: (cell) => <CellEllipsis>{JSON.stringify(cell.original.configuration)}</CellEllipsis>,
+    cell: (cell) => (
+      <CellEllipsis
+        className="link"
+        onClick={(e) => {
+          if (cell.original.configuration.contentId) {
+            e.preventDefault();
+            e.stopPropagation();
+            onClickOpen?.(cell.original.configuration.contentId);
+          }
+        }}
+      >
+        {cell.original.configuration.headline ?? cell.original.configuration.contentId}
+      </CellEllipsis>
+    ),
   },
   {
     label: 'Submitted',

--- a/app/editor/src/features/admin/work-orders/styled/WorkOrderList.tsx
+++ b/app/editor/src/features/admin/work-orders/styled/WorkOrderList.tsx
@@ -13,4 +13,13 @@ export const WorkOrderList = styled(FormPage)`
     align-items: center;
     justify-content: center;
   }
+
+  .link {
+    cursor: pointer;
+    color: ${(props) => props.theme.css.primaryColor};
+
+    &:hover {
+      color: ${(props) => props.theme.css.primaryLightColor};
+    }
+  }
 `;

--- a/app/editor/src/features/content/form/utils/getDefaultCommentaryExpiryValue.ts
+++ b/app/editor/src/features/content/form/utils/getDefaultCommentaryExpiryValue.ts
@@ -15,7 +15,6 @@ import { isHoliday } from '.';
 export const getDefaultCommentaryExpiryValue = (date: Date | string, holidays: IHolidayModel[]) => {
   const value = moment(date);
   const weekDay = value.weekday();
-  console.debug(weekDay);
   // TODO: There may be an issue if local time has Monday as the start of the week.
   return isHoliday(date, holidays) ? 5 : weekDay === 0 || weekDay === 6 ? 5 : 3;
 };

--- a/libs/net/dal/Services/WorkOrderService.cs
+++ b/libs/net/dal/Services/WorkOrderService.cs
@@ -90,6 +90,7 @@ public class WorkOrderService : BaseService<WorkOrder, long>, IWorkOrderService
         query = query.Skip(skip).Take(filter.Quantity);
 
         var items = query?.ToArray() ?? Array.Empty<WorkOrder>();
+
         return new Paged<WorkOrder>(items, filter.Page, filter.Quantity, total);
     }
 

--- a/libs/net/entities/WorkOrder.cs
+++ b/libs/net/entities/WorkOrder.cs
@@ -151,7 +151,7 @@ public class WorkOrder : AuditColumns
     /// <param name="type"></param>
     /// <param name="description"></param>
     /// <param name="content"></param>
-    public WorkOrder(WorkOrderType type, string description, Content content) : this(type, description, content.Id)
+    public WorkOrder(WorkOrderType type, string description, Content content) : this(type, description, content.Id, content.Headline)
     {
     }
 
@@ -161,7 +161,8 @@ public class WorkOrder : AuditColumns
     /// <param name="type"></param>
     /// <param name="description"></param>
     /// <param name="contentId"></param>
-    public WorkOrder(WorkOrderType type, string description, long contentId) : this(type, description, $"{{ \"contentId\": {contentId} }}")
+    /// <param name="headline"></param>
+    public WorkOrder(WorkOrderType type, string description, long contentId, string headline) : this(type, description, $"{{ \"contentId\": {contentId}, \"headline\": \"{headline}\" }}")
     {
     }
 
@@ -185,7 +186,8 @@ public class WorkOrder : AuditColumns
     /// <param name="requestorId"></param>
     /// <param name="description"></param>
     /// <param name="contentId"></param>
-    public WorkOrder(WorkOrderType type, int requestorId, string description, long contentId) : this(type, description, contentId)
+    /// <param name="headline"></param>
+    public WorkOrder(WorkOrderType type, int requestorId, string description, long contentId, string headline) : this(type, description, contentId, headline)
     {
         this.RequestorId = requestorId;
     }


### PR DESCRIPTION
All future work orders for transcripts or NLP will include the headline so that it can be displayed without making an additional query.

You can now click on the headline and it will load the content.

> Existing work orders will not have the value regrettably.

![image](https://user-images.githubusercontent.com/3180256/235713137-e9e219f3-2794-4ae7-8d32-f7424de9988d.png)
