### PR TITLE
TNO-1299 Publish will reset form

### DIFF
--- a/app/editor/src/features/content/form/ContentStoryForm.tsx
+++ b/app/editor/src/features/content/form/ContentStoryForm.tsx
@@ -16,29 +16,22 @@ import {
   FormikSelect,
   FormikText,
   IOptionItem,
-  IUserModel,
   Modal,
   OptionItem,
   Row,
   Show,
   TimeInput,
-  useKeycloakWrapper,
-  useModal,
 } from 'tno-core';
 
-import { IFile, Tags, TimeLogSection, ToningGroup, Wysiwyg } from '.';
-import { Topic } from './components';
+import { IFile, Tags, ToningGroup, Wysiwyg } from '.';
+import { TimeLogSection, Topic } from './components';
 import { IContentForm } from './interfaces';
 import { MediaSummary } from './MediaSummary';
 import * as styled from './styled';
-import { TimeLogTable } from './TimeLogTable';
-import { getTotalTime } from './utils';
 
 export interface IContentStoryFormProps {
-  setContent: (content: IContentForm) => void;
-  content: IContentForm;
   contentType: ContentTypeName;
-  savePressed?: boolean;
+  setContent: (content: IContentForm) => void;
 }
 
 /**
@@ -46,22 +39,13 @@ export interface IContentStoryFormProps {
  * @param param0 Component properties
  * @returns A new instance of a component.
  */
