### PR TITLE
TNO-1295: New icon for A/V content

### DIFF
--- a/app/subscriber/src/features/commentary/utils/DetermineContentIcon.tsx
+++ b/app/subscriber/src/features/commentary/utils/DetermineContentIcon.tsx
@@ -1,5 +1,4 @@
-import { BiRadio } from 'react-icons/bi';
-import { FaCamera, FaNewspaper, FaTv } from 'react-icons/fa';
+import { FaCamera, FaNewspaper, FaPlayCircle, FaTv } from 'react-icons/fa';
 import { ContentTypeName } from 'tno-core';
 
 import * as styled from './styled';
@@ -17,7 +16,7 @@ export const DetermineContentIcon: React.FC<IDetermineContentIconProps> = ({ con
       case ContentTypeName.Story:
         return <FaTv />;
       case ContentTypeName.Snippet:
-        return <BiRadio />;
+        return <FaPlayCircle />;
       default:
         return <FaCamera />;
     }


### PR DESCRIPTION
Simple change to have a more universal symbol for A/V content as there is presently no trivial way to differentiate the two.
(have confirmed with Bobbi that this one is ok)

- These changes will be reflected in the commentary box of the subscriber site

