### PR TITLE
TNO-1288: Adjust order of display of papers

### DIFF
--- a/app/subscriber/src/features/home/Home.tsx
+++ b/app/subscriber/src/features/home/Home.tsx
@@ -32,6 +32,7 @@ export const Home: React.FC = () => {
             contentTypes:
               filter.contentTypes.length > 0 ? filter.contentTypes : [ContentTypeName.PrintContent],
             startDate: filter.startDate ? filter.startDate : new Date().toDateString(),
+            sort: [{ id: 'sourceSort' }],
             status: ContentStatus.Published,
           }),
         );
@@ -68,7 +69,7 @@ export const Home: React.FC = () => {
           onRowClick={(e: any) => {
             navigate(`/view/${e.original.id}`);
           }}
-          data={homeItems || []}
+          data={homeItems}
           pageButtons={5}
           showPaging={false}
         />

--- a/app/subscriber/src/features/home/Home.tsx
+++ b/app/subscriber/src/features/home/Home.tsx
@@ -32,7 +32,7 @@ export const Home: React.FC = () => {
             contentTypes:
               filter.contentTypes.length > 0 ? filter.contentTypes : [ContentTypeName.PrintContent],
             startDate: filter.startDate ? filter.startDate : new Date().toDateString(),
-            sort: [{ id: 'sourceSort' }],
+            sort: [{ id: 'source.sortOrder' }],
             status: ContentStatus.Published,
           }),
         );

--- a/app/subscriber/src/features/home/utils/makeFilter.ts
+++ b/app/subscriber/src/features/home/utils/makeFilter.ts
@@ -29,6 +29,7 @@ export const makeFilter = (
     includeHidden: filter.includeHidden ? true : undefined,
     publishedStartOn: filter.startDate ? moment(filter.startDate).toISOString() : undefined,
     publishedEndOn: filter.endDate ? filter.endDate : undefined,
+    sort: filter.sort.length > 0 ? filter.sort.map((x) => x.id) : undefined,
     logicalOperator:
       filter.searchTerm !== '' && filter.logicalOperator !== ''
         ? filter.logicalOperator

--- a/libs/net/dal/Services/ContentService.cs
+++ b/libs/net/dal/Services/ContentService.cs
@@ -372,6 +372,7 @@ public class ContentService : BaseService<Content, long>, IContentService
                 if (sort == "otherSource") objPath = p => p.OtherSource;
                 if (sort == "page") objPath = p => p.Page;
                 if (sort == "status") objPath = p => p.Status;
+                if (sort == "sourceSort") objPath = p => p.Source!.SortOrder;
 
                 if (objPath != null) result = result.Sort(s => sorts.EndsWith(" desc") ? s.Descending(objPath) : s.Ascending(objPath));
             }

--- a/libs/net/dal/Services/ContentService.cs
+++ b/libs/net/dal/Services/ContentService.cs
@@ -372,7 +372,7 @@ public class ContentService : BaseService<Content, long>, IContentService
                 if (sort == "otherSource") objPath = p => p.OtherSource;
                 if (sort == "page") objPath = p => p.Page;
                 if (sort == "status") objPath = p => p.Status;
-                if (sort == "sourceSort") objPath = p => p.Source!.SortOrder;
+                if (sort == "source.sortOrder") objPath = p => p.Source!.SortOrder;
 
                 if (objPath != null) result = result.Sort(s => sorts.EndsWith(" desc") ? s.Descending(objPath) : s.Ascending(objPath));
             }


### PR DESCRIPTION
In this PR:

- papers on the home page will now display based off the papers defined sort order 
- these can be updated at any time through the editor -> admin -> sources -> sort order