### PR TITLE
TNO-1406 Editor Fixes

### DIFF
--- a/app/editor/src/features/content/form/components/tags/Tags.tsx
+++ b/app/editor/src/features/content/form/components/tags/Tags.tsx
@@ -55,6 +55,7 @@ export const Tags: React.FC<ITagsProps> = () => {
             name="tags"
             options={tagOptions}
             maxMenuHeight={120}
+            menuPlacement="top"
             value={tagOptions.filter((option) =>
               values.tags.find((tag) => tag.id === option.value),
             )}

--- a/app/editor/src/features/content/form/components/time-log/styled/TimeLogSection.tsx
+++ b/app/editor/src/features/content/form/components/time-log/styled/TimeLogSection.tsx
@@ -6,13 +6,14 @@ export const TimeLogSection = styled(Row)`
     align-self: center;
     padding-right: 0.25em;
     padding-top: 0.5em;
+    height: 1.75em;
+    width: 2em;
     color: ${(props) => props.theme.css.actionButtonColor};
+    cursor: pointer;
+
     :hover {
       color: ${(props) => props.theme.css.lightVariantColor};
     }
-    height: 1.75em;
-    width: 2em;
-    cursor: pointer;
   }
   .disabled-section {
     label {

--- a/app/editor/src/features/content/form/styled/TimeLogTable.tsx
+++ b/app/editor/src/features/content/form/styled/TimeLogTable.tsx
@@ -2,11 +2,11 @@ import styled from 'styled-components';
 
 export const TimeLogTable = styled.div`
   div[role='table'] {
-    width: 550px;
     .fa-trash:hover {
       color: red;
     }
   }
+
   .total-text {
     font-weight: 700;
     margin-top: 1%;


### PR DESCRIPTION
Tags select opens from the top instead of the bottom.  Also fixed layout of time log.

![image](https://github.com/bcgov/tno/assets/3180256/1308fe1c-fc09-44d3-b506-eccd68d20633)

Time Log Modal

![image](https://github.com/bcgov/tno/assets/3180256/b29a1750-5c2c-4b8d-9f31-470e46ea0802)
