### PR TITLE
Fix Image/Syndication/Content Services

### DIFF
--- a/libs/net/kafka/Models/ContentBase.cs
+++ b/libs/net/kafka/Models/ContentBase.cs
@@ -178,7 +178,7 @@ public abstract class ContentBase
     /// <param name="title"></param>
     /// <param name="summary"></param>
     /// <param name="publishedOn"></param>
-    public ContentBase(string dataLocation, string source, ContentType contentType, int productId, string uid, string title, string summary, DateTime publishedOn)
+    public ContentBase(string dataLocation, string source, ContentType contentType, int productId, string uid, string title, string summary, DateTime? publishedOn)
         : this(dataLocation, source, contentType, productId, uid, title, summary)
     {
         this.PublishedOn = publishedOn;

--- a/libs/net/kafka/Models/SourceContent.cs
+++ b/libs/net/kafka/Models/SourceContent.cs
@@ -40,7 +40,7 @@ public class SourceContent : ContentBase
     /// <param name="publish"></param>
     /// <exception cref="ArgumentNullException"></exception>
     public SourceContent(string dataLocation, string source, ContentType contentType, int productId,
-        string uid, string title, string summary, string body, DateTime publishedOn, bool publish = false)
+        string uid, string title, string summary, string body, DateTime? publishedOn, bool publish = false)
         : base(dataLocation, source, contentType, productId, uid, title, summary, publishedOn)
     {
         this.Body = body ?? throw new ArgumentNullException(nameof(body));

--- a/libs/net/services/Actions/IngestAction.cs
+++ b/libs/net/services/Actions/IngestAction.cs
@@ -169,11 +169,17 @@ public abstract class IngestAction<TOptions> : ServiceAction<TOptions>, IIngestA
         return date.ToTimeZone(IngestActionManager<TOptions>.GetTimeZone(ingest, this.Options.TimeZone));
     }
 
+    /// <summary>
+    /// Create a unique hash for the specified 'source', 'headline', and 'publishedOn'
+    /// </summary>
+    /// <param name="source"></param>
+    /// <param name="headline"></param>
+    /// <param name="publishedOn"></param>
+    /// <returns></returns>
     protected string GetContentHash(string source, string headline, DateTime? publishedOn)
     {
-        string hashInput = publishedOn.HasValue
-            ? $"{source}:{headline}:{publishedOn:yyyy-MM-dd-hh-mm-ss}"
-            : $"{source}:{headline}";
+        var date = publishedOn.HasValue ? $"{publishedOn:yyyy-MM-dd-hh-mm-ss}" : "";
+        string hashInput = $"{source}:{headline}:{date}";
         var inputBytes = Encoding.UTF8.GetBytes(hashInput);
         var inputHash = SHA256.HashData(inputBytes);
         return Convert.ToHexString(inputHash);

--- a/libs/net/services/Managers/IngestManager`.cs
+++ b/libs/net/services/Managers/IngestManager`.cs
@@ -197,9 +197,6 @@ public abstract class IngestManager<TIngestServiceActionManager, TOption> : Serv
         {
             try
             {
-                // If the service isn't running, don't make additional requests.
-                if (this.State.Status == ServiceStatus.Paused || this.State.Status == ServiceStatus.Sleeping) continue;
-
                 var results = await this.Api.HandleRequestFailure<IEnumerable<IngestModel>>(
                     async () => await this.Api.GetIngestsForIngestTypeAsync(ingestType),
                     this.Options.ReuseIngests,

--- a/openshift/kustomize/api/base/deploy.yaml
+++ b/openshift/kustomize/api/base/deploy.yaml
@@ -81,6 +81,8 @@ spec:
               value: http://+:8080
             - name: HubPath
               value: /hub
+            - name: Charts__Url
+              value: "http://charts-api:8080"
 
             - name: Logging__LogLevel__TNO
               value: Information

--- a/openshift/kustomize/api/base/statefulset.yaml
+++ b/openshift/kustomize/api/base/statefulset.yaml
@@ -97,6 +97,8 @@ spec:
               value: http://+:8080
             - name: HubPath
               value: /hub
+            - name: Charts__Url
+              value: "http://charts-api:8080"
 
             - name: Logging__LogLevel__TNO
               value: Information

--- a/services/net/syndication/Xml/Rss/RssItem.cs
+++ b/services/net/syndication/Xml/Rss/RssItem.cs
@@ -112,7 +112,8 @@ public class RssItem
         this.Categories = RssCategory.LoadAll(element, enforceSpec);
         this.Source = RssSource.Load(element, enforceSpec);
 
-        if (element.Element("pubDate")?.Value.TryParseDateTimeExact(CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out DateTime pubDate, RssFeed.PUB_DATE_FORMATS) == true) this.PublishedOn = pubDate;
+        if (element.Element("pubDate")?.Value.TryParseDateTimeExact(CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out DateTime pubDate, RssFeed.PUB_DATE_FORMATS) == true)
+            this.PublishedOn = pubDate;
     }
     #endregion
 


### PR DESCRIPTION
There were a number of regression issues introduced with the latest changes to support the Content Migration Service.  This should resolve the identified issues.

- Front page images should now be imported
- Front page images should not result in mass duplication
- Front page image files should now be imported
- Syndication feeds that require a separate request for content should now work again (CPNews)
- All Ingest Services should always fetch the ingest configurations even when they go error out