### PR TITLE
Fix bug for published link

### DIFF
--- a/app/editor/src/features/content/form/components/tool-bar/ContentFormToolBar.tsx
+++ b/app/editor/src/features/content/form/components/tool-bar/ContentFormToolBar.tsx
@@ -82,7 +82,7 @@ export const ContentFormToolBar: React.FC<IContentFormToolBarProps> = ({
           label="LICENCE EXPIRY"
         />
       </Show>
-      <Show visible={values.status === 'Publish'}>
+      <Show visible={values.status === 'Publish' || values.status === 'Published'}>
         <PublishedSection values={values} />
       </Show>
     </ToolBar>


### PR DESCRIPTION
This should solve the bug Carolynn found with the link disappearing. 

But also I have a question, should we not bother showing the link for `Publish` and only show for `Published`? It seems to work as expected for `Publish` (until the status is changed of course).