### PR TITLE
fix: #tno-1524 - only update content status

### DIFF
--- a/api/net/Areas/Services/Controllers/ContentController.cs
+++ b/api/net/Areas/Services/Controllers/ContentController.cs
@@ -252,6 +252,23 @@ public class ContentController : ControllerBase
 
         return new JsonResult(new ContentModel(content));
     }
+    /// <summary>
+    /// Update content for the specified 'id'.
+    /// Will not trigger any re-index or audit trail update
+    /// </summary>
+    /// <param name="model"></param>
+    /// <returns></returns>
+    [HttpPut("{id}/status")]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(typeof(ContentModel), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
+    [SwaggerOperation(Tags = new[] { "Content" })]
+    public IActionResult UpdateStatusAsync(ContentModel model)
+    {
+        var content = _contentService.UpdateStatusOnly((Content)model);
+
+        return new JsonResult(new ContentModel(content));
+    }
 
     /// <summary>
     /// Upload a file and link it to the specified content.

--- a/libs/net/dal/Services/ContentService.cs
+++ b/libs/net/dal/Services/ContentService.cs
@@ -223,7 +223,7 @@ public class ContentService : BaseService<Content, long>, IContentService
 
         if (filter.Sentiment.Any())
             filterQueries.Add(s => s.Nested(n => n.Path(p => p.TonePools).Query(y => y.Range(m => m.Field("tonePools.value").GreaterThanOrEquals(filter.Sentiment.First()).LessThanOrEquals(filter.Sentiment.Last())))));
-        
+
         if (filter.ProductIds.Any())
             filterQueries.Add(s => s.Terms(t => t.Field(f => f.ProductId).Terms(filter.ProductIds)));
 
@@ -514,7 +514,6 @@ public class ContentService : BaseService<Content, long>, IContentService
         var original = FindById(updated.Id) ?? throw new InvalidOperationException("Entity does not exist");
 
         this.Context.Entry(original.Status).CurrentValues.SetValues(updated.Status);
-        this.Context.ResetVersion(original);
 
         return base.Update(original);
     }

--- a/libs/net/dal/Services/ContentService.cs
+++ b/libs/net/dal/Services/ContentService.cs
@@ -501,5 +501,22 @@ public class ContentService : BaseService<Content, long>, IContentService
         return this.Context.NotificationInstances
             .Where(n => n.ContentId == contentId);
     }
+
+    /// <summary>
+    /// Update the specified 'entity' in the database.
+    /// </summary>
+    /// <param name="updated"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// TODO: Switch to not found exception throughout services.
+    public Content UpdateStatusOnly(Content updated)
+    {
+        var original = FindById(updated.Id) ?? throw new InvalidOperationException("Entity does not exist");
+
+        this.Context.Entry(original.Status).CurrentValues.SetValues(updated.Status);
+        this.Context.ResetVersion(original);
+
+        return base.Update(original);
+    }
     #endregion
 }

--- a/libs/net/dal/Services/Interfaces/IContentService.cs
+++ b/libs/net/dal/Services/Interfaces/IContentService.cs
@@ -20,4 +20,13 @@ public interface IContentService : IBaseService<Content, long>
     /// <param name="contentId"></param>
     /// <returns></returns>
     IEnumerable<NotificationInstance> GetNotificationsFor(long contentId);
+
+    /// <summary>
+    /// Update the ContentStatus for the specified 'contentId'.
+    /// Will not trigger a version number change.
+    /// </summary>
+    /// <param name="contentId"></param>
+    /// <returns></returns>
+    Content UpdateStatusOnly(Content entity);
+
 }

--- a/libs/net/services/Helpers/ApiService.cs
+++ b/libs/net/services/Helpers/ApiService.cs
@@ -10,6 +10,8 @@ using TNO.Services.Config;
 using TNO.Core.Extensions;
 using TNO.Core.Http;
 using Microsoft.Extensions.Logging;
+using TNO.API.Areas.Services.Models.Content;
+using TNO.Entities;
 
 namespace TNO.Services;
 
@@ -476,6 +478,21 @@ public class ApiService : IApiService
         int? requestorId = null)
     {
         var url = this.Options.ApiUrl.Append($"services/contents/{content.Id}?index={index}{(requestorId.HasValue ? $"&requestorId={requestorId.Value}" : "")}");
+        return await RetryRequestAsync(async () => await Client.SendAsync<API.Areas.Services.Models.Content.ContentModel>(url, HttpMethod.Put, headers, JsonContent.Create(content)));
+    }
+
+    /// <summary>
+    /// Make an HTTP request to the api to update the content status for the specified 'id'.
+    /// Will not trigger any re-index or audit trail update
+    /// </summary>
+    /// <param name="contentId"></param>
+    /// <param name="newStatus"></param>
+    /// <returns></returns>
+    public async Task<ContentModel?> UpdateContentStatusAsync(
+        API.Areas.Services.Models.Content.ContentModel content,
+        HttpRequestHeaders? headers = null)
+    {
+        var url = this.Options.ApiUrl.Append($"services/contents/{content.Id}/status");
         return await RetryRequestAsync(async () => await Client.SendAsync<API.Areas.Services.Models.Content.ContentModel>(url, HttpMethod.Put, headers, JsonContent.Create(content)));
     }
 

--- a/libs/net/services/Interfaces/IApiService.cs
+++ b/libs/net/services/Interfaces/IApiService.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Headers;
+using TNO.Entities;
 
 namespace TNO.Services;
 
@@ -186,6 +187,15 @@ public interface IApiService
     /// <param name="requestorId">The user ID who is requesting the update.</param>
     /// <returns></returns>
     public Task<API.Areas.Services.Models.Content.ContentModel?> UpdateContentAsync(API.Areas.Services.Models.Content.ContentModel content, HttpRequestHeaders? headers = null, bool index = false, int? requestorId = null);
+
+    /// <summary>
+    /// Make a request to the API to update the content status for the specified ContentModel.
+    /// Will not trigger any re-index or audit trail update
+    /// </summary>
+    /// <param name="content"></param>
+    /// <param name="headers"></param>
+    /// <returns></returns>
+    public Task<API.Areas.Services.Models.Content.ContentModel?> UpdateContentStatusAsync(API.Areas.Services.Models.Content.ContentModel content, HttpRequestHeaders? headers = null);
 
     /// <summary>
     /// Make a request to the API to upload the file and link to specified content.

--- a/services/net/indexing/IndexingManager.cs
+++ b/services/net/indexing/IndexingManager.cs
@@ -294,7 +294,7 @@ public class IndexingManager : ServiceManager<IndexingOptions>
         if (content.Status != ContentStatus.Published)
         {
             content.Status = ContentStatus.Published;
-            content = await this.Api.UpdateContentAsync(content, Headers) ?? throw new InvalidOperationException($"Content failed to update. ID:{content.Id}");
+            content = await this.Api.UpdateContentStatusAsync(content, Headers) ?? throw new InvalidOperationException($"Content failed to update. ID:{content.Id}");
         }
 
         // Remove the transcript body if it hasn't been approved.


### PR DESCRIPTION
Update the API endpoint and Content Service to only update the `Content.Status` to eliminate data corruption or concurrency issues.