### PR TITLE
[Bug] Content summary displaying instead of body: Updating logic

### DIFF
--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -138,12 +138,11 @@ export const ViewContent: React.FC = () => {
       </Show>
       <Row id="summary" className="summary">
         {/* only show summary if there is no body */}
-        <Show visible={!!content?.summary && !content.body}>
-          <p>{parse(content?.summary ?? '')}</p>
-        </Show>
-        <Show visible={!!content?.body}>
+        {!!content?.body ? (
           <p>{parse(content?.body ?? '')}</p>
-        </Show>
+        ) : (
+          <p>{parse(content?.summary ?? '')}</p>
+        )}
       </Row>
     </styled.ViewContent>
   );


### PR DESCRIPTION
Summary would somehow override body with previous logic (in certain scenarios), using ternary instead of the Show component now.

Unable to recreate locally so hopefully this will work as it is on my local machine.