### PR TITLE
TNO-1622: Add grip bars to av overview

### DIFF
--- a/app/editor/src/features/admin/av-overviews/OverviewGrid.tsx
+++ b/app/editor/src/features/admin/av-overviews/OverviewGrid.tsx
@@ -1,6 +1,6 @@
 import { useFormikContext } from 'formik';
 import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
-import { FaTrash } from 'react-icons/fa';
+import { FaGripLines, FaTrash } from 'react-icons/fa';
 import {
   AVOverviewItemTypeName,
   castEnumToOptions,
@@ -94,6 +94,7 @@ export const OverviewGrid: React.FC<IOverviewGridProps> = ({ index }) => {
                             {...provided.draggableProps}
                           >
                             <Row className="rows" key={itemIndex} nowrap>
+                              <FaGripLines className="grip-lines" />
                               <FormikSelect
                                 key={itemIndex + `select`}
                                 name={`sections.${index}.items.${itemIndex}.itemType`}

--- a/app/editor/src/features/admin/av-overviews/styled/OverviewGrid.tsx
+++ b/app/editor/src/features/admin/av-overviews/styled/OverviewGrid.tsx
@@ -16,6 +16,14 @@ export const OverviewGrid = styled.div`
       resize: vertical;
       max-height: fit-content;
     }
+    .grip-lines {
+      margin-right: 0.5em;
+      margin-left: 0.5em;
+      align-self: center;
+      &:hover {
+        color: ${(props) => props.theme.css.primaryLightColor};
+      }
+    }
     .clear-item {
       margin-top: 0.75em;
       cursor: pointer;
@@ -28,13 +36,15 @@ export const OverviewGrid = styled.div`
       width: 100%;
       background-color: #f5f5f5;
     }
-
-    .placement-header,
     .time-header {
-      width: 9.25em;
+      width: 9em;
+    }
+    .placement-header {
+      width: 11em;
     }
     .placement-header,
     .summary-header,
+    .content-header,
     .time-header {
       padding: 0.75em;
     }

--- a/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
+++ b/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
@@ -1,6 +1,6 @@
 import { useFormikContext } from 'formik';
 import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
-import { FaTrash } from 'react-icons/fa';
+import { FaGripLines, FaTrash } from 'react-icons/fa';
 import {
   AVOverviewItemTypeName,
   castEnumToOptions,
@@ -96,6 +96,7 @@ export const OverviewGrid: React.FC<IOverviewGridProps> = ({ editable = true, in
                             {...provided.draggableProps}
                           >
                             <Row className="rows" key={itemIndex} nowrap>
+                              <FaGripLines className="grip-lines" />
                               <FormikSelect
                                 key={itemIndex + `select`}
                                 name={`sections.${index}.items.${itemIndex}.itemType`}

--- a/app/editor/src/features/reports/av-overview/styled/OverviewGrid.tsx
+++ b/app/editor/src/features/reports/av-overview/styled/OverviewGrid.tsx
@@ -16,6 +16,14 @@ export const OverviewGrid = styled.div`
       resize: vertical;
       max-height: fit-content;
     }
+    .grip-lines {
+      margin-right: 0.5em;
+      margin-left: 0.5em;
+      align-self: center;
+      &:hover {
+        color: ${(props) => props.theme.css.primaryLightColor};
+      }
+    }
     .clear-item {
       margin-top: 0.75em;
       cursor: pointer;
@@ -28,10 +36,11 @@ export const OverviewGrid = styled.div`
       width: 100%;
       background-color: #f5f5f5;
     }
-
-    .placement-header,
     .time-header {
-      width: 9.25em;
+      width: 9em;
+    }
+    .placement-header {
+      width: 11em;
     }
     .placement-header,
     .summary-header,

--- a/app/editor/src/features/reports/av-overview/styled/OverviewGrid.tsx
+++ b/app/editor/src/features/reports/av-overview/styled/OverviewGrid.tsx
@@ -42,6 +42,10 @@ export const OverviewGrid = styled.div`
     .placement-header {
       width: 11em;
     }
+
+    .summary-header {
+      max-width: 71.75em;
+    }
     .placement-header,
     .summary-header,
     .content-header,


### PR DESCRIPTION
Simple PR to add Grip Lines to each AV Overview item to make the drag and drop more intuitive.

- Included in the admin and editor areas of the application

![image](https://github.com/bcgov/tno/assets/15724124/499ac8e1-83d5-4018-9137-7c909bf3a96d)

