### PR TITLE
TNO-1408 Fix MOV keyframe

### DIFF
--- a/app/editor/src/features/content/form/components/upload/Upload.tsx
+++ b/app/editor/src/features/content/form/components/upload/Upload.tsx
@@ -125,7 +125,7 @@ export const Upload: React.FC<IUploadProps> = ({
             </audio>
           </Show>
           <Show visible={fileReference?.contentType.startsWith('video/')}>
-            <video src={stream?.url} controls>
+            <video src={`${stream?.url}#t=0.5`} controls preload="metadata">
               HTML5 Video is required
             </video>
           </Show>


### PR DESCRIPTION
Browsers have a client side feature that allows us to control the default keyframe loaded in a video file.  It appears that in the case of the default MOV file created by editors they are perhaps incorrectly creating the first frame, or they are not including a default image.  With controlling the keyframe it is essentially moving the head forward a little with the hope that an image can be displayed.  I have tested the example MOV file in Chrome and it works.

![image](https://github.com/bcgov/tno/assets/3180256/7b6ed97f-0790-44f5-a762-7382a46b9526)
