### PR TITLE
TNO-1705: Advanced search bugs

### DIFF
--- a/app/subscriber/public/constants.json
+++ b/app/subscriber/public/constants.json
@@ -1,0 +1,3 @@
+{
+  "frontPageId": 11
+}

--- a/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
@@ -67,6 +67,7 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ expanded, setEx
   const advancedFilter = React.useMemo(
     () =>
       makeFilter({
+        actions: advancedSearch?.topStory ? ['Top Story'] : [],
         headline:
           advancedSearch?.searchTerm && advancedSearch.searchInField?.headline
             ? advancedSearch.searchTerm
@@ -87,8 +88,9 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ expanded, setEx
           Object.values(advancedSearch.searchInField).every((v) => v === false)
             ? advancedSearch.searchTerm
             : '',
+        productIds: advancedSearch?.frontPage ? [11] : [],
         startDate: advancedSearch?.startDate,
-        sourceIds: advancedSearch?.frontPage ? [11] : advancedSearch?.sourceIds,
+        sourceIds: advancedSearch?.sourceIds,
         sentiment: advancedSearch?.sentiment,
         endDate: advancedSearch?.endDate,
         topStory: advancedSearch?.topStory,

--- a/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
@@ -1,6 +1,5 @@
 import { makeFilter } from 'features';
 import React from 'react';
-import constants from './constants/constants.json';
 import { BsCalendarEvent, BsSun } from 'react-icons/bs';
 import { FaRegSmile, FaSearch } from 'react-icons/fa';
 import { GiHamburgerMenu } from 'react-icons/gi';
@@ -22,6 +21,7 @@ import {
   SentimentSection,
 } from './components';
 import { defaultAdvancedSearch } from './constants';
+import constants from './constants/constants.json';
 import {
   defaultSubMediaGroupExpanded,
   IAdvancedSearchFilter,

--- a/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
@@ -1,5 +1,6 @@
 import { makeFilter } from 'features';
 import React from 'react';
+import constants from './constants/constants.json';
 import { BsCalendarEvent, BsSun } from 'react-icons/bs';
 import { FaRegSmile, FaSearch } from 'react-icons/fa';
 import { GiHamburgerMenu } from 'react-icons/gi';
@@ -88,7 +89,7 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ expanded, setEx
           Object.values(advancedSearch.searchInField).every((v) => v === false)
             ? advancedSearch.searchTerm
             : '',
-        productIds: advancedSearch?.frontPage ? [Number(process.env.FRONT_PAGE_ID)] : [],
+        productIds: advancedSearch?.frontPage ? [constants['front.page.id']] : [],
         startDate: advancedSearch?.startDate,
         sourceIds: advancedSearch?.sourceIds,
         sentiment: advancedSearch?.sentiment,

--- a/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
@@ -12,6 +12,7 @@ import {
 import { useNavigate } from 'react-router';
 import { useParams } from 'react-router-dom';
 import { Button, Col, Row, Show, Text, toQueryString } from 'tno-core';
+
 import {
   DateSection,
   MediaSection,
@@ -107,7 +108,7 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ expanded, setEx
         pageIndex: 0,
         pageSize: 100,
       }),
-    [advancedSearch],
+    [advancedSearch, constants?.frontPageId],
   );
 
   const handleSearch = async () => {

--- a/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
@@ -12,7 +12,6 @@ import {
 import { useNavigate } from 'react-router';
 import { useParams } from 'react-router-dom';
 import { Button, Col, Row, Show, Text, toQueryString } from 'tno-core';
-
 import {
   DateSection,
   MediaSection,
@@ -21,7 +20,6 @@ import {
   SentimentSection,
 } from './components';
 import { defaultAdvancedSearch } from './constants';
-import constants from './constants/constants.json';
 import {
   defaultSubMediaGroupExpanded,
   IAdvancedSearchFilter,
@@ -59,11 +57,20 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ expanded, setEx
   /** the object that will eventually be converted to a query and be passed to elastic search */
   const [advancedSearch, setAdvancedSearch] =
     React.useState<IAdvancedSearchFilter>(defaultAdvancedSearch);
+  const [constants, setConstants] = React.useState<any>({});
 
   // update state when query changes, necessary to keep state in sync with url when navigating directly
   React.useEffect(() => {
     if (query) setAdvancedSearch(queryToState(query.toString()));
   }, [query]);
+
+  React.useEffect(() => {
+    fetch('/constants.json')
+      .then((res) => res.json())
+      .then((data) => {
+        setConstants(data);
+      });
+  }, []);
 
   const advancedFilter = React.useMemo(
     () =>
@@ -89,7 +96,7 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ expanded, setEx
           Object.values(advancedSearch.searchInField).every((v) => v === false)
             ? advancedSearch.searchTerm
             : '',
-        productIds: advancedSearch?.frontPage ? [constants['front.page.id']] : [],
+        productIds: advancedSearch?.frontPage ? [constants?.frontPageId] : [],
         startDate: advancedSearch?.startDate,
         sourceIds: advancedSearch?.sourceIds,
         sentiment: advancedSearch?.sentiment,

--- a/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
@@ -88,7 +88,7 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ expanded, setEx
           Object.values(advancedSearch.searchInField).every((v) => v === false)
             ? advancedSearch.searchTerm
             : '',
-        productIds: advancedSearch?.frontPage ? [11] : [],
+        productIds: advancedSearch?.frontPage ? [Number(process.env.FRONT_PAGE_ID)] : [],
         startDate: advancedSearch?.startDate,
         sourceIds: advancedSearch?.sourceIds,
         sentiment: advancedSearch?.sentiment,

--- a/app/subscriber/src/components/sidebar/advanced-search/components/MoreOptions.tsx
+++ b/app/subscriber/src/components/sidebar/advanced-search/components/MoreOptions.tsx
@@ -25,26 +25,26 @@ export const MoreOptions: React.FC<IMoreOptionsProps> = ({
           your search using these settings.
         </p>
         <Col>
-          {/* TODO: What is the below? */}
-          <Checkbox label="featured on the MMIA home page" />
           <Checkbox
             label="are marked as top stories"
-            value={advancedSearch.topStory}
-            onChange={(e) => setAdvancedSearch({ ...advancedSearch, topStory: e.target.checked })}
+            checked={Boolean(advancedSearch.topStory)}
+            onChange={(e) => {
+              setAdvancedSearch({ ...advancedSearch, topStory: e.target.checked });
+            }}
           />
           <Checkbox
             label="are marked as a front page"
-            value={advancedSearch.frontPage}
+            checked={Boolean(advancedSearch.frontPage)}
             onChange={(e) => setAdvancedSearch({ ...advancedSearch, frontPage: e.target.checked })}
           />
           <Checkbox
             label="includes an image"
-            value={advancedSearch.hasFile}
+            checked={Boolean(advancedSearch.hasFile)}
             onChange={(e) => setAdvancedSearch({ ...advancedSearch, hasFile: e.target.checked })}
           />
           <Checkbox
             label={'bold keywords on search page'}
-            value={advancedSearch.boldKeywords}
+            checked={Boolean(advancedSearch.boldKeywords)}
             onChange={(e) =>
               setAdvancedSearch({ ...advancedSearch, boldKeywords: e.target.checked })
             }

--- a/app/subscriber/src/components/sidebar/advanced-search/components/MoreOptions.tsx
+++ b/app/subscriber/src/components/sidebar/advanced-search/components/MoreOptions.tsx
@@ -25,6 +25,8 @@ export const MoreOptions: React.FC<IMoreOptionsProps> = ({
           your search using these settings.
         </p>
         <Col>
+          {/* TODO: Future ticket covers this */}
+          <Checkbox label="featured on the MMIA home page" />
           <Checkbox
             label="are marked as top stories"
             checked={Boolean(advancedSearch.topStory)}

--- a/app/subscriber/src/components/sidebar/advanced-search/constants/DefaultAdvancedSearch.ts
+++ b/app/subscriber/src/components/sidebar/advanced-search/constants/DefaultAdvancedSearch.ts
@@ -5,4 +5,8 @@ export const defaultAdvancedSearch: IAdvancedSearchFilter = {
   searchInField: { headline: false, byline: false, storyText: false },
   startDate: '',
   endDate: '',
+  topStory: false,
+  frontPage: false,
+  hasFile: false,
+  boldKeywords: true,
 };

--- a/app/subscriber/src/components/sidebar/advanced-search/constants/constants.json
+++ b/app/subscriber/src/components/sidebar/advanced-search/constants/constants.json
@@ -1,3 +1,0 @@
-{
-  "front.page.id": 11
-}

--- a/app/subscriber/src/components/sidebar/advanced-search/constants/constants.json
+++ b/app/subscriber/src/components/sidebar/advanced-search/constants/constants.json
@@ -1,0 +1,3 @@
+{
+  "front.page.id": 11
+}

--- a/app/subscriber/src/components/sidebar/advanced-search/interfaces/IAdvancedSearchFilter.ts
+++ b/app/subscriber/src/components/sidebar/advanced-search/interfaces/IAdvancedSearchFilter.ts
@@ -1,4 +1,6 @@
 export interface IAdvancedSearchFilter {
+  /** array of actions to filter by */
+  actions?: string[];
   /** keeps track of which field the search term will query */
   searchInField?: { byline: boolean; headline: boolean; storyText: boolean };
   /** the term that will be queried */

--- a/app/subscriber/src/components/sidebar/advanced-search/utils/queryToState.ts
+++ b/app/subscriber/src/components/sidebar/advanced-search/utils/queryToState.ts
@@ -31,7 +31,13 @@ export const queryToState = (queryString: string) => {
   return {
     searchInField: searchInField,
     searchTerm: searchTerm,
+    actions: search.actions,
+    boldKeywords: search.boldKeywords,
+    hasFile: search.hasFile === 'true',
+    frontPage: search.productIds?.includes(11) || false,
+    topStory: search.actions?.includes('Top Story') || false,
     sourceIds: search.sourceIds?.map((v: any) => Number(v)),
+    productIds: search.productIds,
     startDate: urlParams.get('publishedStartOn') || '',
     endDate: urlParams.get('publishedEndOn') || '',
     sentiment: search.sentiment?.map((v: any) => Number(v)),

--- a/app/subscriber/src/features/content/list-view/interfaces/IContentListFilter.ts
+++ b/app/subscriber/src/features/content/list-view/interfaces/IContentListFilter.ts
@@ -3,6 +3,7 @@ import { ContentStatus, ContentTypeName } from 'tno-core';
 import { ISortBy } from './ISortBy';
 
 export interface IContentListFilter {
+  actions?: string[];
   boldKeywords?: boolean;
   byline?: string;
   contentTypes: ContentTypeName[];

--- a/app/subscriber/src/features/home/utils/makeFilter.ts
+++ b/app/subscriber/src/features/home/utils/makeFilter.ts
@@ -14,7 +14,7 @@ export const makeFilter = (
   filter: IContentListFilter & Partial<IContentListAdvancedFilter>,
 ): ISubscriberContentFilter => {
   const result: ISubscriberContentFilter = {
-    actions: applyActions(filter),
+    actions: filter.actions,
     boldKeywords: filter.boldKeywords,
     quantity: filter.pageSize,
     byline: filter.byline ?? undefined,
@@ -33,18 +33,4 @@ export const makeFilter = (
     storyText: filter.storyText ?? undefined,
   };
   return result;
-};
-
-/**
- * Creates an array of actions from the provided filter information.
- * Cleans up the data to ensure it matches what is expected by the API.
- * @param filter Filter object
- * @returns An array of actions.
- */
-const applyActions = (filter: any) => {
-  const actions = [];
-  if (filter.onTicker) actions.push('On Ticker');
-  if (filter.commentary) actions.push('Commentary');
-  if (filter.topStory) actions.push('Top Story');
-  return actions;
 };

--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -108,7 +108,6 @@ export const SearchPage: React.FC = () => {
       return parse(tempText);
     },
     [
-      urlParams,
       advancedSubscriberFilter.storyText,
       advancedSubscriberFilter.keyword,
       advancedSubscriberFilter.boldKeywords,

--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -5,7 +5,6 @@ import {
 } from 'features/content/list-view/interfaces';
 import { DetermineToneIcon, makeFilter } from 'features/home/utils';
 import parse from 'html-react-parser';
-import { url } from 'inspector';
 import React from 'react';
 import { FaPlay, FaSave, FaStop } from 'react-icons/fa';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -108,7 +107,12 @@ export const SearchPage: React.FC = () => {
       if (!advancedSubscriberFilter.boldKeywords) return parse(text);
       return parse(tempText);
     },
-    [urlParams],
+    [
+      urlParams,
+      advancedSubscriberFilter.storyText,
+      advancedSubscriberFilter.keyword,
+      advancedSubscriberFilter.boldKeywords,
+    ],
   );
   const fetch = React.useCallback(
     async (filter: IContentListFilter & Partial<IContentListAdvancedFilter>) => {


### PR DESCRIPTION
This ticket ended up expanding a bit more as I have been running into issues, I have it down to 1 now.

My current issue as you will see in the GIF below is that when searching for content with files attached I get an "all shards failed" message. 

Interestingly enough this only started to happen once I had content with a file attached, before it was correctly returning no items without an error (previously when no content with a file existed).

![adv-filt](https://github.com/bcgov/tno/assets/15724124/1410eb26-8997-4d74-ac9d-9796cf857da9)

This PR includes the functionality for filtering by

- top story
- front page
- if a file includes an image
- disable/enable bolding