### PR TITLE
Jobs automatic deletion

### DIFF
--- a/openshift/kustomize/cron/base/cron-job.yaml
+++ b/openshift/kustomize/cron/base/cron-job.yaml
@@ -13,6 +13,7 @@ metadata:
     managed-by: kustomize
     created-by: jeremy.foster
 spec:
+  ttlSecondsAfterFinished: 100
   schedule: "0 0 * * *" # Midnight
   # schedule: "* * * * *" # Immediately
   jobTemplate:

--- a/openshift/kustomize/postgres/crunchy/base/deploy.yaml
+++ b/openshift/kustomize/postgres/crunchy/base/deploy.yaml
@@ -80,6 +80,8 @@ spec:
           limits:
             cpu: 250m
             memory: 1Gi
+      jobs: 
+        ttlSecondsAfterFinished: 100
       repos:
         - name: repo1
           schedules:


### PR DESCRIPTION
1) Feat(Crunchy PG backup jobs deletion): Added jobs: ttlSecondsAfterFinished will be applied to both full & incremental backups schedules and will delete jobs after success or failed state after 100 seconds. This will free up occupied resource capacity.

2) feat(cron job deletion): Delete as above.