### PR TITLE
TNO-1411: Add page number to content view

### DIFF
--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -152,7 +152,8 @@ export const ViewContent: React.FC = () => {
         </p>
         <p className="source-section">
           <Show visible={content?.contentType === ContentTypeName.PrintContent}>
-            {content?.source?.name} - {`${content?.section}: ${content?.page}`}
+            {content?.source?.name} -{' '}
+            {`${content?.section}${content?.page ? `: ${content?.page}` : ''}`}
           </Show>
           <Show visible={content?.contentType !== ContentTypeName.PrintContent}>
             {!!content?.series && `${content?.source?.name} / ${content?.series?.name}`}

--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -152,7 +152,7 @@ export const ViewContent: React.FC = () => {
         </p>
         <p className="source-section">
           <Show visible={content?.contentType === ContentTypeName.PrintContent}>
-            {content?.source?.name} - {content?.section}
+            {content?.source?.name} - {`${content?.section}: ${content?.page}`}
           </Show>
           <Show visible={content?.contentType !== ContentTypeName.PrintContent}>
             {!!content?.series && `${content?.source?.name} / ${content?.series?.name}`}


### PR DESCRIPTION
Simple fix to add page number on the content view page.

![image](https://github.com/bcgov/tno/assets/15724124/daf4cbf3-3345-48fe-a72a-58abca8a8186)
