### PR TITLE
TNO-1707: Link to subscriber

### DIFF
--- a/app/editor/public/links.json
+++ b/app/editor/public/links.json
@@ -1,5 +1,0 @@
-{
-  "devSubscriber": "https://mmia-dev.apps.silver.devops.gov.bc.ca",
-  "testSubscriber": "https://mmia-test.apps.silver.devops.gov.bc.ca",
-  "localSubscriber": "http://localhost:40081"
-}

--- a/app/editor/public/links.json
+++ b/app/editor/public/links.json
@@ -1,0 +1,5 @@
+{
+  "devSubscriber": "https://mmia-dev.apps.silver.devops.gov.bc.ca",
+  "testSubscriber": "https://mmia-test.apps.silver.devops.gov.bc.ca",
+  "localSubscriber": "http://localhost:40081"
+}

--- a/app/editor/src/features/content/form/components/tool-bar/ContentFormToolBar.tsx
+++ b/app/editor/src/features/content/form/components/tool-bar/ContentFormToolBar.tsx
@@ -5,7 +5,7 @@ import { useLookup } from 'store/hooks';
 import { Row, Show, ToggleGroup, ToolBar, ToolBarSection } from 'tno-core';
 
 import { IContentForm } from '../../../form/interfaces';
-import { ActionSection, AlertSection, StatusSection } from './form';
+import { ActionSection, AlertSection, PublishedSection, StatusSection } from './form';
 
 export interface IContentFormToolBarProps {
   /** Function to fetch content. */
@@ -81,6 +81,9 @@ export const ContentFormToolBar: React.FC<IContentFormToolBarProps> = ({
           }
           label="LICENCE EXPIRY"
         />
+      </Show>
+      <Show visible={values.status === 'Publish'}>
+        <PublishedSection values={values} />
       </Show>
     </ToolBar>
   );

--- a/app/editor/src/features/content/form/components/tool-bar/form/PublishedSection.tsx
+++ b/app/editor/src/features/content/form/components/tool-bar/form/PublishedSection.tsx
@@ -2,7 +2,7 @@ import { IContentForm } from 'features/content/form/interfaces';
 import React from 'react';
 import { FaExternalLinkAlt } from 'react-icons/fa';
 import { toast } from 'react-toastify';
-import { useSettings } from 'store/hooks/admin';
+import { useLookup } from 'store/hooks';
 import { Col, Row } from 'tno-core';
 
 import * as styled from './styled';
@@ -14,13 +14,11 @@ export interface IPublishedSectionProps {
 
 export const PublishedSection: React.FC<IPublishedSectionProps> = ({ values }) => {
   const [subscriberUrl, setSubscriberUrl] = React.useState<string>();
-  const [{ settings }, api] = useSettings();
+  const [{ settings }] = useLookup();
 
   React.useEffect(() => {
-    api.findAllSettings().then((data) => {
-      setSubscriberUrl(data.find((i) => i.name === 'SubscriberUrl')?.value);
-    });
-  }, [api, settings, subscriberUrl]);
+    setSubscriberUrl(settings.find((i) => i.name === 'SubscriberUrl')?.value);
+  }, [settings, subscriberUrl]);
 
   return (
     <styled.PublishedSection

--- a/app/editor/src/features/content/form/components/tool-bar/form/PublishedSection.tsx
+++ b/app/editor/src/features/content/form/components/tool-bar/form/PublishedSection.tsx
@@ -1,6 +1,8 @@
 import { IContentForm } from 'features/content/form/interfaces';
 import React from 'react';
 import { FaExternalLinkAlt } from 'react-icons/fa';
+import { toast } from 'react-toastify';
+import { useSettings } from 'store/hooks/admin';
 import { Col, Row } from 'tno-core';
 
 import * as styled from './styled';
@@ -11,22 +13,30 @@ export interface IPublishedSectionProps {
 }
 
 export const PublishedSection: React.FC<IPublishedSectionProps> = ({ values }) => {
-  const [subscriberLink, setSubscriberLink] = React.useState<string>('');
+  const [subscriberUrl, setSubscriberUrl] = React.useState<string>();
+  const [{ settings }, api] = useSettings();
+
   React.useEffect(() => {
-    fetch('/links.json')
-      .then((res) => res.json())
-      .then((data) => {
-        if (process.env.NODE_ENV === 'development') setSubscriberLink(data.localSubscriber);
-        if (process.env.NODE_ENV === 'test') setSubscriberLink(data.devSubscriber);
-        if (process.env.NODE_ENV === 'production') setSubscriberLink(data.prodSubscriber);
-      });
-  }, []);
+    api.findAllSettings().then((data) => {
+      setSubscriberUrl(data.find((i) => i.name === 'SubscriberUrl')?.value);
+    });
+  }, [api, settings, subscriberUrl]);
+
   return (
     <styled.PublishedSection
       label="VIEW ON MMIA"
       children={
         <Col>
-          <Row className="view" onClick={() => window.open(`${subscriberLink}/view/${values.id}`)}>
+          <Row
+            className="view"
+            onClick={() => {
+              if (!subscriberUrl) {
+                toast.error('SubscriberUrl setting not found. Please set and try again.');
+                return;
+              }
+              window.open(`${subscriberUrl}/view/${values.id}`);
+            }}
+          >
             <FaExternalLinkAlt /> View on site
           </Row>
         </Col>

--- a/app/editor/src/features/content/form/components/tool-bar/form/PublishedSection.tsx
+++ b/app/editor/src/features/content/form/components/tool-bar/form/PublishedSection.tsx
@@ -1,0 +1,36 @@
+import { IContentForm } from 'features/content/form/interfaces';
+import React from 'react';
+import { FaExternalLinkAlt } from 'react-icons/fa';
+import { Col, Row } from 'tno-core';
+
+import * as styled from './styled';
+
+export interface IPublishedSectionProps {
+  /** Form values */
+  values: IContentForm;
+}
+
+export const PublishedSection: React.FC<IPublishedSectionProps> = ({ values }) => {
+  const [subscriberLink, setSubscriberLink] = React.useState<string>('');
+  React.useEffect(() => {
+    fetch('/links.json')
+      .then((res) => res.json())
+      .then((data) => {
+        if (process.env.NODE_ENV === 'development') setSubscriberLink(data.localSubscriber);
+        if (process.env.NODE_ENV === 'test') setSubscriberLink(data.devSubscriber);
+        if (process.env.NODE_ENV === 'production') setSubscriberLink(data.prodSubscriber);
+      });
+  }, []);
+  return (
+    <styled.PublishedSection
+      label="VIEW ON MMIA"
+      children={
+        <Col>
+          <Row className="view" onClick={() => window.open(`${subscriberLink}/view/${values.id}`)}>
+            <FaExternalLinkAlt /> View on site
+          </Row>
+        </Col>
+      }
+    />
+  );
+};

--- a/app/editor/src/features/content/form/components/tool-bar/form/index.ts
+++ b/app/editor/src/features/content/form/components/tool-bar/form/index.ts
@@ -1,3 +1,4 @@
 export * from './ActionSection';
 export * from './AlertSection';
+export * from './PublishedSection';
 export * from './StatusSection';

--- a/app/editor/src/features/content/form/components/tool-bar/form/styled/PublishedSection.tsx
+++ b/app/editor/src/features/content/form/components/tool-bar/form/styled/PublishedSection.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+import { ToolBarSection } from 'tno-core';
+
+export const PublishedSection = styled(ToolBarSection)`
+  .view {
+    cursor: pointer;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+  svg {
+    align-self: center;
+    margin-right: 0.25rem;
+  }
+`;

--- a/app/editor/src/features/content/form/components/tool-bar/form/styled/index.ts
+++ b/app/editor/src/features/content/form/components/tool-bar/form/styled/index.ts
@@ -1,0 +1,1 @@
+export * from './PublishedSection';


### PR DESCRIPTION
In this PR:
- allow editors to view published content on the subscriber site
- only shows if content is published
- link changes depending on environment

I am curious what is the best way to store these external subscriber links and if a JSON is the best approach.

![externallink](https://github.com/bcgov/tno/assets/15724124/76859b54-7589-4589-8a54-16eaeec73b37)
