### PR TITLE
TNO-1701 Add content type filter

### DIFF
--- a/app/editor/src/features/admin/filters/FilterFormQuery.tsx
+++ b/app/editor/src/features/admin/filters/FilterFormQuery.tsx
@@ -22,8 +22,8 @@ import {
   ToggleGroup,
 } from 'tno-core';
 
-import { searchInOptions } from './constants/searchInOptions';
-import { generateQuery, getActionOptions } from './utils';
+import { contentTypeOptions, searchInOptions } from './constants';
+import { generateQuery, getActionOptions, getTagOptions } from './utils';
 
 /**
  * The page used to view and edit report filter.
@@ -31,15 +31,20 @@ import { generateQuery, getActionOptions } from './utils';
  */
 export const FilterFormQuery: React.FC = () => {
   const { values, setFieldValue } = useFormikContext<IFilterModel>();
-  const [{ productOptions, sourceOptions, seriesOptions, contributorOptions, actions }] =
+  const [{ productOptions, sourceOptions, seriesOptions, contributorOptions, actions, tags }] =
     useLookupOptions();
 
   const [filter, setFilter] = React.useState(JSON.stringify(values.query, null, 2));
   const [actionOptions, setActionOptions] = React.useState(getActionOptions(actions));
+  const [tagOptions, setTagOptions] = React.useState(getTagOptions(tags));
 
   React.useEffect(() => {
     setActionOptions(getActionOptions(actions));
   }, [actions]);
+
+  React.useEffect(() => {
+    setTagOptions(getTagOptions(tags));
+  }, [tags]);
 
   /**
    * Update the settings and query values based on the new key=value.
@@ -105,7 +110,7 @@ export const FilterFormQuery: React.FC = () => {
             label="Keywords"
             value={values.settings.search ?? ''}
             onChange={(e) => {
-              const value = e.target.value;
+              const value = e.target.value.length ? e.target.value : undefined;
               updateQuery('search', value);
             }}
           >
@@ -162,6 +167,41 @@ export const FilterFormQuery: React.FC = () => {
               relative to today's date.
             </p>
           </Row>
+        </Row>
+        <Row>
+          <Col flex="1">
+            <FormikText
+              name="edition"
+              label="Edition"
+              value={values.settings.edition ?? ''}
+              onChange={(e) => {
+                const value = e.target.value.length ? e.target.value : undefined;
+                updateQuery('edition', value);
+              }}
+            />
+          </Col>
+          <Col flex="1">
+            <FormikText
+              name="section"
+              label="Section"
+              value={values.settings.section ?? ''}
+              onChange={(e) => {
+                const value = e.target.value.length ? e.target.value : undefined;
+                updateQuery('section', value);
+              }}
+            />
+          </Col>
+          <Col flex="1">
+            <FormikText
+              name="page"
+              label="Page"
+              value={values.settings.page ?? ''}
+              onChange={(e) => {
+                const value = e.target.value.length ? e.target.value : undefined;
+                updateQuery('page', value);
+              }}
+            />
+          </Col>
         </Row>
         <Row>
           <Col flex="1">
@@ -256,6 +296,42 @@ export const FilterFormQuery: React.FC = () => {
                   value: o.label === 'Commentary' ? '*' : 'true',
                 }));
                 updateQuery('actions', actions);
+              }}
+            />
+          </Col>
+          <Col flex="1">
+            <Select
+              name="contentTypes"
+              label="Content Types"
+              isMulti
+              options={contentTypeOptions}
+              value={
+                contentTypeOptions.filter((mt) =>
+                  values.settings.contentTypes?.some((o: string) => o === mt.value),
+                ) ?? []
+              }
+              onChange={(newValue: any) => {
+                const contentTypes = newValue.map((o: OptionItem) => o.value);
+                updateQuery('contentTypes', contentTypes);
+              }}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col flex="1">
+            <Select
+              name="tags"
+              label="Tags"
+              isMulti
+              options={tagOptions}
+              value={
+                tagOptions.filter((t) =>
+                  values.settings.tags?.some((o: string) => o === t.value),
+                ) ?? []
+              }
+              onChange={(newValue: any) => {
+                const tags = newValue.map((o: OptionItem) => o.value);
+                updateQuery('tags', tags);
               }}
             />
           </Col>

--- a/app/editor/src/features/admin/filters/constants/contentTypeOptions.ts
+++ b/app/editor/src/features/admin/filters/constants/contentTypeOptions.ts
@@ -1,0 +1,3 @@
+import { ContentTypeName, OptionItem } from 'tno-core';
+
+export const contentTypeOptions = Object.values(ContentTypeName).map((v) => new OptionItem(v, v));

--- a/app/editor/src/features/admin/filters/constants/index.ts
+++ b/app/editor/src/features/admin/filters/constants/index.ts
@@ -1,3 +1,4 @@
+export * from './contentTypeOptions';
 export * from './defaultFilter';
 export * from './filterColumns';
 export * from './searchInOptions';

--- a/app/editor/src/features/admin/filters/utils/generateQuery.ts
+++ b/app/editor/src/features/admin/filters/utils/generateQuery.ts
@@ -6,7 +6,9 @@ import {
   generateRangeForArrayField,
   generateRangeForDateOffset,
   generateRangeForDates,
+  generateTerm,
   generateTerms,
+  generateTermsForArrayField,
 } from '.';
 
 /**
@@ -29,9 +31,14 @@ export const generateQuery = (settings: IFilterSettingsModel, query: any = {}) =
           generateTerms('productId', settings.productIds),
           generateTerms('seriesId', settings.seriesIds),
           generateTerms('contributorId', settings.contributorIds),
+          generateTerms('contentType', settings.contentTypes),
+          generateTermsForArrayField('tags.code', settings.tags),
           generateRangeForArrayField('tonePools.value', settings.sentiment),
           ...generateQueryForActions(settings.actions ?? []),
           generateTextQuery(settings),
+          generateTerm('edition', settings.edition),
+          generateTerm('section', settings.section),
+          generateTerm('page', settings.page),
         ].filter((v) => v !== undefined),
       },
     },

--- a/app/editor/src/features/admin/filters/utils/generateTerm.ts
+++ b/app/editor/src/features/admin/filters/utils/generateTerm.ts
@@ -1,0 +1,16 @@
+/**
+ * Generates an Elasticsearch query for a field that has one of the specified vale.
+ * @param field Field path.
+ * @param values A value to search for.
+ * @returns An Elasticsearch query.
+ */
+export const generateTerm = (field: string, value?: any) => {
+  if (value === undefined || value === null) return undefined;
+  return value.includes('*')
+    ? {
+        wildcard: { [field]: value },
+      }
+    : {
+        term: { [field]: value },
+      };
+};

--- a/app/editor/src/features/admin/filters/utils/generateTermsForArrayField.ts
+++ b/app/editor/src/features/admin/filters/utils/generateTermsForArrayField.ts
@@ -1,0 +1,26 @@
+/**
+ * Generates an Elasticsearch query for an array field that has one of the specified values.
+ * @param field Field path.
+ * @param values An array of values to search for.
+ * @returns An Elasticsearch query.
+ */
+export const generateTermsForArrayField = (field: string, values?: any[]) => {
+  if (values === undefined || values === null) return undefined;
+  return Array.isArray(values)
+    ? {
+        nested: {
+          path: field.split('.')[0],
+          query: {
+            terms: { [field]: values },
+          },
+        },
+      }
+    : {
+        nested: {
+          path: field.split('.')[0],
+          query: {
+            term: { [field]: values },
+          },
+        },
+      };
+};

--- a/app/editor/src/features/admin/filters/utils/getTagOptions.ts
+++ b/app/editor/src/features/admin/filters/utils/getTagOptions.ts
@@ -1,0 +1,5 @@
+import { ITagModel, OptionItem } from 'tno-core';
+
+export const getTagOptions = (tags: ITagModel[]) => {
+  return tags.map((t) => new OptionItem(`${t.code} - ${t.name}`, t.code, t.isEnabled));
+};

--- a/app/editor/src/features/admin/filters/utils/index.ts
+++ b/app/editor/src/features/admin/filters/utils/index.ts
@@ -5,5 +5,8 @@ export * from './generateQueryForActions';
 export * from './generateRangeForArrayField';
 export * from './generateRangeForDateOffset';
 export * from './generateRangeForDates';
+export * from './generateTerm';
 export * from './generateTerms';
+export * from './generateTermsForArrayField';
 export * from './getActionOptions';
+export * from './getTagOptions';


### PR DESCRIPTION
We can now dynamically add tags, edition, section, and page values to the Elasticsearch filter.

## Summary

- Add tags filter
- Add edition filter
- Add section filter
- Add page filter

## Filter Admin

![image](https://github.com/bcgov/tno/assets/3180256/a9955460-745a-4829-844d-7a9acd5480cc)
