### PR TITLE
TNO-1317: CP News content not appearing

### DIFF
--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -121,10 +121,10 @@ export const ViewContent: React.FC = () => {
         </Row>
       </Show>
       <Row id="summary" className="summary">
-        <Show visible={content?.contentType === ContentTypeName.Snippet}>
+        <Show visible={!!content?.summary}>
           <p>{parse(content?.summary ?? '')}</p>
         </Show>
-        <Show visible={content?.contentType === ContentTypeName.PrintContent}>
+        <Show visible={!!content?.body}>
           <p>{parse(content?.body ?? '')}</p>
         </Show>
       </Row>


### PR DESCRIPTION
Previous logic no longer accurate as CP News contains a body and not a summary. New logic will check if summary or body contains data rather than determining off content type.