### PR TITLE
Search page bug

### DIFF
--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -32,14 +32,25 @@ export const SearchPage: React.FC = () => {
 
   const urlParams = new URLSearchParams(window.location.search);
   const queryText = urlParams.get('queryText');
+
+  // function that bolds the searched text
   const formatSearch = (text: string) => {
     let tempText = text;
     queryText?.split(' ').forEach((word) => {
       const regex = new RegExp(word ?? '', 'gi');
-      const matches = text.match(regex) ?? [];
+      // remove duplicates found only want unique matches, this will be varying capitalization
+      const matches = text.match(regex)?.filter((v, i, a) => a.indexOf(v) == i) ?? [];
       // text.match included in replace in order to keep the proper capitalization
-      // TODO: Small capitlization bug when searching for a word that appears multiple times and has lower and upercase instances.
-      tempText = tempText.replace(regex, `<b>${matches.length > 1 ? word : text.match(regex)}</b>`);
+      // When there is more than one match, this indicates there will be varying capitalization. In this case we
+      // have to iterate through the matches and do a more specific replace in order to keep the words capitalization
+      if (matches.length > 1) {
+        matches.forEach((match, i) => {
+          let multiMatch = new RegExp(`${matches[i]}`);
+          tempText = tempText.replace(multiMatch, `<b>${match}</b>`);
+        });
+      } else {
+        tempText = tempText.replace(regex, `<b>${text.match(regex)}</b>`);
+      }
     });
     return parse(tempText);
   };

--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -39,7 +39,7 @@ export const SearchPage: React.FC = () => {
     queryText?.split(' ').forEach((word) => {
       const regex = new RegExp(word ?? '', 'gi');
       // remove duplicates found only want unique matches, this will be varying capitalization
-      const matches = text.match(regex)?.filter((v, i, a) => a.indexOf(v) == i) ?? [];
+      const matches = text.match(regex)?.filter((v, i, a) => a.indexOf(v) === i) ?? [];
       // text.match included in replace in order to keep the proper capitalization
       // When there is more than one match, this indicates there will be varying capitalization. In this case we
       // have to iterate through the matches and do a more specific replace in order to keep the words capitalization

--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -36,8 +36,10 @@ export const SearchPage: React.FC = () => {
     let tempText = text;
     queryText?.split(' ').forEach((word) => {
       const regex = new RegExp(word ?? '', 'gi');
+      const matches = text.match(regex) ?? [];
       // text.match included in replace in order to keep the proper capitalization
-      tempText = tempText.replace(regex, `<b>${text.match(regex)}</b>`);
+      // TODO: Small capitlization bug when searching for a word that appears multiple times and has lower and upercase instances.
+      tempText = tempText.replace(regex, `<b>${matches.length > 1 ? word : text.match(regex)}</b>`);
     });
     return parse(tempText);
   };


### PR DESCRIPTION
This fixes the following current issue in dev: 
![image](https://github.com/bcgov/tno/assets/15724124/80c9558b-503a-4da1-8833-5b03118f8f46)

When there are multiple matched instances of a queried word, it will repeat itself. This PR will only bold and replace it with the proper word/capitalization.

Got a tiny bit tricky to maintain the capitalization of each word, could not simply replace it with a bolded version of the query text as that would result in things like `Eby` being replaced with `<b>eby</b>` (lowecase)
