### PR TITLE
TNO-1713: In the online form, content is not...

### DIFF
--- a/app/editor/src/features/content/form/ContentStoryForm.tsx
+++ b/app/editor/src/features/content/form/ContentStoryForm.tsx
@@ -221,10 +221,18 @@ export const ContentStoryForm: React.FC<IContentStoryFormProps> = ({
         body={
           <Wysiwyg
             className="modal-quill"
-            label={contentType === ContentTypeName.PrintContent ? 'Story' : 'Summary'}
+            label={
+              contentType === ContentTypeName.PrintContent || contentType === ContentTypeName.Story
+                ? 'Story'
+                : 'Summary'
+            }
             required={isSummaryRequired}
             height={height}
-            fieldName={contentType === ContentTypeName.PrintContent ? 'body' : 'summary'}
+            fieldName={
+              contentType === ContentTypeName.PrintContent || contentType === ContentTypeName.Story
+                ? 'body'
+                : 'summary'
+            }
           />
         }
         isShowing={showExpandModal}


### PR DESCRIPTION
TNO-1713: In the online form, content is not syncing when editing via pop-out editor - content should be reflected on both sites (Editor & Subscriber) when closing/collapsing the view