### PR TITLE
TNO-1380: Bold minister's name on returned content - Adjustment

### DIFF
--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -137,7 +137,8 @@ export const ViewContent: React.FC = () => {
         </Row>
       </Show>
       <Row id="summary" className="summary">
-        <Show visible={!!content?.summary}>
+        {/* only show summary if there is no body */}
+        <Show visible={!!content?.summary && !content.body}>
           <p>{parse(content?.summary ?? '')}</p>
         </Show>
         <Show visible={!!content?.body}>


### PR DESCRIPTION
Only return summary if there is no body present. Body contains the full content the user is looking for when present.