### PR TITLE
TNO-1380: Bold minister's name on returned content

### DIFF
--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -26,6 +26,13 @@ export const ViewContent: React.FC = () => {
   const { width } = useWindowSize();
   const path = content?.fileReferences ? content?.fileReferences[0]?.path : '';
 
+  const myMinister = localStorage.getItem('myMinister');
+  const regex = new RegExp(myMinister ?? '', 'gi');
+
+  // this will bold the ministers name in the summary and body depending on what piece of content it is
+  if (content?.summary) content.summary = content.summary.replace(regex, `<b>${myMinister}</b>`);
+  if (content?.body) content.body = content.body.replace(regex, `<b>${myMinister}</b>`);
+
   React.useEffect(() => {
     if (!!path)
       stream(path).then((result) => {

--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -29,9 +29,17 @@ export const ViewContent: React.FC = () => {
   const myMinister = localStorage.getItem('myMinister');
   const regex = new RegExp(myMinister ?? '', 'gi');
 
-  // this will bold the ministers name in the summary and body depending on what piece of content it is
-  if (content?.summary) content.summary = content.summary.replace(regex, `<b>${myMinister}</b>`);
-  if (content?.body) content.body = content.body.replace(regex, `<b>${myMinister}</b>`);
+  React.useEffect(() => {
+    // this will bold the ministers name in the summary or body, only when viewing from the my minister list
+    if (window.location.href.includes('my-minister')) {
+      if (content?.summary && !content.summary.includes(`<b>${myMinister}</b>`))
+        setContent({ ...content, body: content.summary.replace(regex, `<b>${myMinister}</b>`) });
+
+      if (content?.body && !content.body.includes(`<b>${myMinister}</b>`)) {
+        setContent({ ...content, body: content.body.replace(regex, `<b>${myMinister}</b>`) });
+      }
+    }
+  }, [content, myMinister, regex]);
 
   React.useEffect(() => {
     if (!!path)

--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -27,10 +27,10 @@ export const ViewContent: React.FC = () => {
   const path = content?.fileReferences ? content?.fileReferences[0]?.path : '';
 
   const myMinister = localStorage.getItem('myMinister');
-  const regex = new RegExp(myMinister ?? '', 'gi');
 
   React.useEffect(() => {
     // this will bold the ministers name in the summary or body, only when viewing from the my minister list
+    const regex = new RegExp(myMinister ?? '', 'gi');
     if (window.location.href.includes('my-minister')) {
       if (content?.summary && !content.summary.includes(`<b>${myMinister}</b>`))
         setContent({ ...content, body: content.summary.replace(regex, `<b>${myMinister}</b>`) });
@@ -39,7 +39,7 @@ export const ViewContent: React.FC = () => {
         setContent({ ...content, body: content.body.replace(regex, `<b>${myMinister}</b>`) });
       }
     }
-  }, [content, myMinister, regex]);
+  }, [content, myMinister]);
 
   React.useEffect(() => {
     if (!!path)

--- a/app/subscriber/src/features/my-minister/MyMinister.tsx
+++ b/app/subscriber/src/features/my-minister/MyMinister.tsx
@@ -57,7 +57,7 @@ export const MyMinister: React.FC = () => {
           isMulti
           groupBy={(item) => item.original.source?.name ?? ''}
           onRowClick={(e: any) => {
-            navigate(`/view/${e.original.id}`);
+            navigate(`/view/my-minister/${e.original.id}`);
           }}
           data={homeItems || []}
           pageButtons={5}

--- a/app/subscriber/src/features/router/AppRouter.tsx
+++ b/app/subscriber/src/features/router/AppRouter.tsx
@@ -36,6 +36,7 @@ export const AppRouter: React.FC<IAppRouter> = () => {
         <Route path="access/request" element={<AccessRequest />} />
         <Route path="/landing/:id" element={<Landing />} />
         <Route path="/view/:id" element={<Landing />} />
+        <Route path="/view/my-minister/:id" element={<Landing />} />
         <Route path="error" element={<InternalServerError />} />
         <Route path="*" element={<NotFound />} />
       </Route>


### PR DESCRIPTION
This PR includes functionality that bolds the user's selected minister in the body or summary of a piece of content. See GIF below for reference (**hard to see from thumbnail - click image for clearer view**).

- only functions when user views content from their my minster list
- currently set up just for one minister at a time


![bold-myminister](https://github.com/bcgov/tno/assets/15724124/cd9ebdb4-3889-4667-acb9-3edda593aab7)
