### PR TITLE
TNO-1448: Link to source url when present

### DIFF
--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -200,22 +200,29 @@ export const ViewContent: React.FC = () => {
         </Row>
       </Show>
       <Row id="summary" className="summary">
-        <Show
-          visible={
-            content?.contentType === ContentTypeName.PrintContent ||
-            content?.contentType === ContentTypeName.Story
-          }
-        >
-          <span>{parse(content?.body ?? '')}</span>
-        </Show>
-        <Show
-          visible={
-            content?.contentType === ContentTypeName.AudioVideo ||
-            content?.contentType === ContentTypeName.Image
-          }
-        >
-          <span>{parse(content?.summary ?? '')}</span>
-        </Show>
+        <Col>
+          <Show
+            visible={
+              content?.contentType === ContentTypeName.PrintContent ||
+              content?.contentType === ContentTypeName.Story
+            }
+          >
+            <span>{parse(content?.body ?? '')}</span>
+          </Show>
+          <Show
+            visible={
+              content?.contentType === ContentTypeName.AudioVideo ||
+              content?.contentType === ContentTypeName.Image
+            }
+          >
+            <span>{parse(content?.summary ?? '')}</span>
+          </Show>
+          <Show visible={!!content?.sourceUrl}>
+            <a target="_blank" href={content?.sourceUrl}>
+              More...
+            </a>
+          </Show>
+        </Col>
         <Show visible={content?.contentType === ContentTypeName.AudioVideo}>
           <Button
             onClick={() => handleTranscribe()}

--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -218,7 +218,7 @@ export const ViewContent: React.FC = () => {
             <span>{parse(content?.summary ?? '')}</span>
           </Show>
           <Show visible={!!content?.sourceUrl}>
-            <a target="_blank" href={content?.sourceUrl}>
+            <a rel="noreferrer" target="_blank" href={content?.sourceUrl}>
               More...
             </a>
           </Show>


### PR DESCRIPTION
Added `More...` link to content when a source url is present. Clicking said link will open a new tab redirecting the user to the source url to "read more".

![morelink](https://github.com/bcgov/tno/assets/15724124/f4bf7358-cdac-4a6b-9d22-0af3e096f061)
