### PR TITLE
feat: #tno-1533 - change layout of subscriber page

### DIFF
--- a/app/subscriber/src/features/commentary/styled/Commentary.tsx
+++ b/app/subscriber/src/features/commentary/styled/Commentary.tsx
@@ -8,7 +8,6 @@ export const Commentary = styled.div`
   }
 
   @media (min-width: 1702px) {
-    min-width: 35em;
     margin-bottom: 5%;
   }
 

--- a/app/subscriber/src/features/front-pages/styled/FrontPages.tsx
+++ b/app/subscriber/src/features/front-pages/styled/FrontPages.tsx
@@ -3,7 +3,6 @@ import { Col } from 'tno-core';
 
 export const FrontPages = styled(Col)`
   @media (min-width: 1702px) {
-    max-width: fit-content;
     min-width: 35em;
   }
 

--- a/app/subscriber/src/features/landing/styled/Landing.tsx
+++ b/app/subscriber/src/features/landing/styled/Landing.tsx
@@ -29,7 +29,7 @@ export const Landing = styled(Col)`
   /* The panel containing Commentary and front pages */
   .right-panel {
     @media (min-width: 1702px) {
-      max-width: fit-content;
+      max-width: 44%;
     }
     margin-left: auto;
     flex-grow: 1;
@@ -67,6 +67,7 @@ export const Landing = styled(Col)`
       max-width: 55%;
     }
     flex-grow: 1;
+    margin-bottom: 0.5em;
 
     .title {
       background-color: ${(props) => props.theme.css.darkHeaderColor};
@@ -87,7 +88,6 @@ export const Landing = styled(Col)`
 
     /* TODO: move these to the button component as styling configuration */
     button {
-      margin-bottom: 10%;
       min-width: 5rem;
       border: none;
       display: flex;


### PR DESCRIPTION
- cleaned up column layout
- tightnened up spacing to be more consistent around edges of main and right
- .right-panel has max-width in % rather than absolute
- .right-panel uses the real estate that main-panel leaves
- fixed bottom margin on main-panel instead of on the button
- front-pages should not fit content, should be 100% of its parent