### PR TITLE
TNO-1177 Fix Image Service

### DIFF
--- a/app/editor/src/features/admin/ingests/configurations/FrontPage.tsx
+++ b/app/editor/src/features/admin/ingests/configurations/FrontPage.tsx
@@ -14,6 +14,13 @@ export const FrontPage: React.FC = (props) => {
         label="Path to Files"
         name="configuration.path"
         value={values.configuration.path}
+        tooltip="Path to files can include '<date>' which will be replaced with today's date"
+      />
+      <FormikText
+        label="Path Date Format"
+        name="configuration.pathDateFormat"
+        value={values.configuration.pathDateFormat}
+        tooltip="Format the date and replace the <date> keyword in the path (i.e. yyyy/MM/dd)"
       />
       <FormikText
         label="File Name Expression"
@@ -25,10 +32,10 @@ export const FrontPage: React.FC = (props) => {
       <Row>
         <Col flex="1">
           <FormikText
-            label="Date Format"
+            label="File Name Date Format"
             name="configuration.dateFormat"
             value={values.configuration.dateFormat}
-            placeholder="ddMMyyyy"
+            tooltip="Format the date and replace the <date> keyword in the file name expression (i.e. ddd-ddMMyyyy)"
           />
         </Col>
         <Col justifyContent="center">

--- a/libs/net/dal/Migrations/Initial/Up/PostUp/02-Ingest.sql
+++ b/libs/net/dal/Migrations/Initial/Up/PostUp/02-Ingest.sql
@@ -483,8 +483,9 @@ INSERT INTO public.ingest (
   , (SELECT id FROM public.source WHERE code = 'POST') -- source_id
   , 'POST' -- topic
   , frontPageId -- product_id
-  , '{ "path": "binaryroot",
-      "fileName": "NTNP",
+  , '{ "path": "binaryroot/<date>",
+      "pathDateFormat": "yyyy/MM/dd",
+      "fileName": "NTNP.+",
       "publishedOnExpression": "^NTNP(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})(?<hour>[0-9]{2})(?<minute>[0-9]{2})(?<second>[0-9]{2})",
       "post": true,
       "import": true }' -- configuration
@@ -502,8 +503,9 @@ INSERT INTO public.ingest (
   , (SELECT id FROM public.source WHERE code = 'PROVINCE') -- source_id
   , 'PROVINCE' -- topic
   , frontPageId -- product_id
-  , '{ "path": "binaryroot",
-      "fileName": "VAPR",
+  , '{ "path": "binaryroot/<date>",
+      "pathDateFormat": "yyyy/MM/dd",
+      "fileName": "VAPR.+",
       "publishedOnExpression": "^VAPR(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})(?<hour>[0-9]{2})(?<minute>[0-9]{2})(?<second>[0-9]{2})",
       "post": true,
       "import": true }' -- configuration
@@ -521,8 +523,9 @@ INSERT INTO public.ingest (
   , (SELECT id FROM public.source WHERE code = 'TC') -- source_id
   , 'TC' -- topic
   , frontPageId -- product_id
-  , '{ "path": "binaryroot",
-      "fileName": "VITC",
+  , '{ "path": "binaryroot/<date>",
+      "pathDateFormat": "yyyy/MM/dd",
+      "fileName": "VITC.+",
       "publishedOnExpression": "^VITC(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})(?<hour>[0-9]{2})(?<minute>[0-9]{2})(?<second>[0-9]{2})",
       "post": true,
       "import": true }' -- configuration
@@ -540,8 +543,9 @@ INSERT INTO public.ingest (
   , (SELECT id FROM public.source WHERE code = 'SUN') -- source_id
   , 'SUN' -- topic
   , frontPageId -- product_id
-  , '{ "path": "binaryroot",
-      "fileName": "VASN",
+  , '{ "path": "binaryroot/<date>",
+      "pathDateFormat": "yyyy/MM/dd",
+      "fileName": "VASN.+",
       "publishedOnExpression": "^VASN(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})(?<hour>[0-9]{2})(?<minute>[0-9]{2})(?<second>[0-9]{2})",
       "post": true,
       "import": true }' -- configuration


### PR DESCRIPTION
With the latest changes to support Globe & Mail frontpage images, it broke the other newspaper front page images.  This update will fix this.

Requires manually updating the front page image ingest configuration values.