### PR TITLE
One more bug 

### DIFF
--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -49,7 +49,8 @@ export const SearchPage: React.FC = () => {
           tempText = tempText.replace(multiMatch, `<b>${match}</b>`);
         });
       } else {
-        tempText = tempText.replace(regex, `<b>${text.match(regex)}</b>`);
+        // in this case there will only be one match, so we can just insert the first match
+        tempText = tempText.replace(regex, `<b>${matches[0]}</b>`);
       }
     });
     return parse(tempText);


### PR DESCRIPTION
One more silly mistake 🐛 

Working as intended now:
![image](https://github.com/bcgov/tno/assets/15724124/9d227d44-e40e-449c-b99a-cd59456e0815)
