### PR TITLE
Fix TNO-1270

### DIFF
--- a/app/editor/src/features/content/form/components/wysiwyg/Wysiwyg.tsx
+++ b/app/editor/src/features/content/form/components/wysiwyg/Wysiwyg.tsx
@@ -53,7 +53,10 @@ export const Wysiwyg: React.FC<IWysiwygProps> = ({
     if (!!id && !!fieldName) {
       setState({
         ...state,
-        html: (values[fieldName] as string)?.replace(/\n/g, '<br />') ?? '',
+        html:
+          (values[fieldName] as string)
+            ?.replace(/\n/g, '<br />')
+            .replaceAll('B.</p><p>C.', 'B.C.') ?? '',
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/editor/src/features/content/form/components/wysiwyg/Wysiwyg.tsx
+++ b/app/editor/src/features/content/form/components/wysiwyg/Wysiwyg.tsx
@@ -53,10 +53,7 @@ export const Wysiwyg: React.FC<IWysiwygProps> = ({
     if (!!id && !!fieldName) {
       setState({
         ...state,
-        html:
-          (values[fieldName] as string)
-            ?.replace(/\n/g, '<br />')
-            .replaceAll('B.</p><p>C.', 'B.C.') ?? '',
+        html: (values[fieldName] as string)?.replace(/\n/g, '<br />') ?? '',
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/libs/net/core/Extensions/StringExtensions.cs
+++ b/libs/net/core/Extensions/StringExtensions.cs
@@ -276,6 +276,7 @@ public static class StringExtensions
         var articleStr = (startPos > 0 ?
             articleContent.Substring(startPos + 9, endPos - (startPos + 9)) :
             articleContent)
+            .Replace("B.</p><p>C.", "B.C.")
             .Replace("</p>", pEndingTagReplacer, true, null);
 
         return Regex.Replace(articleStr, @"<[^>]*>", string.Empty)

--- a/libs/net/core/Extensions/StringExtensions.cs
+++ b/libs/net/core/Extensions/StringExtensions.cs
@@ -276,13 +276,12 @@ public static class StringExtensions
         var articleStr = (startPos > 0 ?
             articleContent.Substring(startPos + 9, endPos - (startPos + 9)) :
             articleContent)
-            .Replace("B.</p><p>C.", "B.C.")
             .Replace("</p>", pEndingTagReplacer, true, null);
 
         return Regex.Replace(articleStr, @"<[^>]*>", string.Empty)
             .Replace("\r\n", string.Empty, true, null)
             .Replace("\n", " ", true, null)
-            .Replace(pEndingTagReplacer, "\n\n")
+            .Replace(pEndingTagReplacer, "\n")
             .Trim();
     }
 


### PR DESCRIPTION
TNO-1270: [QA] Create rule so B.C. and other acronyms do not display with a paragraph break