### PR TITLE
TNO-1379: Reduce width of tone column

### DIFF
--- a/app/subscriber/src/features/home/constants/columns.tsx
+++ b/app/subscriber/src/features/home/constants/columns.tsx
@@ -8,6 +8,7 @@ export const determinecolumns = (contentType: ContentTypeName | 'all') => {
     {
       name: 'tone',
       label: 'TONE',
+      width: 0.25,
       cell: (cell) => (
         <DetermineToneIcon tone={cell.original.tonePools ? cell.original.tonePools[0]?.value : 0} />
       ),
@@ -16,7 +17,7 @@ export const determinecolumns = (contentType: ContentTypeName | 'all') => {
       name: 'headline',
       label: 'HEADLINE',
       cell: (cell) => <div className="headline">{cell.original.headline}</div>,
-      width: 5,
+      width: 4,
     },
   ];
   // columns specific to print content


### PR DESCRIPTION
Simple fix to reduce the width of the tone column to free up some space, additionally reducing width of headline column to help with the responsiveness when collapsing.