### PR TITLE
TNO-1681 Friendly error messages

### DIFF
--- a/api/net/Areas/Editor/Controllers/IngestController.cs
+++ b/api/net/Areas/Editor/Controllers/IngestController.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Editor.Models.Ingest;
 using TNO.API.Models;
+using TNO.Core.Exceptions;
 using TNO.DAL.Models;
 using TNO.DAL.Services;
 using TNO.Entities.Models;
@@ -77,7 +78,7 @@ public class IngestController : ControllerBase
     [SwaggerOperation(Tags = new[] { "Ingest" })]
     public IActionResult AddSchedule(IngestScheduleModel model)
     {
-        var ingest = _service.FindById(model.IngestId) ?? throw new KeyNotFoundException();
+        var ingest = _service.FindById(model.IngestId) ?? throw new NoContentException();
         var schedule = model.ToEntity();
         ingest.Schedules.Add(schedule);
         _service.UpdateAndSave(ingest, true);

--- a/api/net/Areas/Editor/Controllers/StorageController.cs
+++ b/api/net/Areas/Editor/Controllers/StorageController.cs
@@ -8,6 +8,7 @@ using TNO.API.Areas.Editor.Models.Storage;
 using TNO.API.Config;
 using TNO.API.Helpers;
 using TNO.API.Models;
+using TNO.Core.Exceptions;
 using TNO.Core.Extensions;
 using TNO.DAL.Config;
 using TNO.DAL.Helpers;
@@ -65,7 +66,7 @@ public class StorageController : ControllerBase
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType(typeof(DirectoryModel), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
     [SwaggerOperation(Tags = new[] { "Storage" })]
     public IActionResult GetDirectory([FromRoute] int? locationId, [FromQuery] string? path)
     {
@@ -117,7 +118,7 @@ public class StorageController : ControllerBase
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType((int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
     [SwaggerOperation(Tags = new[] { "Storage" })]
     public IActionResult DirectoryExists([FromRoute] int? locationId, [FromQuery] string? path)
     {
@@ -228,7 +229,7 @@ public class StorageController : ControllerBase
     [HttpGet("{locationId:int}/stream")]
     [ProducesResponseType(typeof(FileStreamResult), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(FileStreamResult), (int)HttpStatusCode.PartialContent)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
     [SwaggerOperation(Tags = new[] { "Storage" })]
     public IActionResult Stream([FromRoute] int? locationId, [FromQuery] string path)
     {
@@ -252,11 +253,11 @@ public class StorageController : ControllerBase
 
     private FileStreamResult GetResult(string safePath, string path)
     {
-        if (!safePath.FileExists()) throw new InvalidOperationException($"Stream does not exist: '{path}'");
+        if (!safePath.FileExists()) throw new NoContentException($"Stream does not exist: '{path}'");
 
         var info = new ItemModel(safePath, true);
-        var filestream = System.IO.File.OpenRead(safePath);
-        return File(filestream, info.MimeType!);
+        var fileStream = System.IO.File.OpenRead(safePath);
+        return File(fileStream, info.MimeType!);
     }
 
     /// <summary>
@@ -269,7 +270,7 @@ public class StorageController : ControllerBase
     [HttpGet("{locationId:int}/download")]
     [Produces("application/octet-stream")]
     [ProducesResponseType(typeof(FileStreamResult), (int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
     [SwaggerOperation(Tags = new[] { "Storage" })]
     public IActionResult Download([FromRoute] int? locationId, [FromQuery] string path)
     {
@@ -312,7 +313,7 @@ public class StorageController : ControllerBase
     [HttpPut("{locationId:int}/move")]
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType(typeof(ItemModel), (int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
     [SwaggerOperation(Tags = new[] { "Storage" })]
     public IActionResult Move([FromRoute] int? locationId, [FromQuery] string path, [FromQuery] string destination)
     {
@@ -368,7 +369,7 @@ public class StorageController : ControllerBase
     [HttpDelete("{locationId:int}")]
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType(typeof(ItemModel), (int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
     [SwaggerOperation(Tags = new[] { "Storage" })]
     public IActionResult Delete([FromRoute] int? locationId, [FromQuery] string path)
     {
@@ -437,7 +438,7 @@ public class StorageController : ControllerBase
     [HttpPost("{locationId:int}/clip")]
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType(typeof(ItemModel), (int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
     [SwaggerOperation(Tags = new[] { "Storage" })]
     public async Task<IActionResult> CreateClipAsync([FromRoute] int? locationId, [FromQuery] string path, [FromQuery] int start, [FromQuery] int end, [FromQuery] string outputName)
     {
@@ -472,7 +473,7 @@ public class StorageController : ControllerBase
     [HttpPost("{locationId:int}/join")]
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType(typeof(ItemModel), (int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
     [SwaggerOperation(Tags = new[] { "Storage" })]
     public async Task<IActionResult> JoinClipsAsync([FromRoute] int? locationId, [FromQuery] string path, [FromQuery] string prefix)
     {

--- a/api/net/Areas/Editor/Controllers/SystemMessageController.cs
+++ b/api/net/Areas/Editor/Controllers/SystemMessageController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Admin.Models.SystemMessage;
 using TNO.API.Models;
+using TNO.Core.Exceptions;
 using TNO.DAL.Services;
 
 namespace TNO.API.Areas.Editor.Controllers;
@@ -47,11 +48,11 @@ public class SystemMessageController : ControllerBase
     [HttpGet]
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType(typeof(IEnumerable<SystemMessageModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
     [SwaggerOperation(Tags = new[] { "System Message" })]
     public IActionResult FindSystemMessage()
     {
-        var result = _service.FindSystemMessage();
-        if (result == null) return new NoContentResult();
+        var result = _service.FindSystemMessage() ?? throw new NoContentException();
         return new JsonResult(new SystemMessageModel(result));
     }
     #endregion

--- a/api/net/Areas/Editor/Controllers/UserController.cs
+++ b/api/net/Areas/Editor/Controllers/UserController.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Editor.Models.User;
 using TNO.API.Filters;
+using TNO.API.Models;
+using TNO.Core.Exceptions;
 using TNO.DAL.Services;
 using TNO.Keycloak;
 
@@ -70,13 +72,11 @@ public class UserController : ControllerBase
     [HttpGet("{id}")]
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType(typeof(UserModel), (int)HttpStatusCode.OK)]
-    [ProducesResponseType(typeof(string), (int)HttpStatusCode.NoContent)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
     [SwaggerOperation(Tags = new[] { "User" })]
     public IActionResult FindById(int id)
     {
-        var result = _userService.FindById(id);
-
-        if (result == null) return new NoContentResult();
+        var result = _userService.FindById(id) ?? throw new NoContentException();
         return new JsonResult(new Admin.Models.User.UserModel(result, _serializerOptions));
     }
     #endregion

--- a/api/net/Areas/Editor/Controllers/WorkOrderController.cs
+++ b/api/net/Areas/Editor/Controllers/WorkOrderController.cs
@@ -123,12 +123,11 @@ public class WorkOrderController : ControllerBase
     [HttpPost("transcribe/{contentId}")]
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType(typeof(WorkOrderMessageModel), (int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.NoContent)]
     [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
     [SwaggerOperation(Tags = new[] { "Content" })]
     public async Task<IActionResult> RequestTranscriptionAsync(long contentId)
     {
-        var content = _contentService.FindById(contentId) ?? throw new InvalidOperationException("Content does not exist");
+        var content = _contentService.FindById(contentId) ?? throw new NoContentException("Content does not exist");
         if (String.IsNullOrWhiteSpace(_kafkaOptions.TranscriptionTopic)) throw new ConfigurationException("Kafka transcription topic not configured.");
 
         // Only allow one work order transcript request at a time.
@@ -165,12 +164,11 @@ public class WorkOrderController : ControllerBase
     [HttpPost("nlp/{contentId}")]
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType(typeof(WorkOrderMessageModel), (int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.NoContent)]
     [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
     [SwaggerOperation(Tags = new[] { "Content" })]
     public async Task<IActionResult> RequestNLPAsync(long contentId)
     {
-        var content = _contentService.FindById(contentId) ?? throw new InvalidOperationException("Content does not exist");
+        var content = _contentService.FindById(contentId) ?? throw new NoContentException("Content does not exist");
         if (String.IsNullOrWhiteSpace(_kafkaOptions.NLPTopic)) throw new ConfigurationException("Kafka NLP topic not configured.");
 
         // Only allow one work order transcript request at a time.
@@ -207,7 +205,7 @@ public class WorkOrderController : ControllerBase
     [HttpPost("request/file/{locationId:int}")]
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
     [SwaggerOperation(Tags = new[] { "Storage" })]
     public async Task<IActionResult> RequestFileAsync([FromRoute] int locationId, [FromQuery] string path)
     {

--- a/app/editor/src/features/admin/filters/utils/generateTermsForArrayField.ts
+++ b/app/editor/src/features/admin/filters/utils/generateTermsForArrayField.ts
@@ -5,7 +5,8 @@
  * @returns An Elasticsearch query.
  */
 export const generateTermsForArrayField = (field: string, values?: any[]) => {
-  if (values === undefined || values === null) return undefined;
+  if (values === undefined || values === null || (Array.isArray(values) && values.length === 0))
+    return undefined;
   return Array.isArray(values)
     ? {
         nested: {

--- a/app/editor/src/store/hooks/useAjaxWrapper.ts
+++ b/app/editor/src/store/hooks/useAjaxWrapper.ts
@@ -32,12 +32,19 @@ export const useAjaxWrapper = () => {
           let message = 'An unexpected error has occurred.';
           let detail = '';
           const data = ae.response?.data as any;
-
           if (ae.response?.status === 401) message = 'Authentication required.';
           else if (ae.response?.status === 403)
             message = 'Authorization required.  Your account does not have access.';
           else if (typeof data === 'string' && !!data) message = data;
-          else if (!!data?.error) {
+          else if (
+            data instanceof Blob &&
+            data.type &&
+            data.type.toLocaleLowerCase().indexOf('json') !== -1
+          ) {
+            const json = JSON.parse(await data.text());
+            message = json.error;
+            detail = message !== json.detail ? json.detail : undefined;
+          } else if (!!data?.error) {
             message = `${data?.error}`;
             detail = message.trim() !== data?.details?.trim() ? data?.details : undefined;
           } else if (!!data?.errors) {

--- a/app/subscriber/src/store/hooks/useAjaxWrapper.ts
+++ b/app/subscriber/src/store/hooks/useAjaxWrapper.ts
@@ -32,12 +32,19 @@ export const useAjaxWrapper = () => {
           let message = 'An unexpected error has occurred.';
           let detail = '';
           const data = ae.response?.data as any;
-
           if (ae.response?.status === 401) message = 'Authentication required.';
           else if (ae.response?.status === 403)
             message = 'Authorization required.  Your account does not have access.';
           else if (typeof data === 'string' && !!data) message = data;
-          else if (!!data?.error) {
+          else if (
+            data instanceof Blob &&
+            data.type &&
+            data.type.toLocaleLowerCase().indexOf('json') !== -1
+          ) {
+            const json = JSON.parse(await data.text());
+            message = json.error;
+            detail = message !== json.detail ? json.detail : undefined;
+          } else if (!!data?.error) {
             message = `${data?.error}`;
             detail = message.trim() !== data?.details?.trim() ? data?.details : undefined;
           } else if (!!data?.errors) {

--- a/libs/net/core/Exceptions/NoContentException.cs
+++ b/libs/net/core/Exceptions/NoContentException.cs
@@ -1,0 +1,30 @@
+namespace TNO.Core.Exceptions;
+
+/// <summary>
+/// NoContentException class, provides a way to throw an exception when a record does not exist.
+/// </summary>
+public class NoContentException : Exception
+{
+    #region Constructors
+    /// <summary>
+    /// Creates a new instance of a NoContentException class.
+    /// </summary>
+    /// <returns></returns>
+    public NoContentException() : base() { }
+
+    /// <summary>
+    /// Creates a new instance of a NoContentException class, and initializes it with the specified arguments.
+    /// </summary>
+    /// <param name="message"></param>
+    /// <returns></returns>
+    public NoContentException(string message) : base(message ?? "User is not authorized to perform this action.") { }
+
+    /// <summary>
+    /// Creates a new instance of a NoContentException class, and initializes it with the specified arguments.
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="innerException"></param>
+    /// <returns></returns>
+    public NoContentException(string message, Exception innerException) : base(message ?? "User is not authorized to perform this action.", innerException) { }
+    #endregion
+}

--- a/libs/net/dal/Services/ActionService.cs
+++ b/libs/net/dal/Services/ActionService.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using TNO.Core.Exceptions;
 using TNO.DAL.Extensions;
 using TNO.DAL.Models;
 using TNO.Entities.Models;
@@ -89,9 +90,10 @@ public class ActionService : BaseService<Entities.Action, int>, IActionService
     /// </summary>
     /// <param name="entity"></param>
     /// <returns></returns>
+    /// <exception cref="NoContentException"></exception>
     public override Entities.Action UpdateAndSave(Entities.Action entity)
     {
-        var original = FindById(entity.Id) ?? throw new InvalidOperationException("Entity does not exist");
+        var original = FindById(entity.Id) ?? throw new NoContentException("Entity does not exist");
         this.Context.UpdateContext(original, entity);
         return base.UpdateAndSave(entity);
     }

--- a/libs/net/dal/Services/ContentReferenceService.cs
+++ b/libs/net/dal/Services/ContentReferenceService.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using TNO.Core.Exceptions;
 using TNO.DAL.Extensions;
 using TNO.DAL.Models;
 using TNO.Entities;
@@ -96,10 +97,10 @@ public class ContentReferenceService : BaseService<ContentReference, string[]>, 
     /// </summary>
     /// <param name="entity"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="NoContentException"></exception>
     public override ContentReference UpdateAndSave(ContentReference entity)
     {
-        var original = FindByKey(entity.Source, entity.Uid) ?? throw new InvalidOperationException("Entity does not exist");
+        var original = FindByKey(entity.Source, entity.Uid) ?? throw new NoContentException("Entity does not exist");
         this.Context.Entry(original).CurrentValues.SetValues(entity);
         this.Context.ResetVersion(original);
         return base.UpdateAndSave(original);

--- a/libs/net/dal/Services/ContentService.cs
+++ b/libs/net/dal/Services/ContentService.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nest;
+using TNO.Core.Exceptions;
 using TNO.Core.Extensions;
 using TNO.DAL.Extensions;
 using TNO.DAL.Models;
@@ -327,7 +328,7 @@ public class ContentService : BaseService<Content, long>, IContentService
 
         if (filter.HasTopic == true)
             filterQueries.Add(s => s.Nested(n => n.IgnoreUnmapped().Path(f => f.Topics).Query(q => q.MatchAll())));
-        
+
         if (filter.HasFile == true)
             filterQueries.Add(s => s.Nested(n => n.IgnoreUnmapped().Path(f => f.FileReferences).Query(q => q.MatchAll())));
 
@@ -514,11 +515,11 @@ public class ContentService : BaseService<Content, long>, IContentService
     /// </summary>
     /// <param name="entity"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="NoContentException"></exception>
     /// TODO: Switch to not found exception throughout services.
     public override Content UpdateAndSave(Content entity)
     {
-        var original = FindById(entity.Id) ?? throw new InvalidOperationException("Entity does not exist");
+        var original = FindById(entity.Id) ?? throw new NoContentException("Entity does not exist");
         this.Context.UpdateContext(original, entity);
         if (entity.GuaranteeUid() && original.Uid != entity.Uid) original.Uid = entity.Uid;
         return base.UpdateAndSave(original);
@@ -540,11 +541,11 @@ public class ContentService : BaseService<Content, long>, IContentService
     /// </summary>
     /// <param name="updated"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="NoContentException"></exception>
     /// TODO: Switch to not found exception throughout services.
     public Content UpdateStatusOnly(Content updated)
     {
-        var original = FindById(updated.Id) ?? throw new InvalidOperationException("Entity does not exist");
+        var original = FindById(updated.Id) ?? throw new NoContentException("Entity does not exist");
 
         original.Status = updated.Status;
         original.Version = updated.Version;

--- a/libs/net/dal/Services/IngestService.cs
+++ b/libs/net/dal/Services/IngestService.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using TNO.Core.Exceptions;
 using TNO.DAL.Extensions;
 using TNO.DAL.Models;
 using TNO.Entities;
@@ -235,11 +236,11 @@ public class IngestService : BaseService<Ingest, int>, IIngestService
     /// <param name="entity"></param>
     /// <param name="updateChildren"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="NoContentException"></exception>
     public Ingest UpdateAndSave(Ingest entity, bool updateChildren = false)
     {
         ValidateScheduleNames(entity);
-        var original = FindById(entity.Id) ?? throw new InvalidOperationException("Entity does not exist");
+        var original = FindById(entity.Id) ?? throw new NoContentException("Entity does not exist");
         this.Context.UpdateContext(original, entity, updateChildren);
         return base.UpdateAndSave(original);
     }

--- a/libs/net/dal/Services/NotificationService.cs
+++ b/libs/net/dal/Services/NotificationService.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using TNO.Core.Exceptions;
 using TNO.Core.Extensions;
 using TNO.DAL.Extensions;
 using TNO.Entities;
@@ -52,10 +53,10 @@ public class NotificationService : BaseService<Notification, int>, INotification
     /// </summary>
     /// <param name="entity"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="NoContentException"></exception>
     public override Notification Update(Notification entity)
     {
-        var original = FindById(entity.Id) ?? throw new InvalidOperationException("Entity does not exist");
+        var original = FindById(entity.Id) ?? throw new NoContentException("Entity does not exist");
         var subscribers = this.Context.UserNotifications.Where(ur => ur.NotificationId == entity.Id).ToArray();
 
         subscribers.Except(entity.SubscribersManyToMany).ForEach(s =>

--- a/libs/net/dal/Services/ReportService.cs
+++ b/libs/net/dal/Services/ReportService.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using TNO.API.Models.Settings;
+using TNO.Core.Exceptions;
 using TNO.Core.Extensions;
 using TNO.DAL.Models;
 using TNO.Elastic;
@@ -121,10 +122,10 @@ public class ReportService : BaseService<Report, int>, IReportService
     /// </summary>
     /// <param name="entity"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="NoContentException"></exception>
     public override Report Update(Report entity)
     {
-        var original = FindById(entity.Id) ?? throw new InvalidOperationException("Entity does not exist");
+        var original = FindById(entity.Id) ?? throw new NoContentException("Entity does not exist");
 
         // Add/Update/Delete report subscribers.
         var originalSubscribers = original.SubscribersManyToMany.ToArray();
@@ -338,10 +339,10 @@ public class ReportService : BaseService<Report, int>, IReportService
     /// </summary>
     /// <param name="reportId"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="NoContentException"></exception>
     public IEnumerable<long> GetRelatedReportInstanceContentToExclude(int reportId)
     {
-        var report = this.Context.Reports.FirstOrDefault(r => r.Id == reportId) ?? throw new InvalidOperationException("Report does not exist.");
+        var report = this.Context.Reports.FirstOrDefault(r => r.Id == reportId) ?? throw new NoContentException("Report does not exist.");
         var relatedReportIds = report.Settings.GetElementValue("instance.excludeReports", Array.Empty<int>())!;
 
         var contentIds = new List<long>();

--- a/libs/net/dal/Services/ReportTemplateService.cs
+++ b/libs/net/dal/Services/ReportTemplateService.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using TNO.Core.Exceptions;
 using TNO.Core.Extensions;
 using TNO.DAL.Extensions;
 using TNO.Entities;
@@ -63,10 +64,10 @@ public class ReportTemplateService : BaseService<ReportTemplate, int>, IReportTe
     /// </summary>
     /// <param name="entity"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="NoContentException"></exception>
     public override ReportTemplate Update(ReportTemplate entity)
     {
-        var original = FindById(entity.Id) ?? throw new InvalidOperationException("Entity does not exist");
+        var original = FindById(entity.Id) ?? throw new NoContentException("Entity does not exist");
         var charts = this.Context.ReportTemplateChartTemplates.Where(ur => ur.ReportTemplateId == entity.Id).ToArray();
 
         charts.Except(entity.ChartTemplatesManyToMany).ForEach(s =>

--- a/libs/net/dal/Services/SourceService.cs
+++ b/libs/net/dal/Services/SourceService.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using TNO.Core.Exceptions;
 using TNO.DAL.Extensions;
 using TNO.DAL.Models;
 using TNO.Entities;
@@ -135,10 +136,10 @@ public class SourceService : BaseService<Source, int>, ISourceService
     /// <param name="entity"></param>
     /// <param name="updateChildren"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="NoContentException"></exception>
     public Source UpdateAndSave(Source entity, bool updateChildren = false)
     {
-        var original = FindById(entity.Id) ?? throw new InvalidOperationException("Entity does not exist");
+        var original = FindById(entity.Id) ?? throw new NoContentException("Entity does not exist");
         this.Context.UpdateContext(original, entity, updateChildren);
         return base.UpdateAndSave(original);
     }

--- a/libs/net/dal/Services/UserService.cs
+++ b/libs/net/dal/Services/UserService.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using LinqKit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using TNO.Core.Exceptions;
 using TNO.DAL.Extensions;
 using TNO.DAL.Models;
 using TNO.Entities;
@@ -122,46 +123,35 @@ public class UserService : BaseService<User, int>, IUserService
 
     public override User UpdateAndSave(User entity)
     {
-        var original = FindById(entity.Id);
+        var original = FindById(entity.Id) ?? throw new NoContentException();
+        original.Key = entity.Key;
+        original.Username = entity.Username;
+        original.Email = entity.Email;
+        original.DisplayName = entity.DisplayName;
+        original.EmailVerified = entity.EmailVerified;
+        original.IsEnabled = entity.IsEnabled;
+        original.FirstName = entity.FirstName;
+        original.LastName = entity.LastName;
+        original.Version = entity.Version;
+        original.Status = entity.Status;
+        original.Note = entity.Note;
+        original.Code = entity.Code;
+        original.Roles = entity.Roles;
+        original.Preferences = entity.Preferences;
+        original.LastLoginOn = entity.LastLoginOn;
+        if (String.IsNullOrWhiteSpace(entity.Code)) original.CodeCreatedOn = null;
+        else if (original.Code != entity.Code) original.CodeCreatedOn = DateTime.UtcNow;
 
-        if (original != null)
-        {
-            original.Key = entity.Key;
-            original.Username = entity.Username;
-            original.Email = entity.Email;
-            original.DisplayName = entity.DisplayName;
-            original.EmailVerified = entity.EmailVerified;
-            original.IsEnabled = entity.IsEnabled;
-            original.FirstName = entity.FirstName;
-            original.LastName = entity.LastName;
-            original.Version = entity.Version;
-            original.Status = entity.Status;
-            original.Note = entity.Note;
-            original.Code = entity.Code;
-            original.Roles = entity.Roles;
-            original.Preferences = entity.Preferences;
-            original.LastLoginOn = entity.LastLoginOn;
-            if (String.IsNullOrWhiteSpace(entity.Code)) original.CodeCreatedOn = null;
-            else if (original.Code != entity.Code) original.CodeCreatedOn = DateTime.UtcNow;
-
-            base.UpdateAndSave(original);
-            return FindById(entity.Id)!;
-        }
-
-        throw new InvalidOperationException("User does not exist");
+        base.UpdateAndSave(original);
+        return FindById(entity.Id)!;
     }
 
     public User UpdatePreferences(User model)
     {
-        var original = FindById(model.Id);
-        if (original != null)
-        {
-            original.Preferences = model.Preferences;
-            base.UpdateAndSave(original);
-            return FindById(model.Id)!;
-        }
-
-        throw new InvalidOperationException("User does not exist");
+        var original = FindById(model.Id) ?? throw new NoContentException();
+        original.Preferences = model.Preferences;
+        base.UpdateAndSave(original);
+        return FindById(model.Id)!;
     }
 
     public IEnumerable<User> FindByRoles(IEnumerable<string> roles)


### PR DESCRIPTION
Updated most of the `NotImplemtedException` uses that were related to not finding content to a new exception `NoContentException`.  This allows us to manage which error messages are returned to the UI.

Update Editor and Subscriber app to handle different types of error message responses.

Also fixed a bug related to report filters.

## File Not Found Error

![image](https://github.com/bcgov/tno/assets/3180256/24ecd9bf-fbff-42d3-9681-ff7e1bfaab84)
