### PR TITLE
[Bug] Change of logic for displaying body or summary

### DIFF
--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -137,12 +137,22 @@ export const ViewContent: React.FC = () => {
         </Row>
       </Show>
       <Row id="summary" className="summary">
-        {/* only show summary if there is no body */}
-        {!!content?.body ? (
+        <Show
+          visible={
+            content?.contentType === ContentTypeName.PrintContent ||
+            content?.contentType === ContentTypeName.Story
+          }
+        >
           <p>{parse(content?.body ?? '')}</p>
-        ) : (
+        </Show>
+        <Show
+          visible={
+            content?.contentType === ContentTypeName.Snippet ||
+            content?.contentType === ContentTypeName.Image
+          }
+        >
           <p>{parse(content?.summary ?? '')}</p>
-        )}
+        </Show>
       </Row>
     </styled.ViewContent>
   );


### PR DESCRIPTION
Let me know if this looks ok, having issues with the previous logic in DEV. Using the same logic now as we do on the editor. 

- if the content is of type snippet or image -> display summary
- if the content is of type story or print content -> display body