-export const ContentStoryForm: React.FC<IContentStoryFormProps> = ({
-  setContent,
-  content,
-  contentType,
-  savePressed,
-}) => {
-  const keycloak = useKeycloakWrapper();
-  const [{ series, users, sources }] = useLookup();
+export const ContentStoryForm: React.FC<IContentStoryFormProps> = ({ setContent, contentType }) => {
+  const [{ series, sources }] = useLookup();
   const { values, setFieldValue } = useFormikContext<IContentForm>();
-  const { isShowing, toggle } = useModal();
   const [, contentApi] = useContent();
   const [showExpandModal, setShowExpandModal] = React.useState(false);
   const [seriesOptions, setSeriesOptions] = React.useState<IOptionItem[]>([]);
-  const [effort, setEffort] = React.useState(0);
 
-  const userId = users.find((u: IUserModel) => u.username === keycloak.getUsername())?.id;
   const source = sources.find((s) => s.id === values.sourceId);
   const program = series.find((s) => s.id === values.seriesId);
 
@@ -75,10 +59,6 @@ export const ContentStoryForm: React.FC<IContentStoryFormProps> = ({
     : undefined;
   const [stream, setStream] = React.useState<IStream>(); // TODO: Remove dependency coupling with storage component.
   const videoRef = React.useRef<HTMLVideoElement>(null);
-
-  React.useEffect(() => {
-    setEffort(getTotalTime(values.timeTrackings));
-  }, [values.timeTrackings]);
 
   React.useEffect(() => {
     setFieldValue(
@@ -253,42 +233,12 @@ export const ContentStoryForm: React.FC<IContentStoryFormProps> = ({
           >
             <Wysiwyg label="Story" fieldName="body" expandModal={setShowExpandModal} />
             <Row>
+              <TimeLogSection />
               <Tags />
               <ToningGroup fieldName="tonePools" />
             </Row>
           </Show>
         </Col>
-      </Row>
-      <Row className={contentType !== ContentTypeName.Image ? 'multi-section' : ''}>
-        <Show visible={contentType === ContentTypeName.Snippet}>
-          <Row className="multi-group">
-            <TimeLogSection
-              toggle={toggle}
-              content={content}
-              setContent={setContent}
-              effort={effort}
-              setEffort={setEffort}
-              userId={userId!}
-            />
-            <Modal
-              hide={toggle}
-              isShowing={isShowing}
-              headerText="Prep Time Log"
-              body={
-                <TimeLogTable
-                  setTotalEffort={setEffort}
-                  totalEffort={effort}
-                  data={values.timeTrackings}
-                />
-              }
-              customButtons={
-                <Button variant={ButtonVariant.secondary} onClick={toggle}>
-                  Close
-                </Button>
-              }
-            />
-          </Row>
-        </Show>
       </Row>
     </styled.ContentStoryForm>
   );

--- a/app/editor/src/features/content/form/components/upload/styled/Upload.tsx
+++ b/app/editor/src/features/content/form/components/upload/styled/Upload.tsx
@@ -4,6 +4,9 @@ export const Upload = styled.div`
   display: flex;
   flex-direction: row;
   width: fit-content;
+  height: 100%;
+  width: 100%;
+
   .indicator {
     align-self: center;
     padding-right: 0.25em;
@@ -13,6 +16,12 @@ export const Upload = styled.div`
     height: 5rem;
     width: 5rem;
     align-self: center;
+  }
+  .drop-box {
+    label {
+      height: 100%;
+      width: 100%;
+    }
   }
 
   .text {
@@ -26,10 +35,9 @@ export const Upload = styled.div`
     font-size: 1rem;
   }
   .upload-box {
-    margin-top: 1.5rem;
+    margin-top: 0.5rem;
     border: 1px dotted #ccc;
-    width: 500px;
-    min-height: 24em;
+    padding-bottom: 1rem;
   }
   .body {
     margin-top: 15%;

--- a/app/editor/src/features/content/form/styled/ContentForm.tsx
+++ b/app/editor/src/features/content/form/styled/ContentForm.tsx
@@ -113,7 +113,7 @@ export const ContentForm = styled.div`
 
   .submit-buttons {
     justify-content: flex-end;
-    padding-top: 4.5em;
+    align-items: center;
   }
 
   .content-status {

--- a/app/editor/src/features/content/form/styled/MediaSummary.tsx
+++ b/app/editor/src/features/content/form/styled/MediaSummary.tsx
@@ -3,11 +3,12 @@ import { Row } from 'tno-core';
 
 export const MediaSummary = styled(Row)`
   justify-content: space-evenly;
-  margin-bottom: 1rem;
-  margin-top: 1rem;
+  flex-wrap: row;
+
   hr {
     height: 0.05em;
   }
+
   .summary {
     width: 65%;
     .ql-editor {

--- a/app/editor/src/features/content/hooks/index.ts
+++ b/app/editor/src/features/content/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useTab';

--- a/app/editor/src/features/content/hooks/useTab.tsx
+++ b/app/editor/src/features/content/hooks/useTab.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useChannel } from 'store/hooks';
+
+export const useTab = () => {
+  const channel = useChannel<any>({});
+
+  const [tab, setTab] = React.useState<Window | null>(null);
+
+  return React.useCallback(
+    (id: number, path: string = '/contents') => {
+      if (!tab || tab.closed) setTab(window.open(`${path}/${id}`, '_blank'));
+      else {
+        channel('fetch', id);
+        tab.focus();
+      }
+    },
+    [channel, tab],
+  );
+};

--- a/app/editor/src/features/content/index.ts
+++ b/app/editor/src/features/content/index.ts
@@ -1,4 +1,5 @@
 export * from './form';
+export * from './hooks';
 export * from './list-view';
 export * from './logs';
 export * from './morning-papers';

--- a/app/editor/src/features/content/list-view/components/tool-bar/filter/CreateNewSection.tsx
+++ b/app/editor/src/features/content/list-view/components/tool-bar/filter/CreateNewSection.tsx
@@ -1,3 +1,4 @@
+import { useTab } from 'features/content';
 import React from 'react';
 import { FaFileAlt, FaFileAudio, FaFileImage, FaFileInvoice } from 'react-icons/fa';
 import { GiFairyWand } from 'react-icons/gi';
@@ -9,6 +10,8 @@ import * as styled from './styled';
 export interface ICreateNewSectionProps {
   /** What types of content will be displayed. */
   contentTypes?: ContentTypeName[];
+  /** Whether to open form in tab. */
+  openTab?: boolean;
 }
 
 /**
@@ -22,8 +25,10 @@ export const CreateNewSection: React.FC<ICreateNewSectionProps> = ({
     ContentTypeName.Image,
     ContentTypeName.Story,
   ],
+  openTab = true,
 }) => {
   const navigate = useNavigate();
+  const initTab = useTab();
 
   const getIcon = React.useCallback(
     (contentType: ContentTypeName) => {
@@ -34,7 +39,7 @@ export const CreateNewSection: React.FC<ICreateNewSectionProps> = ({
               key={contentType}
               data-tooltip-content="Radio/TV"
               data-tooltip-id="main-tooltip"
-              onClick={() => navigate('/snippets/0')}
+              onClick={() => (openTab ? initTab(0, '/contents') : navigate('/contents/0'))}
               className="action-button"
             />
           );
@@ -44,7 +49,7 @@ export const CreateNewSection: React.FC<ICreateNewSectionProps> = ({
               key={contentType}
               data-tooltip-content="Print content"
               data-tooltip-id="main-tooltip"
-              onClick={() => navigate('/papers/0')}
+              onClick={() => (openTab ? initTab(0, '/papers') : navigate('/papers/0'))}
               className="action-button"
             />
           );
@@ -54,7 +59,7 @@ export const CreateNewSection: React.FC<ICreateNewSectionProps> = ({
               key={contentType}
               data-tooltip-content="Image"
               data-tooltip-id="main-tooltip"
-              onClick={() => navigate('/images/0')}
+              onClick={() => (openTab ? initTab(0, '/images') : navigate('/images/0'))}
               className="action-button"
             />
           );
@@ -64,13 +69,13 @@ export const CreateNewSection: React.FC<ICreateNewSectionProps> = ({
               key={contentType}
               data-tooltip-content="Internet"
               data-tooltip-id="main-tooltip"
-              onClick={() => navigate('/stories/0')}
+              onClick={() => (openTab ? initTab(0, '/stories') : navigate('/stories/0'))}
               className="action-button"
             />
           );
       }
     },
-    [navigate],
+    [initTab, navigate, openTab],
   );
 
   return (

--- a/app/editor/src/features/content/list-view/constants/columns.tsx
+++ b/app/editor/src/features/content/list-view/constants/columns.tsx
@@ -14,6 +14,7 @@ import {
 import { getStatusText } from '../utils';
 
 export const getColumns = (
+  openTab: boolean,
   onClickOpen: (contentId: number) => void,
 ): ITableHookColumn<IContentModel>[] => [
   {
@@ -119,6 +120,7 @@ export const getColumns = (
     // ),
     showSort: false,
     hAlign: 'center',
+    isVisible: !openTab,
     cell: (cell) => {
       return (
         <FaExternalLinkAlt


### PR DESCRIPTION
The Content List View will now default to opening another tab to load content.  We can come up with a way to make this responsive or based on user preferences later.

- Content Form navigation buttons update the active row on the Content List View
- Creating a new content item will open the form in the other tab
- Modified the layout of the Content Form a little to squeeze the bottom up a little.  Still needs work though.


![image](https://github.com/bcgov/tno/assets/3180256/21198b69-9a51-41ec-b6db-ab6b49926c57)
