### PR TITLE
TNO-1286: Format time w/ 2 digits

### DIFF
--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -7,6 +7,8 @@ import { ContentTypeName, IContentModel, Row, Show, useWindowSize } from 'tno-co
 
 import * as styled from './styled';
 import { ViewContentToolbar } from './ViewContentToolbar';
+import { format } from 'path';
+import { formatTime } from './utils';
 
 export interface IStream {
   url: string;
@@ -66,7 +68,7 @@ export const ViewContent: React.FC = () => {
       const ye = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(d);
       const mo = new Intl.DateTimeFormat('en', { month: 'short' }).format(d);
       const da = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(d);
-      return `${da}-${mo}-${ye} ${d.getHours()}:${d.getMinutes()}:${d.getSeconds()}`;
+      return `${da}-${mo}-${ye} ${formatTime(d)}`;
     } else {
       return '';
     }

--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -6,9 +6,8 @@ import { useContent } from 'store/hooks';
 import { ContentTypeName, IContentModel, Row, Show, useWindowSize } from 'tno-core';
 
 import * as styled from './styled';
-import { ViewContentToolbar } from './ViewContentToolbar';
-import { format } from 'path';
 import { formatTime } from './utils';
+import { ViewContentToolbar } from './ViewContentToolbar';
 
 export interface IStream {
   url: string;

--- a/app/subscriber/src/features/content/view-content/utils/formatTime.ts
+++ b/app/subscriber/src/features/content/view-content/utils/formatTime.ts
@@ -1,0 +1,6 @@
+export const formatTime = (date: Date) => {
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+  return `${hours}:${minutes}:${seconds}`;
+};

--- a/app/subscriber/src/features/content/view-content/utils/index.ts
+++ b/app/subscriber/src/features/content/view-content/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './formatTime';


### PR DESCRIPTION
Time while viewing content will now display in a 2 digit format as requested.
![image](https://github.com/bcgov/tno/assets/15724124/c0f2ce01-f035-48d1-a061-bd32d4dce192)
