### PR TITLE
TNO-1439: Include source on internet types

### DIFF
--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -7,6 +7,7 @@ import { useApp, useContent, useWorkOrders } from 'store/hooks';
 import {
   Button,
   ButtonVariant,
+  Col,
   ContentTypeName,
   IContentModel,
   IWorkOrderModel,
@@ -74,7 +75,6 @@ export const ViewContent: React.FC = () => {
       myMinisters.length &&
         myMinisters.forEach((minister: string, index: number) => {
           const regex = new RegExp(minister ?? '', 'gi');
-          console.log(minister);
           if (content?.summary && !content.summary.includes(`<b>${minister}</b>`)) {
             tempSummary = tempSummary?.replace(regex, `<b>${minister}</b>`);
           }
@@ -165,10 +165,15 @@ export const ViewContent: React.FC = () => {
         </Row>
       </Row>
       <Row justifyContent="space-between">
-        <p className="name-date">
-          {content?.byline ? `by ${content?.byline} - ` : ''}
-          {formatDate(content?.publishedOn ?? '')}
-        </p>
+        <Col>
+          <p className="name-date">
+            {content?.byline ? `by ${content?.byline} - ` : ''}
+            {formatDate(content?.publishedOn ?? '')}
+          </p>
+          <Show visible={!!content?.source?.name && content?.contentType === ContentTypeName.Story}>
+            <p className="source-name">{content?.source?.name}</p>
+          </Show>
+        </Col>
         <p className="source-section">
           <Show visible={content?.contentType === ContentTypeName.PrintContent}>
             {content?.source?.name} -{' '}

--- a/app/subscriber/src/features/content/view-content/styled/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/styled/ViewContent.tsx
@@ -23,9 +23,14 @@ export const ViewContent = styled.div`
   .neut {
     color: #ffc107;
   }
-  .name-date {
+  .name-date,
+  .source-name {
     font-size: 0.875rem;
     font-weight: 600;
+  }
+
+  .source-name {
+    margin-top: 0;
   }
   .source-section {
     font-size: 0.875rem;


### PR DESCRIPTION
Include source name on content with the content type of Internet, other types already include this. 

![image](https://github.com/bcgov/tno/assets/15724124/922a91b3-704c-4dbc-8ba5-4d94669c8193)
