### PR TITLE
Fix JsonDocument extension method and elastic migration tool

### DIFF
--- a/libs/net/core/Extensions/JsonElementExtensions.cs
+++ b/libs/net/core/Extensions/JsonElementExtensions.cs
@@ -73,7 +73,7 @@ public static class JsonElementExtensions
     /// <returns></returns>
     public static T? GetElementValue<T>(this JsonElement element, string path = "", T? defaultValue = default, JsonSerializerOptions? options = null)
     {
-        var property = GetElement(element, path);
+        var property = path.Contains('.') ? GetElement(element, path) : element;
 
         if (property == null) return defaultValue;
         var node = (JsonElement)property;


### PR DESCRIPTION
I introduced a regression issue when I updated the extension methods for JsonDocument and JsonElement.  It would be wonderful if we could find time to add unit-tests for these things.

This bug was causing all elastic migrations to fail.