### PR TITLE
fix: #tno-1538 - switch Label and Name

### DIFF
--- a/services/net/syndication/SyndicationAction.cs
+++ b/services/net/syndication/SyndicationAction.cs
@@ -251,7 +251,7 @@ public class SyndicationAction : IngestAction<SyndicationOptions>
             Language = "", // TODO: Need to extract this from the ingest, or determine it after transcription.
             Authors = item.Authors.Select(a => new Author(a.Name, a.Email, a.Uri)),
             UpdatedOn = item.LastUpdatedTime != DateTime.MinValue ? item.LastUpdatedTime.UtcDateTime : null,
-            Labels = item.Categories.Select(c => new LabelModel(c.Name, c.Label)),
+            Labels = item.Categories.Select(c => new LabelModel(c.Label, c.Name)),
             ExternalUid = item.Id
         };
     }


### PR DESCRIPTION
when translating the Categories to Labels, swapped the Name and Label so that the 'Key' and 'Value' are set correctly for Syndication sources