### PR TITLE
TNO-1723 Enable report preview

### DIFF
--- a/api/net/Areas/Subscriber/Controllers/ReportController.cs
+++ b/api/net/Areas/Subscriber/Controllers/ReportController.cs
@@ -212,7 +212,9 @@ public class ReportController : ControllerBase
         var username = User.GetUsername() ?? throw new NotAuthorizedException("Username is missing");
         var user = _userService.FindByUsername(username) ?? throw new NotAuthorizedException("User does not exist");
         var report = _reportService.FindById(id) ?? throw new InvalidOperationException("Report does not exist");
-        if (report.OwnerId != user?.Id && !report.IsPublic) throw new NotAuthorizedException("Not authorized to preview this report");
+        if (report.OwnerId != user.Id && // User does not own the report
+            !report.SubscribersManyToMany.Any(s => s.IsSubscribed && s.UserId == user.Id) &&  // User is not subscribed to the report
+            !report.IsPublic) throw new NotAuthorizedException("Not authorized to preview this report"); // Report is not public
         var model = new Services.Models.Report.ReportModel(report, _serializerOptions);
         var result = await _reportHelper.GenerateReportAsync(model);
         return new JsonResult(result);

--- a/app/editor/src/features/admin/reports/ReportForm.tsx
+++ b/app/editor/src/features/admin/reports/ReportForm.tsx
@@ -71,6 +71,7 @@ export const ReportForm: React.FC = () => {
             ...s,
             name: generateScheduleName(`Schedule ${i + 1}`, values),
             description: values.description,
+            requestedById: values.ownerId,
           })),
         ],
       };

--- a/openshift/kustomize/services/capture/base/kustomization.yaml
+++ b/openshift/kustomize/services/capture/base/kustomization.yaml
@@ -3,9 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - pvc.yaml
+  # - pvc.yaml
   - config-map.yaml
-  - services-config-map.yaml
+  # - services-config-map.yaml
   - deploy.yaml
   - service.yaml
 

--- a/openshift/kustomize/services/clip/base/kustomization.yaml
+++ b/openshift/kustomize/services/clip/base/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 
 resources:
   - config-map.yaml
-  - services-config-map.yaml
+  # - services-config-map.yaml
   - deploy.yaml
   - service.yaml
 

--- a/openshift/kustomize/tekton/base/pipelines/buildah-all.yaml
+++ b/openshift/kustomize/tekton/base/pipelines/buildah-all.yaml
@@ -140,7 +140,7 @@ spec:
         - name: PROJECT
           value: $(params.PROJECT_SHORTNAME)-$(params.DEPLOY_TO)
         - name: ROUTE
-          value: editor
+          value: editor-tls
         - name: SERVICE
           value: nginx
 
@@ -154,7 +154,7 @@ spec:
         - name: PROJECT
           value: $(params.PROJECT_SHORTNAME)-$(params.DEPLOY_TO)
         - name: ROUTE
-          value: subscriber
+          value: subscriber-tls
         - name: SERVICE
           value: nginx
 
@@ -209,7 +209,7 @@ spec:
         - name: PROJECT
           value: $(params.PROJECT_SHORTNAME)-$(params.DEPLOY_TO)
         - name: ROUTE
-          value: editor
+          value: editor-tls
         - name: SERVICE
           value: editor
 
@@ -223,7 +223,7 @@ spec:
         - name: PROJECT
           value: $(params.PROJECT_SHORTNAME)-$(params.DEPLOY_TO)
         - name: ROUTE
-          value: subscriber
+          value: subscriber-tls
         - name: SERVICE
           value: subscriber
 

--- a/openshift/kustomize/tekton/base/triggers/dev/binding.yaml
+++ b/openshift/kustomize/tekton/base/triggers/dev/binding.yaml
@@ -16,3 +16,7 @@ spec:
       value: dev
     - name: COMPONENT
       value: "*"
+    - name: EDITOR_URL
+      value: https://tno-dev.apps.silver.devops.gov.bc.ca
+    - name: SUBSCRIBER_URL
+      value: https://mmia-dev.apps.silver.devops.gov.bc.ca

--- a/openshift/kustomize/tekton/base/triggers/template.yaml
+++ b/openshift/kustomize/tekton/base/triggers/template.yaml
@@ -14,6 +14,16 @@ spec:
       description: The environment to deploy to
     - name: COMPONENT
       description: Which components to build/deploy [*|all|[name]]
+
+    - name: EDITOR_URL
+      description: The URL to the web application that will be ZAP scanned.
+      type: string
+      default: https://tno-dev.apps.silver.devops.gov.bc.ca
+
+    - name: SUBSCRIBER_URL
+      description: The URL to the web application that will be ZAP scanned.
+      type: string
+      default: https://mmia-dev.apps.silver.devops.gov.bc.ca
   resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
@@ -49,6 +59,10 @@ spec:
             value: $(tt.params.DEPLOY_TO)
           - name: COMPONENT
             value: $(tt.params.COMPONENT)
+          - name: EDITOR_URL
+            value: $(tt.params.EDITOR_URL)
+          - name: SUBSCRIBER_URL
+            value: $(tt.params.SUBSCRIBER_URL)
         workspaces:
           - name: source
             persistentVolumeClaim:

--- a/openshift/kustomize/tekton/base/triggers/test/binding.yaml
+++ b/openshift/kustomize/tekton/base/triggers/test/binding.yaml
@@ -16,3 +16,7 @@ spec:
       value: test
     - name: COMPONENT
       value: all
+    - name: EDITOR_URL
+      value: https://tno-test.apps.silver.devops.gov.bc.ca
+    - name: SUBSCRIBER_URL
+      value: https://mmia-test.apps.silver.devops.gov.bc.ca

--- a/services/net/scheduler/SchedulerManager.cs
+++ b/services/net/scheduler/SchedulerManager.cs
@@ -66,8 +66,7 @@ public class SchedulerManager : ServiceManager<SchedulerOptions>
                         var scheduledEvent = await this.Api.GetEventScheduleAsync(ev.Id) ?? throw new InvalidOperationException($"Event does not exist {ev.Id}:{ev.Name}");
                         if (VerifySchedule(scheduledEvent))
                         {
-                            // Generate topic message
-                            // Send message to Kafka
+                            this.Logger.LogInformation("Scheduled event '{name}' is running", scheduledEvent.Name);
                             if (ev.EventType == EventScheduleType.Report)
                                 await GenerateReportRequestAsync(scheduledEvent);
                             else if (ev.EventType == EventScheduleType.Notification)


### PR DESCRIPTION
A user who is subscribed to a report can now preview it even though the report is private and the user does not own the report.  This provides a way for users to share their private reports with other users.

By default a report scheduled event will be assigned to the owner of the report.  This will make that user the owner of the instance when the report is run in the Reporting Service.

Fixed DevOps issues to be able to deploy Capture and Clip Service to the TEST environment.