### PR TITLE
Add reset button to advanced search

### DIFF
--- a/app/subscriber/src/App.tsx
+++ b/app/subscriber/src/App.tsx
@@ -52,6 +52,7 @@ function App() {
           color: 'black',
           opacity: '1',
           boxShadow: '0 0 8px #464545',
+          zIndex: '999',
         }}
         id="main-tooltip"
         place="top"

--- a/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
@@ -3,13 +3,18 @@ import React from 'react';
 import { BsCalendarEvent, BsSun } from 'react-icons/bs';
 import { FaRegSmile, FaSearch } from 'react-icons/fa';
 import { GiHamburgerMenu } from 'react-icons/gi';
-import { IoIosArrowDropdownCircle, IoIosArrowDroprightCircle, IoIosCog } from 'react-icons/io';
+import {
+  IoIosArrowDropdownCircle,
+  IoIosArrowDroprightCircle,
+  IoIosCog,
+  IoMdRefresh,
+} from 'react-icons/io';
 import { useNavigate } from 'react-router';
 import { useParams } from 'react-router-dom';
 import { Button, Col, ContentStatus, Row, Show, Text, ToggleGroup, toQueryString } from 'tno-core';
 
 import { DateSection, MediaSection, SentimentSection } from './components';
-import { SearchInFieldName, toggleOptions } from './constants';
+import { defaultAdvancedSearch, SearchInFieldName, toggleOptions } from './constants';
 import {
   defaultSubMediaGroupExpanded,
   IAdvancedSearchFilter,
@@ -41,12 +46,8 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ expanded, setEx
   /** controls the sub group statee for sentiment */
   const [sentimentExpanded, setSentimentExpanded] = React.useState(false);
   /** the object that will eventually be converted to a query and be passed to elastic search */
-  const [advancedSearch, setAdvancedSearch] = React.useState<IAdvancedSearchFilter>({
-    searchTerm: '',
-    searchInField: '',
-    startDate: '',
-    endDate: '',
-  });
+  const [advancedSearch, setAdvancedSearch] =
+    React.useState<IAdvancedSearchFilter>(defaultAdvancedSearch);
 
   // update state when query changes, necessary to keep state in sync with url when navigating directly
   React.useEffect(() => {
@@ -114,9 +115,20 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ expanded, setEx
   return (
     <styled.AdvancedSearch>
       <Show visible={expanded}>
-        <p onClick={() => setExpanded(false)} className="back-text">
-          {`<< Back to basic search`}
-        </p>
+        <Row className="top-bar">
+          <p onClick={() => setExpanded(false)} className="back-text">
+            {`<< Back to basic search`}
+          </p>
+          <IoMdRefresh
+            className="reset"
+            data-tooltip-id="main-tooltip"
+            data-tooltip-content="Reset filters"
+            onClick={() => {
+              setAdvancedSearch(defaultAdvancedSearch);
+              handleSearch();
+            }}
+          />
+        </Row>
       </Show>
       <Row className="search-bar">
         <GiHamburgerMenu />

--- a/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
@@ -92,6 +92,10 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ expanded, setEx
 
   const searchInOptions = [
     {
+      label: 'All',
+      onClick: () => setAdvancedSearch({ ...advancedSearch, searchInField: 'keyword' }),
+    },
+    {
       label: 'Headline',
       onClick: () => setAdvancedSearch({ ...advancedSearch, searchInField: 'headline' }),
     },
@@ -125,7 +129,6 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ expanded, setEx
             data-tooltip-content="Reset filters"
             onClick={() => {
               setAdvancedSearch(defaultAdvancedSearch);
-              handleSearch();
             }}
           />
         </Row>
@@ -153,7 +156,9 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ expanded, setEx
           <b>Search in: </b>
           <ToggleGroup
             defaultSelected={
-              toggleOptions[advancedSearch?.searchInField as keyof typeof toggleOptions]
+              !advancedSearch?.searchInField
+                ? toggleOptions.keyword
+                : toggleOptions[advancedSearch?.searchInField as keyof typeof toggleOptions]
             }
             className="toggles"
             options={searchInOptions}
@@ -247,7 +252,12 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ expanded, setEx
         </Row>
       </Show>
       <Show visible={expanded}>
-        <Button onClick={() => handleSearch()} className="search-button">
+        <Button
+          onClick={() => {
+            handleSearch();
+          }}
+          className="search-button"
+        >
           Search
         </Button>
       </Show>

--- a/app/subscriber/src/components/sidebar/advanced-search/constants/DefaultAdvancedSearch.ts
+++ b/app/subscriber/src/components/sidebar/advanced-search/constants/DefaultAdvancedSearch.ts
@@ -1,0 +1,8 @@
+import { IAdvancedSearchFilter } from '../interfaces';
+
+export const defaultAdvancedSearch: IAdvancedSearchFilter = {
+  searchTerm: '',
+  searchInField: '',
+  startDate: '',
+  endDate: '',
+};

--- a/app/subscriber/src/components/sidebar/advanced-search/constants/DefaultAdvancedSearch.ts
+++ b/app/subscriber/src/components/sidebar/advanced-search/constants/DefaultAdvancedSearch.ts
@@ -2,7 +2,7 @@ import { IAdvancedSearchFilter } from '../interfaces';
 
 export const defaultAdvancedSearch: IAdvancedSearchFilter = {
   searchTerm: '',
-  searchInField: '',
+  searchInField: 'keyword',
   startDate: '',
   endDate: '',
 };

--- a/app/subscriber/src/components/sidebar/advanced-search/constants/ToggleOptions.ts
+++ b/app/subscriber/src/components/sidebar/advanced-search/constants/ToggleOptions.ts
@@ -2,4 +2,5 @@ export const toggleOptions = {
   headline: 'Headline',
   byline: 'Byline',
   storyText: 'Story text',
+  keyword: 'All',
 };

--- a/app/subscriber/src/components/sidebar/advanced-search/constants/index.ts
+++ b/app/subscriber/src/components/sidebar/advanced-search/constants/index.ts
@@ -1,3 +1,4 @@
+export * from './DefaultAdvancedSearch';
 export * from './SearchInFieldName';
 export * from './SubMediaGroups';
 export * from './ToggleOptions';

--- a/app/subscriber/src/components/sidebar/advanced-search/styled/AdvancedSearch.tsx
+++ b/app/subscriber/src/components/sidebar/advanced-search/styled/AdvancedSearch.tsx
@@ -5,6 +5,19 @@ export const AdvancedSearch = styled(Row)`
   background-color: white;
   padding: 0.5em;
 
+  .top-bar {
+    width: 100%;
+    .reset {
+      margin-left: auto;
+      align-self: center;
+      cursor: pointer;
+      &:hover {
+        color: ${(props) => props.theme.css.subscriberPurple};
+        transform: scale(1, 1.1);
+      }
+    }
+  }
+
   .search-icon {
     &:hover {
       color: ${(props) => props.theme.css.subscriberPurple};

--- a/app/subscriber/src/components/sidebar/advanced-search/utils/queryToState.ts
+++ b/app/subscriber/src/components/sidebar/advanced-search/utils/queryToState.ts
@@ -7,7 +7,7 @@ export const queryToState = (queryString: string) => {
   if (queryString.includes('headline')) searchInField = 'headline';
   if (queryString.includes('byline')) searchInField = 'byline';
   if (queryString.includes('storyText')) searchInField = 'storyText';
-  if (queryString.includes('keyword')) searchInField = '';
+  if (queryString.includes('keyword')) searchInField = 'keyword';
 
   const urlParams = new URLSearchParams(queryString);
   const search = fromQueryString(queryString, {


### PR DESCRIPTION
Simple PR to add a reset button to the advanced search on the subscriber site

![image](https://github.com/bcgov/tno/assets/15724124/d354e2ef-048b-4768-9ee6-4f97f2ec54a3)
