### PR TITLE
TNO-474 Fix Report/Notification Template

### DIFF
--- a/services/net/notification/NotificationManager.cs
+++ b/services/net/notification/NotificationManager.cs
@@ -390,13 +390,16 @@ public class NotificationManager : ServiceManager<NotificationOptions>
     /// <returns></returns>
     private async Task<string> GenerateNotificationSubjectAsync(NotificationModel notification, ContentModel content, bool updateCache = false)
     {
-        var key = $"notification_{notification.Id}_subject";
-        var cache = this.RazorEngine.Handler.Cache.RetrieveTemplate(key);
+        // TODO: Having a key for every version is a memory leak, but the RazorLight library is junk and has no way to invalidate a cached item.
+        var key = $"notification_{notification.Id}-{notification.Version}_subject";
         var model = new TemplateModel(content, this.Options);
-        if (updateCache && cache.Success)
+        var cache = this.RazorEngine.Handler.Cache?.RetrieveTemplate(key);
+        if (!updateCache && cache?.Success == true)
             return await this.RazorEngine.RenderTemplateAsync(cache.Template.TemplatePageFactory(), model);
         else
+        {
             return await this.RazorEngine.CompileRenderStringAsync(key, notification.Settings.GetDictionaryJsonValue<string>("subject") ?? "", model);
+        }
     }
 
     /// <summary>
@@ -408,13 +411,16 @@ public class NotificationManager : ServiceManager<NotificationOptions>
     /// <returns></returns>
     private async Task<string> GenerateNotificationBodyAsync(NotificationModel notification, ContentModel content, bool updateCache = false)
     {
-        var key = $"notification_{notification.Id}";
-        var cache = this.RazorEngine.Handler.Cache.RetrieveTemplate(key);
+        // TODO: Having a key for every version is a memory leak, but the RazorLight library is junk and has no way to invalidate a cached item.
+        var key = $"notification_{notification.Id}-{notification.Version}";
         var model = new TemplateModel(content, this.Options);
-        if (updateCache && cache.Success)
+        var cache = this.RazorEngine.Handler.Cache?.RetrieveTemplate(key);
+        if (!updateCache && cache?.Success == true)
             return await this.RazorEngine.RenderTemplateAsync(cache.Template.TemplatePageFactory(), model);
         else
+        {
             return await this.RazorEngine.CompileRenderStringAsync(key, notification.Template, model);
+        }
     }
     #endregion
 }

--- a/services/net/reporting/ReportingManager.cs
+++ b/services/net/reporting/ReportingManager.cs
@@ -350,13 +350,16 @@ public class ReportingManager : ServiceManager<ReportingOptions>
     /// <returns></returns>
     private async Task<string> GenerateReportSubjectAsync(API.Areas.Services.Models.Report.ReportModel report, IEnumerable<API.Areas.Services.Models.Content.ContentModel> content, bool updateCache = false)
     {
-        var key = $"report_{report.Id}_subject";
-        var cache = this.RazorEngine.Handler.Cache.RetrieveTemplate(key);
+        // TODO: Having a key for every version is a memory leak, but the RazorLight library is junk and has no way to invalidate a cached item.
+        var key = $"report_{report.Id}-{report.Version}_subject";
         var model = new TemplateModel(content, this.Options);
-        if (updateCache && cache.Success)
+        var cache = this.RazorEngine.Handler.Cache?.RetrieveTemplate(key);
+        if (!updateCache && cache?.Success == true)
             return await this.RazorEngine.RenderTemplateAsync(cache.Template.TemplatePageFactory(), model);
         else
+        {
             return await this.RazorEngine.CompileRenderStringAsync(key, report.Settings.GetDictionaryJsonValue<string>("subject") ?? "", model);
+        }
     }
 
     /// <summary>
@@ -367,13 +370,16 @@ public class ReportingManager : ServiceManager<ReportingOptions>
     /// <returns></returns>
     private async Task<string> GenerateReportBodyAsync(API.Areas.Services.Models.Report.ReportModel report, IEnumerable<API.Areas.Services.Models.Content.ContentModel> content, bool updateCache = false)
     {
-        var key = $"report_{report.Id}";
-        var cache = this.RazorEngine.Handler.Cache.RetrieveTemplate(key);
+        // TODO: Having a key for every version is a memory leak, but the RazorLight library is junk and has no way to invalidate a cached item.
+        var key = $"report_{report.Id}-{report.Version}";
         var model = new TemplateModel(content, this.Options);
-        if (updateCache && cache.Success)
+        var cache = this.RazorEngine.Handler.Cache?.RetrieveTemplate(key);
+        if (!updateCache && cache?.Success == true)
             return await this.RazorEngine.RenderTemplateAsync(cache.Template.TemplatePageFactory(), model);
         else
+        {
             return await this.RazorEngine.CompileRenderStringAsync(key, report.Template, model);
+        }
     }
 
     /// <summary>

--- a/services/net/reporting/ReportingService.cs
+++ b/services/net/reporting/ReportingService.cs
@@ -5,7 +5,6 @@ using TNO.Kafka.Models;
 using TNO.Kafka;
 using TNO.Ches;
 using System.Security.Claims;
-using TNO.Entities.Validation;
 using RazorLight;
 using System.Reflection;
 


### PR DESCRIPTION
Now when we update a report/notification template it will generate a new cached parsing template.

> Please note that this design has a memory leak due to RazorLight being poorly designed.  I've created a story to resolve this issue.  I have also reviewed Fluid templating engine.  However that engine doesn't support grouping (I couldn't figure out how to get it to work).