### PR TITLE
Fix alert message

### DIFF
--- a/app/editor/src/features/home/InfoText.tsx
+++ b/app/editor/src/features/home/InfoText.tsx
@@ -27,7 +27,7 @@ export const InfoText: React.FC = () => {
         <li>Articles related to major stories.</li>
       </ul>
       <Show visible={alert.isEnabled}>
-        <p>{alert.message ?? ''}</p>
+        <p className="alert-message">{alert.message ?? ''}</p>
       </Show>
       <div className="email">
         <a style={{ marginTop: 25 }} href="mailto:tnonews-help@gov.bc.ca">

--- a/app/editor/src/features/home/styled/InfoPanel.tsx
+++ b/app/editor/src/features/home/styled/InfoPanel.tsx
@@ -19,6 +19,11 @@ export const InfoPanel = styled.div<IInfoPanelProps>`
     .email {
       margin-top: 25px;
     }
+    .alert-message {
+      max-height: 13em;
+      overflow: scroll;
+      overflow-x: hidden;
+    }
   }
 
   .loginPanel {


### PR DESCRIPTION
Added scroll box for alert message on the editor side, everything behaves as expected on subscriber side (enough room for large messages)

![image](https://user-images.githubusercontent.com/15724124/236573600-7cdbbec3-9e2d-4813-9b6a-252af855137c.png)
