### PR TITLE
TNO-474 Update report cache

### DIFF
--- a/api/net/Areas/Admin/Controllers/NotificationController.cs
+++ b/api/net/Areas/Admin/Controllers/NotificationController.cs
@@ -165,7 +165,8 @@ public class NotificationController : ControllerBase
             NotificationId = notification.Id,
             ContentId = contentId,
             RequestorId = user.Id,
-            To = to
+            To = to,
+            UpdateCache = true
         };
         await _kafkaProducer.SendMessageAsync(_kafkaOptions.NotificationTopic, $"notification-{notification.Id}-test", request);
         return new JsonResult(new NotificationModel(notification, _serializerOptions));

--- a/api/net/Areas/Admin/Controllers/ReportController.cs
+++ b/api/net/Areas/Admin/Controllers/ReportController.cs
@@ -161,7 +161,8 @@ public class ReportController : ControllerBase
         var request = new ReportRequestModel(ReportDestination.ReportingService, report.Id, new { })
         {
             RequestorId = user.Id,
-            To = to
+            To = to,
+            UpdateCache = true
         };
         await _kafkaProducer.SendMessageAsync(_kafkaOptions.ReportingTopic, $"report-{report.Id}-test", request);
         return new JsonResult(new ReportModel(report, _serializerOptions));

--- a/services/net/content/ContentManager.cs
+++ b/services/net/content/ContentManager.cs
@@ -251,7 +251,7 @@ public class ContentManager : ServiceManager<ContentOptions>
                 OwnerId = model.RequestedById ?? source?.OwnerId,
                 Headline = String.IsNullOrWhiteSpace(model.Title) ? "[TBD]" : model.Title,
                 Uid = model.Uid,
-                Page = model.Page,
+                Page = model.Page[0..Math.Min(model.Page.Length, 10)], // TODO: Temporary workaround to deal FileMonitor Service.
                 Summary = String.IsNullOrWhiteSpace(model.Summary) ? "[TBD]" : StringExtensions.SanitizeContent(model.Summary, "<p(?:\\s[^>]*)?>|</p>", Environment.NewLine),
                 Body = !String.IsNullOrWhiteSpace(model.Body) ? StringExtensions.SanitizeContent(model.Body, "<p(?:\\s[^>]*)?>|</p>", Environment.NewLine) : model.ContentType == ContentType.Snippet ? "" : StringExtensions.SanitizeContent(model.Summary, "<p(?:\\s[^>]*)?>|</p>", Environment.NewLine),
                 SourceUrl = model.Link,


### PR DESCRIPTION
The Razor engine is setup to cache the templates after they are compiled and rendered for the first time.  Without caching it would be slow to recompile each time it ran.  To overwrite cache I've added a flag to control this behaviour.