### PR TITLE
Implement Route-based code splitting

### DIFF
--- a/app/editor/src/components/layout/DefaultLayout.tsx
+++ b/app/editor/src/components/layout/DefaultLayout.tsx
@@ -33,7 +33,7 @@ interface ILayoutProps extends React.HTMLAttributes<HTMLDivElement> {
  * @param param0 Component properties.
  * @returns DefaultLayout component.
  */
-export const DefaultLayout: React.FC<ILayoutProps> = ({ name, children, ...rest }) => {
+const DefaultLayout: React.FC<ILayoutProps> = ({ name, children, ...rest }) => {
   const keycloak = useKeycloakWrapper();
   const { setToken } = React.useContext(SummonContext);
   var hub = useApiHub();
@@ -152,3 +152,5 @@ export const DefaultLayout: React.FC<ILayoutProps> = ({ name, children, ...rest 
     </styled.Layout>
   );
 };
+
+export default DefaultLayout;

--- a/app/editor/src/features/access-request/AccessRequest.tsx
+++ b/app/editor/src/features/access-request/AccessRequest.tsx
@@ -13,7 +13,7 @@ import * as styled from './styled';
  * Component to submit access requests.
  * @returns Access request page.
  */
-export const AccessRequest: React.FC = () => {
+const AccessRequest: React.FC = () => {
   const keycloak = useKeycloakWrapper();
   const [{ userInfo }] = useApp();
   const navigate = useNavigate();
@@ -53,3 +53,5 @@ export const AccessRequest: React.FC = () => {
     </styled.AccessRequest>
   );
 };
+
+export default AccessRequest;

--- a/app/editor/src/features/admin/AdminRouter.tsx
+++ b/app/editor/src/features/admin/AdminRouter.tsx
@@ -1,137 +1,139 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
-import {
-  ActionForm,
-  ActionList,
-  ChartTemplateForm,
-  ConnectionForm,
-  ConnectionList,
-  ContentReferenceList,
-  ContributorForm,
-  ContributorList,
-  DataLocationForm,
-  DataLocationList,
-  FilterForm,
-  FilterList,
-  IngestDetails,
-  IngestForm,
-  IngestList,
-  IngestSchedule,
-  IngestSettings,
-  IngestTypeForm,
-  IngestTypeList,
-  LicenseForm,
-  LicenseList,
-  MinisterForm,
-  MinisterList,
-  NotificationForm,
-  NotificationList,
-  ProductForm,
-  ProductList,
-  ReachEarnedMedia,
-  ReportAdmin,
-  ReportForm,
-  ReportTemplateForm,
-  SeriesForm,
-  SeriesList,
-  SettingForm,
-  SettingList,
-  SourceDetails,
-  SourceForm,
-  SourceList,
-  TagList,
-  TagsForm,
-  TopicList,
-  TopicScoreRuleList,
-  UserForm,
-  UserList,
-  WorkOrderForm,
-  WorkOrderList,
-} from '.';
-import { AVOverview } from './av-overviews';
-import { SystemMessageForm } from './system-message/SystemMessageForm';
+const ActionForm = lazy(() => import('features/admin/actions/ActionForm'));
+const ActionList = lazy(() => import('features/admin/actions/ActionList'));
+const AVOverview = lazy(() => import('features/admin/av-overviews/AVOverview'));
+const ChartTemplateForm = lazy(() => import('features/admin/charts/ChartTemplateForm'));
+const ConnectionForm = lazy(() => import('features/admin/connections/ConnectionForm'));
+const ConnectionList = lazy(() => import('features/admin/connections/ConnectionList'));
+const ContentReferenceList = lazy(() => import('features/admin/ingests/ContentReferenceList'));
+const ContributorForm = lazy(() => import('features/admin/contributors/ContributorForm'));
+const ContributorList = lazy(() => import('features/admin/contributors/ContributorList'));
+const DataLocationForm = lazy(() => import('features/admin/data-locations/DataLocationForm'));
+const DataLocationList = lazy(() => import('features/admin/data-locations/DataLocationList'));
+const FilterForm = lazy(() => import('features/admin/filters/FilterForm'));
+const FilterList = lazy(() => import('features/admin/filters/FilterList'));
+const IngestDetails = lazy(() => import('features/admin/ingests/IngestDetails'));
+const IngestForm = lazy(() => import('features/admin/ingests/IngestForm'));
+const IngestList = lazy(() => import('features/admin/ingests/IngestList'));
+const IngestSchedule = lazy(() => import('features/admin/ingests/schedules/IngestSchedule'));
+const IngestSettings = lazy(() => import('features/admin/ingests/IngestSettings'));
+const IngestTypeForm = lazy(() => import('features/admin/ingest-types/IngestTypeForm'));
+const IngestTypeList = lazy(() => import('features/admin/ingest-types/IngestTypeList'));
+const LicenseForm = lazy(() => import('features/admin/licenses/LicenseForm'));
+const LicenseList = lazy(() => import('features/admin/licenses/LicenseList'));
+const MinisterForm = lazy(() => import('features/admin/ministers/MinisterForm'));
+const MinisterList = lazy(() => import('features/admin/ministers/MinisterList'));
+const NotificationForm = lazy(() => import('features/admin/notifications/NotificationForm'));
+const NotificationList = lazy(() => import('features/admin/notifications/NotificationList'));
+const ProductForm = lazy(() => import('features/admin/products/ProductForm'));
+const ProductList = lazy(() => import('features/admin/products/ProductList'));
+const ReachEarnedMedia = lazy(() => import('features/admin/sources/ReachEarnedMedia'));
+const ReportAdmin = lazy(() => import('features/admin/reports/ReportAdmin'));
+const ReportForm = lazy(() => import('features/admin/reports/ReportForm'));
+const ReportTemplateForm = lazy(() => import('features/admin/report-templates/ReportTemplateForm'));
+const SeriesForm = lazy(() => import('features/admin/series/SeriesForm'));
+const SeriesList = lazy(() => import('features/admin/series/SeriesList'));
+const SettingForm = lazy(() => import('features/admin/settings/SettingForm'));
+const SettingList = lazy(() => import('features/admin/settings/SettingList'));
+const SourceDetails = lazy(() => import('features/admin/sources/SourceDetails'));
+const SourceForm = lazy(() => import('features/admin/sources/SourceForm'));
+const SourceList = lazy(() => import('features/admin/sources/SourceList'));
+const SystemMessageForm = lazy(() => import('features/admin/system-message/SystemMessageForm'));
+const TagList = lazy(() => import('features/admin/tags/TagList'));
+const TagsForm = lazy(() => import('features/admin/tags/TagsForm'));
+const TopicList = lazy(() => import('features/admin/topics/TopicList'));
+const TopicScoreRuleList = lazy(
+  () => import('features/admin/topic-score-rules/TopicScoreRuleList'),
+);
+const UserForm = lazy(() => import('features/admin/users/UserForm'));
+const UserList = lazy(() => import('features/admin/users/UserList'));
+const WorkOrderForm = lazy(() => import('features/admin/work-orders/WorkOrderForm'));
+const WorkOrderList = lazy(() => import('features/admin/work-orders/WorkOrderList'));
 
 export const AdminRouter: React.FC = () => {
   return (
-    <Routes>
-      <Route index element={<Navigate to="users" />} />
-      <Route path="users" element={<UserList />} />
-      <Route path="users/:id" element={<UserForm />} />
+    <Suspense fallback={<div>Loading...</div>}>
+      <Routes>
+        <Route index element={<Navigate to="users" />} />
+        <Route path="users" element={<UserList />} />
+        <Route path="users/:id" element={<UserForm />} />
 
-      <Route path="topics" element={<TopicList />} />
-      <Route path="topics/:id" element={<TopicList />} />
+        <Route path="topics" element={<TopicList />} />
+        <Route path="topics/:id" element={<TopicList />} />
 
-      <Route path="topic-scores" element={<TopicScoreRuleList />} />
+        <Route path="topic-scores" element={<TopicScoreRuleList />} />
 
-      <Route path="tags" element={<TagList />} />
-      <Route path="tags/:id" element={<TagsForm />} />
+        <Route path="tags" element={<TagList />} />
+        <Route path="tags/:id" element={<TagsForm />} />
 
-      <Route path="system-message" element={<SystemMessageForm />} />
+        <Route path="system-message" element={<SystemMessageForm />} />
 
-      <Route path="programs" element={<SeriesList />} />
-      <Route path="programs/:id" element={<SeriesForm />} />
+        <Route path="programs" element={<SeriesList />} />
+        <Route path="programs/:id" element={<SeriesForm />} />
 
-      <Route path="contributors" element={<ContributorList />} />
-      <Route path="contributors/:id" element={<ContributorForm />} />
+        <Route path="contributors" element={<ContributorList />} />
+        <Route path="contributors/:id" element={<ContributorForm />} />
 
-      <Route path="products" element={<ProductList />} />
-      <Route path="products/:id" element={<ProductForm />} />
+        <Route path="products" element={<ProductList />} />
+        <Route path="products/:id" element={<ProductForm />} />
 
-      <Route path="actions" element={<ActionList />} />
-      <Route path="actions/:id" element={<ActionForm />} />
+        <Route path="actions" element={<ActionList />} />
+        <Route path="actions/:id" element={<ActionForm />} />
 
-      <Route path="licences" element={<LicenseList />} />
-      <Route path="licences/:id" element={<LicenseForm />} />
+        <Route path="licences" element={<LicenseList />} />
+        <Route path="licences/:id" element={<LicenseForm />} />
 
-      <Route path="sources" element={<SourceList />} />
-      <Route path="sources/:id" element={<SourceForm />}>
-        <Route index element={<SourceDetails />} />
-        <Route path="details" element={<SourceDetails />} />
-        <Route path="metrics" element={<ReachEarnedMedia />} />
-      </Route>
+        <Route path="sources" element={<SourceList />} />
+        <Route path="sources/:id" element={<SourceForm />}>
+          <Route index element={<SourceDetails />} />
+          <Route path="details" element={<SourceDetails />} />
+          <Route path="metrics" element={<ReachEarnedMedia />} />
+        </Route>
 
-      <Route path="connections" element={<ConnectionList />} />
-      <Route path="connections/:id" element={<ConnectionForm />} />
+        <Route path="connections" element={<ConnectionList />} />
+        <Route path="connections/:id" element={<ConnectionForm />} />
 
-      <Route path="ministers" element={<MinisterList />} />
-      <Route path="ministers/:id" element={<MinisterForm />} />
+        <Route path="ministers" element={<MinisterList />} />
+        <Route path="ministers/:id" element={<MinisterForm />} />
 
-      <Route path="data/locations" element={<DataLocationList />} />
-      <Route path="data/locations/:id" element={<DataLocationForm />} />
+        <Route path="data/locations" element={<DataLocationList />} />
+        <Route path="data/locations/:id" element={<DataLocationForm />} />
 
-      <Route path="ingest/types" element={<IngestTypeList />} />
-      <Route path="ingest/types/:id" element={<IngestTypeForm />} />
+        <Route path="ingest/types" element={<IngestTypeList />} />
+        <Route path="ingest/types/:id" element={<IngestTypeForm />} />
 
-      <Route path="ingests" element={<IngestList />} />
-      <Route path="ingests/:id" element={<IngestForm />}>
-        <Route index element={<IngestDetails />} />
-        <Route path="details" element={<IngestDetails />} />
-        <Route path="schedule" element={<IngestSchedule />} />
-        <Route path="settings" element={<IngestSettings />} />
-        <Route path="ingesting" element={<ContentReferenceList />} />
-      </Route>
+        <Route path="ingests" element={<IngestList />} />
+        <Route path="ingests/:id" element={<IngestForm />}>
+          <Route index element={<IngestDetails />} />
+          <Route path="details" element={<IngestDetails />} />
+          <Route path="schedule" element={<IngestSchedule />} />
+          <Route path="settings" element={<IngestSettings />} />
+          <Route path="ingesting" element={<ContentReferenceList />} />
+        </Route>
 
-      <Route path="work/orders" element={<WorkOrderList />} />
-      <Route path="work/orders/:id" element={<WorkOrderForm />} />
+        <Route path="work/orders" element={<WorkOrderList />} />
+        <Route path="work/orders/:id" element={<WorkOrderForm />} />
 
-      <Route path="reports" element={<ReportAdmin />} />
-      <Route path="reports/:id" element={<ReportForm />} />
-      <Route path="report/templates/:id" element={<ReportTemplateForm />} />
-      <Route path="report/:path" element={<ReportAdmin />} />
-      <Route path="chart/templates" element={<ReportAdmin path="charts" />} />
-      <Route path="chart/templates/:id" element={<ChartTemplateForm />} />
+        <Route path="reports" element={<ReportAdmin />} />
+        <Route path="reports/:id" element={<ReportForm />} />
+        <Route path="report/templates/:id" element={<ReportTemplateForm />} />
+        <Route path="report/:path" element={<ReportAdmin />} />
+        <Route path="chart/templates" element={<ReportAdmin path="charts" />} />
+        <Route path="chart/templates/:id" element={<ChartTemplateForm />} />
 
-      <Route path="filters" element={<FilterList />} />
-      <Route path="filters/:id" element={<FilterForm />} />
+        <Route path="filters" element={<FilterList />} />
+        <Route path="filters/:id" element={<FilterForm />} />
 
-      <Route path="settings" element={<SettingList />} />
-      <Route path="settings/:id" element={<SettingForm />} />
+        <Route path="settings" element={<SettingList />} />
+        <Route path="settings/:id" element={<SettingForm />} />
 
-      <Route path="notifications" element={<NotificationList />} />
-      <Route path="notifications/:id" element={<NotificationForm />} />
+        <Route path="notifications" element={<NotificationList />} />
+        <Route path="notifications/:id" element={<NotificationForm />} />
 
-      <Route path="av/evening-overview" element={<AVOverview />} />
-    </Routes>
+        <Route path="av/evening-overview" element={<AVOverview />} />
+      </Routes>
+    </Suspense>
   );
 };

--- a/app/editor/src/features/admin/actions/ActionForm.tsx
+++ b/app/editor/src/features/admin/actions/ActionForm.tsx
@@ -34,7 +34,7 @@ import * as styled from './styled';
  * The page used to view and edit actions.
  * @returns Component.
  */
-export const ActionForm: React.FC = () => {
+const ActionForm: React.FC = () => {
   const { id } = useParams();
   const navigate = useNavigate();
   const [, api] = useActions();
@@ -185,3 +185,5 @@ export const ActionForm: React.FC = () => {
     </styled.ActionForm>
   );
 };
+
+export default ActionForm;

--- a/app/editor/src/features/admin/actions/ActionList.tsx
+++ b/app/editor/src/features/admin/actions/ActionList.tsx
@@ -7,7 +7,7 @@ import { ActionFilter } from './ActionFilter';
 import { columns } from './constants';
 import * as styled from './styled';
 
-export const ActionList: React.FC = () => {
+const ActionList: React.FC = () => {
   const navigate = useNavigate();
   const [{ actions }, api] = useActions();
 
@@ -65,3 +65,5 @@ export const ActionList: React.FC = () => {
     </styled.ActionList>
   );
 };
+
+export default ActionList;

--- a/app/editor/src/features/admin/av-overviews/AVOverview.tsx
+++ b/app/editor/src/features/admin/av-overviews/AVOverview.tsx
@@ -24,7 +24,7 @@ import { OverviewSection } from './OverviewSection';
 import * as styled from './styled';
 
 /** Evening overview section, contains table of items, and list of overview sections */
-export const AVOverview: React.FC = () => {
+const AVOverview: React.FC = () => {
   const [api] = useAVOverviewTemplates();
   const [{ reportTemplates }, { findAllReportTemplates }] = useReportTemplates();
 
@@ -156,3 +156,5 @@ export const AVOverview: React.FC = () => {
     </styled.AVOverview>
   );
 };
+
+export default AVOverview;

--- a/app/editor/src/features/admin/charts/ChartTemplateForm.tsx
+++ b/app/editor/src/features/admin/charts/ChartTemplateForm.tsx
@@ -28,7 +28,7 @@ import * as styled from './styled';
  * The page used to view and edit a chart template.
  * @returns Component.
  */
-export const ChartTemplateForm: React.FC = () => {
+const ChartTemplateForm: React.FC = () => {
   const navigate = useNavigate();
   const { id } = useParams();
   const [, { addChartTemplate, deleteChartTemplate, getChartTemplate, updateChartTemplate }] =
@@ -182,3 +182,5 @@ export const ChartTemplateForm: React.FC = () => {
     </styled.ChartForm>
   );
 };
+
+export default ChartTemplateForm;

--- a/app/editor/src/features/admin/connections/ConnectionForm.tsx
+++ b/app/editor/src/features/admin/connections/ConnectionForm.tsx
@@ -31,7 +31,7 @@ import * as styled from './styled';
  * Admin form for connection configuration.
  * @returns Component.
  */
-export const ConnectionForm: React.FC = () => {
+const ConnectionForm: React.FC = () => {
   const [, api] = useConnections();
   const { state } = useLocation();
   const { id } = useParams();
@@ -181,3 +181,5 @@ export const ConnectionForm: React.FC = () => {
     </styled.ConnectionForm>
   );
 };
+
+export default ConnectionForm;

--- a/app/editor/src/features/admin/connections/ConnectionList.tsx
+++ b/app/editor/src/features/admin/connections/ConnectionList.tsx
@@ -11,7 +11,7 @@ import * as styled from './styled';
  * Admin list view for connections.
  * @returns Component.
  */
-export const ConnectionList: React.FC = () => {
+const ConnectionList: React.FC = () => {
   const navigate = useNavigate();
   const [{ connections }, api] = useConnections();
 
@@ -69,3 +69,5 @@ export const ConnectionList: React.FC = () => {
     </styled.ConnectionList>
   );
 };
+
+export default ConnectionList;

--- a/app/editor/src/features/admin/contributors/ContributorForm.tsx
+++ b/app/editor/src/features/admin/contributors/ContributorForm.tsx
@@ -33,7 +33,7 @@ import * as styled from './styled';
 import { toForm, toModel } from './utils';
 
 /** The page used to view and edit contributors the administrative section. */
-export const ContributorForm: React.FC = () => {
+const ContributorForm: React.FC = () => {
   const { id } = useParams();
   const [, api] = useContributors();
   const { state } = useLocation();
@@ -188,3 +188,5 @@ export const ContributorForm: React.FC = () => {
     </styled.ContributorForm>
   );
 };
+
+export default ContributorForm;

--- a/app/editor/src/features/admin/contributors/ContributorList.tsx
+++ b/app/editor/src/features/admin/contributors/ContributorList.tsx
@@ -7,7 +7,7 @@ import { columns } from './constants';
 import { ContributorFilter } from './ContributorFilter';
 import * as styled from './styled';
 
-export const ContributorList: React.FC = () => {
+const ContributorList: React.FC = () => {
   const navigate = useNavigate();
   const [{ contributors }, api] = useContributors();
 
@@ -64,3 +64,5 @@ export const ContributorList: React.FC = () => {
     </styled.ContributorList>
   );
 };
+
+export default ContributorList;

--- a/app/editor/src/features/admin/data-locations/DataLocationForm.tsx
+++ b/app/editor/src/features/admin/data-locations/DataLocationForm.tsx
@@ -31,7 +31,7 @@ import * as styled from './styled';
 import { toForm, toModel } from './utils';
 
 /** The page used to view and edit tags in the administrative section. */
-export const DataLocationForm: React.FC = () => {
+const DataLocationForm: React.FC = () => {
   const [, api] = useDataLocations();
   const { state } = useLocation();
   const [{ connections }, { findAllConnections }] = useConnections();
@@ -191,3 +191,5 @@ export const DataLocationForm: React.FC = () => {
     </styled.DataLocationForm>
   );
 };
+
+export default DataLocationForm;

--- a/app/editor/src/features/admin/data-locations/DataLocationList.tsx
+++ b/app/editor/src/features/admin/data-locations/DataLocationList.tsx
@@ -7,7 +7,7 @@ import { columns } from './constants';
 import { DataLocationFilter } from './DataLocationFilter';
 import * as styled from './styled';
 
-export const DataLocationList: React.FC = () => {
+const DataLocationList: React.FC = () => {
   const navigate = useNavigate();
   const [{ dataLocations }, api] = useDataLocations();
 
@@ -63,3 +63,4 @@ export const DataLocationList: React.FC = () => {
     </styled.DataLocationList>
   );
 };
+export default DataLocationList;

--- a/app/editor/src/features/admin/filters/FilterForm.tsx
+++ b/app/editor/src/features/admin/filters/FilterForm.tsx
@@ -29,7 +29,7 @@ export interface IFilterFormProps {}
  * Provides a page to admin a list of filters and filter templates.
  * @returns Component to admin filters and filter templates.
  */
-export const FilterForm: React.FC<IFilterFormProps> = () => {
+const FilterForm: React.FC<IFilterFormProps> = () => {
   const navigate = useNavigate();
   const [{ userInfo }] = useApp();
   const { id } = useParams();
@@ -153,3 +153,5 @@ export const FilterForm: React.FC<IFilterFormProps> = () => {
     </styled.FilterForm>
   );
 };
+
+export default FilterForm;

--- a/app/editor/src/features/admin/filters/FilterList.tsx
+++ b/app/editor/src/features/admin/filters/FilterList.tsx
@@ -7,7 +7,7 @@ import { filterColumns } from './constants';
 import { ListFilter } from './ListFilter';
 import * as styled from './styled';
 
-export const FilterList: React.FC = () => {
+const FilterList: React.FC = () => {
   const navigate = useNavigate();
   const [{ initialized, filters }, api] = useFilters();
 
@@ -66,3 +66,5 @@ export const FilterList: React.FC = () => {
     </styled.FilterList>
   );
 };
+
+export default FilterList;

--- a/app/editor/src/features/admin/ingest-types/IngestTypeForm.tsx
+++ b/app/editor/src/features/admin/ingest-types/IngestTypeForm.tsx
@@ -27,7 +27,7 @@ import { contentTypeOptions, defaultIngestType } from './constants';
 import * as styled from './styled';
 
 /** The page used to view and edit ingest types in the administrative section. */
-export const IngestTypeForm: React.FC = () => {
+const IngestTypeForm: React.FC = () => {
   const [, api] = useIngestTypes();
   const { state } = useLocation();
   const { id } = useParams();
@@ -177,3 +177,5 @@ export const IngestTypeForm: React.FC = () => {
     </styled.IngestTypeForm>
   );
 };
+
+export default IngestTypeForm;

--- a/app/editor/src/features/admin/ingest-types/IngestTypeList.tsx
+++ b/app/editor/src/features/admin/ingest-types/IngestTypeList.tsx
@@ -7,7 +7,7 @@ import { columns } from './constants';
 import { IngestTypeFilter } from './IngestTypeFilter';
 import * as styled from './styled';
 
-export const IngestTypeList: React.FC = () => {
+const IngestTypeList: React.FC = () => {
   const navigate = useNavigate();
   const [{ ingestTypes }, api] = useIngestTypes();
 
@@ -63,3 +63,5 @@ export const IngestTypeList: React.FC = () => {
     </styled.IngestTypeList>
   );
 };
+
+export default IngestTypeList;

--- a/app/editor/src/features/admin/ingests/ContentReferenceList.tsx
+++ b/app/editor/src/features/admin/ingests/ContentReferenceList.tsx
@@ -29,7 +29,7 @@ import * as styled from './styled';
 
 export interface IContentReferenceListProps {}
 
-export const ContentReferenceList: React.FC<IContentReferenceListProps> = (props) => {
+const ContentReferenceList: React.FC<IContentReferenceListProps> = (props) => {
   const [{ requests }] = useApp();
   const [, api] = useContentReferences();
   const { values } = useFormikContext<IIngestModel>();
@@ -178,3 +178,5 @@ export const ContentReferenceList: React.FC<IContentReferenceListProps> = (props
     </styled.ContentReferenceList>
   );
 };
+
+export default ContentReferenceList;

--- a/app/editor/src/features/admin/ingests/IngestDetails.tsx
+++ b/app/editor/src/features/admin/ingests/IngestDetails.tsx
@@ -26,7 +26,7 @@ interface IIngestDetailsProps {}
  * A component with ingest detail form.
  * @returns Component provides ingest detail form.
  */
-export const IngestDetails: React.FC<IIngestDetailsProps> = () => {
+const IngestDetails: React.FC<IIngestDetailsProps> = () => {
   const { values, setFieldValue, setErrors, errors } = useFormikContext<IIngestModel>();
   const [lookups] = useLookup();
   const [{ dataLocations }, { findAllDataLocations }] = useDataLocations();
@@ -139,3 +139,5 @@ export const IngestDetails: React.FC<IIngestDetailsProps> = () => {
     </styled.IngestDetails>
   );
 };
+
+export default IngestDetails;

--- a/app/editor/src/features/admin/ingests/IngestForm.tsx
+++ b/app/editor/src/features/admin/ingests/IngestForm.tsx
@@ -25,7 +25,7 @@ import * as styled from './styled';
 
 interface IIngestProps {}
 
-export const IngestForm: React.FC<IIngestProps> = (props) => {
+const IngestForm: React.FC<IIngestProps> = (props) => {
   const [, api] = useIngests();
   const { state } = useLocation();
   const { id } = useParams();
@@ -168,3 +168,5 @@ export const IngestForm: React.FC<IIngestProps> = (props) => {
     </styled.IngestForm>
   );
 };
+
+export default IngestForm;

--- a/app/editor/src/features/admin/ingests/IngestList.tsx
+++ b/app/editor/src/features/admin/ingests/IngestList.tsx
@@ -9,7 +9,7 @@ import * as styled from './styled';
 
 interface IIngestListProps {}
 
-export const IngestList: React.FC<IIngestListProps> = (props) => {
+const IngestList: React.FC<IIngestListProps> = (props) => {
   const navigate = useNavigate();
   const [{ ingests }, api] = useIngests();
 
@@ -68,3 +68,5 @@ export const IngestList: React.FC<IIngestListProps> = (props) => {
     </styled.IngestList>
   );
 };
+
+export default IngestList;

--- a/app/editor/src/features/admin/ingests/IngestSettings.tsx
+++ b/app/editor/src/features/admin/ingests/IngestSettings.tsx
@@ -24,7 +24,7 @@ interface IIngestSettingsProps {}
  * A UI component form to manage data source ingest settings.
  * @returns Component.
  */
-export const IngestSettings: React.FC<IIngestSettingsProps> = () => {
+const IngestSettings: React.FC<IIngestSettingsProps> = () => {
   const { values, setFieldValue } = useFormikContext<IIngestModel>();
   const [{ connections }, { findAllConnections }] = useConnections();
   const [lookups] = useLookup();
@@ -259,3 +259,5 @@ export const IngestSettings: React.FC<IIngestSettingsProps> = () => {
     </styled.IngestSettings>
   );
 };
+
+export default IngestSettings;

--- a/app/editor/src/features/admin/ingests/schedules/IngestSchedule.tsx
+++ b/app/editor/src/features/admin/ingests/schedules/IngestSchedule.tsx
@@ -16,7 +16,7 @@ import * as styled from './styled';
 
 interface IIngestScheduleProps {}
 
-export const IngestSchedule: React.FC<IIngestScheduleProps> = () => {
+const IngestSchedule: React.FC<IIngestScheduleProps> = () => {
   const { values, setFieldValue } = useFormikContext<IIngestModel>();
 
   const scheduleTypeOptions = getEnumStringOptions(ScheduleTypeName);
@@ -59,3 +59,5 @@ export const IngestSchedule: React.FC<IIngestScheduleProps> = () => {
     </styled.IngestSchedule>
   );
 };
+
+export default IngestSchedule;

--- a/app/editor/src/features/admin/licenses/LicenseForm.tsx
+++ b/app/editor/src/features/admin/licenses/LicenseForm.tsx
@@ -27,7 +27,7 @@ import { defaultLicense } from './constants';
 import * as styled from './styled';
 
 /** The page used to view and edit tags in the administrative section. */
-export const LicenseForm: React.FC = () => {
+const LicenseForm: React.FC = () => {
   const [, api] = useLicenses();
   const { state } = useLocation();
   const { id } = useParams();
@@ -171,3 +171,5 @@ export const LicenseForm: React.FC = () => {
     </styled.LicenseForm>
   );
 };
+
+export default LicenseForm;

--- a/app/editor/src/features/admin/licenses/LicenseList.tsx
+++ b/app/editor/src/features/admin/licenses/LicenseList.tsx
@@ -7,7 +7,7 @@ import { columns } from './constants';
 import { LicenseFilter } from './LicenseFilter';
 import * as styled from './styled';
 
-export const LicenseList: React.FC = () => {
+const LicenseList: React.FC = () => {
   const navigate = useNavigate();
   const [{ licenses }, api] = useLicenses();
 
@@ -65,3 +65,4 @@ export const LicenseList: React.FC = () => {
     </styled.LicenseList>
   );
 };
+export default LicenseList;

--- a/app/editor/src/features/admin/ministers/MinisterForm.tsx
+++ b/app/editor/src/features/admin/ministers/MinisterForm.tsx
@@ -28,7 +28,7 @@ import * as styled from './styled';
  * Admin form for minister configuration.
  * @returns Component.
  */
-export const MinisterForm: React.FC = () => {
+const MinisterForm: React.FC = () => {
   const [, api] = useMinisters();
   const { state } = useLocation();
   const { id } = useParams();
@@ -167,3 +167,5 @@ export const MinisterForm: React.FC = () => {
     </styled.MinisterForm>
   );
 };
+
+export default MinisterForm;

--- a/app/editor/src/features/admin/ministers/MinisterList.tsx
+++ b/app/editor/src/features/admin/ministers/MinisterList.tsx
@@ -11,7 +11,7 @@ import * as styled from './styled';
  * Admin list view for ministers.
  * @returns Component.
  */
-export const MinisterList: React.FC = () => {
+const MinisterList: React.FC = () => {
   const navigate = useNavigate();
   const [{ ministers }, api] = useMinisters();
 
@@ -68,3 +68,5 @@ export const MinisterList: React.FC = () => {
     </styled.MinisterList>
   );
 };
+
+export default MinisterList;

--- a/app/editor/src/features/admin/notifications/NotificationForm.tsx
+++ b/app/editor/src/features/admin/notifications/NotificationForm.tsx
@@ -45,7 +45,7 @@ import * as styled from './styled';
  * The page used to view and edit Notifications.
  * @returns Component.
  */
-export const NotificationForm: React.FC = () => {
+const NotificationForm: React.FC = () => {
   const navigate = useNavigate();
   const [{ userInfo }] = useApp();
   const { id } = useParams();
@@ -308,3 +308,5 @@ export const NotificationForm: React.FC = () => {
     </styled.NotificationForm>
   );
 };
+
+export default NotificationForm;

--- a/app/editor/src/features/admin/notifications/NotificationList.tsx
+++ b/app/editor/src/features/admin/notifications/NotificationList.tsx
@@ -7,7 +7,7 @@ import { columns } from './constants';
 import { NotificationFilter } from './NotificationFilter';
 import * as styled from './styled';
 
-export const NotificationList: React.FC = () => {
+const NotificationList: React.FC = () => {
   const navigate = useNavigate();
   const [{ notifications }, api] = useNotifications();
 
@@ -65,3 +65,5 @@ export const NotificationList: React.FC = () => {
     </styled.NotificationList>
   );
 };
+
+export default NotificationList;

--- a/app/editor/src/features/admin/products/ProductForm.tsx
+++ b/app/editor/src/features/admin/products/ProductForm.tsx
@@ -27,7 +27,7 @@ import { defaultProduct } from './constants';
 import * as styled from './styled';
 
 /** The page used to view and edit tags in the administrative section. */
-export const ProductForm: React.FC = () => {
+const ProductForm: React.FC = () => {
   const [, api] = useProducts();
   const { state } = useLocation();
   const { id } = useParams();
@@ -163,3 +163,5 @@ export const ProductForm: React.FC = () => {
     </styled.ProductForm>
   );
 };
+
+export default ProductForm;

--- a/app/editor/src/features/admin/products/ProductList.tsx
+++ b/app/editor/src/features/admin/products/ProductList.tsx
@@ -7,7 +7,7 @@ import { columns } from './constants';
 import { ProductFilter } from './ProductFilter';
 import * as styled from './styled';
 
-export const ProductList: React.FC = () => {
+const ProductList: React.FC = () => {
   const navigate = useNavigate();
   const [{ products }, api] = useProducts();
 
@@ -64,3 +64,5 @@ export const ProductList: React.FC = () => {
     </styled.ProductList>
   );
 };
+
+export default ProductList;

--- a/app/editor/src/features/admin/report-templates/ReportTemplateForm.tsx
+++ b/app/editor/src/features/admin/report-templates/ReportTemplateForm.tsx
@@ -27,7 +27,7 @@ import * as styled from './styled';
  * The page used to view and edit a report template.
  * @returns Component.
  */
-export const ReportTemplateForm: React.FC = () => {
+const ReportTemplateForm: React.FC = () => {
   const navigate = useNavigate();
   const { id } = useParams();
   const [, { addReportTemplate, deleteReportTemplate, getReportTemplate, updateReportTemplate }] =
@@ -160,3 +160,5 @@ export const ReportTemplateForm: React.FC = () => {
     </styled.ReportTemplateForm>
   );
 };
+
+export default ReportTemplateForm;

--- a/app/editor/src/features/admin/reports/ReportAdmin.tsx
+++ b/app/editor/src/features/admin/reports/ReportAdmin.tsx
@@ -14,7 +14,7 @@ export interface IReportAdminProps {
  * Provides a page to admin a list of reports and report templates.
  * @returns Component to admin reports and report templates.
  */
-export const ReportAdmin: React.FC<IReportAdminProps> = ({ path: defaultPath = 'reports' }) => {
+const ReportAdmin: React.FC<IReportAdminProps> = ({ path: defaultPath = 'reports' }) => {
   const navigate = useNavigate();
   const { path = defaultPath } = useParams();
 
@@ -60,3 +60,5 @@ export const ReportAdmin: React.FC<IReportAdminProps> = ({ path: defaultPath = '
     </styled.ReportAdmin>
   );
 };
+
+export default ReportAdmin;

--- a/app/editor/src/features/admin/reports/ReportForm.tsx
+++ b/app/editor/src/features/admin/reports/ReportForm.tsx
@@ -33,7 +33,7 @@ import * as styled from './styled';
  * The page used to view and edit reports.
  * @returns Component.
  */
-export const ReportForm: React.FC = () => {
+const ReportForm: React.FC = () => {
   const navigate = useNavigate();
   const [{ userInfo }] = useApp();
   const { id } = useParams();
@@ -232,3 +232,5 @@ export const ReportForm: React.FC = () => {
     </styled.ReportForm>
   );
 };
+
+export default ReportForm;

--- a/app/editor/src/features/admin/series/SeriesForm.tsx
+++ b/app/editor/src/features/admin/series/SeriesForm.tsx
@@ -33,7 +33,7 @@ import * as styled from './styled';
 import { toForm, toModel } from './utils';
 
 /** The page used to view and edit series the administrative section. */
-export const SeriesForm: React.FC = () => {
+const SeriesForm: React.FC = () => {
   const { id } = useParams();
   const [, api] = useSeries();
   const { state } = useLocation();
@@ -191,3 +191,5 @@ export const SeriesForm: React.FC = () => {
     </styled.SeriesForm>
   );
 };
+
+export default SeriesForm;

--- a/app/editor/src/features/admin/series/SeriesList.tsx
+++ b/app/editor/src/features/admin/series/SeriesList.tsx
@@ -7,7 +7,7 @@ import { columns } from './constants';
 import { SeriesFilter } from './SeriesFilter';
 import * as styled from './styled';
 
-export const SeriesList: React.FC = () => {
+const SeriesList: React.FC = () => {
   const navigate = useNavigate();
   const [{ series }, api] = useSeries();
 
@@ -67,3 +67,5 @@ export const SeriesList: React.FC = () => {
     </styled.SeriesList>
   );
 };
+
+export default SeriesList;

--- a/app/editor/src/features/admin/settings/SettingForm.tsx
+++ b/app/editor/src/features/admin/settings/SettingForm.tsx
@@ -30,7 +30,7 @@ import * as styled from './styled';
  * The page used to view and edit settings.
  * @returns Component.
  */
-export const SettingForm: React.FC = () => {
+const SettingForm: React.FC = () => {
   const { id } = useParams();
   const navigate = useNavigate();
   const [, api] = useSettings();
@@ -167,3 +167,5 @@ export const SettingForm: React.FC = () => {
     </styled.SettingForm>
   );
 };
+
+export default SettingForm;

--- a/app/editor/src/features/admin/settings/SettingList.tsx
+++ b/app/editor/src/features/admin/settings/SettingList.tsx
@@ -7,7 +7,7 @@ import { columns } from './constants';
 import { SettingFilter } from './SettingFilter';
 import * as styled from './styled';
 
-export const SettingList: React.FC = () => {
+const SettingList: React.FC = () => {
   const navigate = useNavigate();
   const [{ settings }, api] = useSettings();
 
@@ -65,3 +65,5 @@ export const SettingList: React.FC = () => {
     </styled.SettingList>
   );
 };
+
+export default SettingList;

--- a/app/editor/src/features/admin/sources/ReachEarnedMedia.tsx
+++ b/app/editor/src/features/admin/sources/ReachEarnedMedia.tsx
@@ -7,7 +7,7 @@ import * as styled from './styled';
 
 interface IReachEarnedMediaProps {}
 
-export const ReachEarnedMedia: React.FC<IReachEarnedMediaProps> = () => {
+const ReachEarnedMedia: React.FC<IReachEarnedMediaProps> = () => {
   const { values } = useFormikContext<ISourceModel>();
 
   return (
@@ -17,3 +17,5 @@ export const ReachEarnedMedia: React.FC<IReachEarnedMediaProps> = () => {
     </styled.ReachEarnedMedia>
   );
 };
+
+export default ReachEarnedMedia;

--- a/app/editor/src/features/admin/sources/SourceDetails.tsx
+++ b/app/editor/src/features/admin/sources/SourceDetails.tsx
@@ -21,7 +21,7 @@ import * as styled from './styled';
 
 interface ISourceDetailsProps {}
 
-export const SourceDetails: React.FC<ISourceDetailsProps> = () => {
+const SourceDetails: React.FC<ISourceDetailsProps> = () => {
   const { values, setFieldValue } = useFormikContext<ISourceModel>();
   const timeZone = TimeZones.find((t) => t.value === values.configuration.timeZone);
   const [lookups] = useLookup();
@@ -104,3 +104,5 @@ export const SourceDetails: React.FC<ISourceDetailsProps> = () => {
     </styled.SourceDetails>
   );
 };
+
+export default SourceDetails;

--- a/app/editor/src/features/admin/sources/SourceForm.tsx
+++ b/app/editor/src/features/admin/sources/SourceForm.tsx
@@ -24,7 +24,7 @@ import * as styled from './styled';
 
 interface ISourceProps {}
 
-export const SourceForm: React.FC<ISourceProps> = (props) => {
+const SourceForm: React.FC<ISourceProps> = (props) => {
   const [, api] = useSources();
   const { state } = useLocation();
   const { id } = useParams();
@@ -134,3 +134,5 @@ export const SourceForm: React.FC<ISourceProps> = (props) => {
     </styled.SourceForm>
   );
 };
+
+export default SourceForm;

--- a/app/editor/src/features/admin/sources/SourceList.tsx
+++ b/app/editor/src/features/admin/sources/SourceList.tsx
@@ -39,7 +39,7 @@ const sortArray = <T,>(items: T[], predicate: keyof T | (keyof T)[] | ((item: T)
   });
 };
 
-export const SourceList: React.FC<ISourceListProps> = (props) => {
+const SourceList: React.FC<ISourceListProps> = (props) => {
   const navigate = useNavigate();
   const [{ sources }, api] = useSources();
 
@@ -97,3 +97,5 @@ export const SourceList: React.FC<ISourceListProps> = (props) => {
     </styled.SourceList>
   );
 };
+
+export default SourceList;

--- a/app/editor/src/features/admin/system-message/SystemMessageForm.tsx
+++ b/app/editor/src/features/admin/system-message/SystemMessageForm.tsx
@@ -28,7 +28,7 @@ import { defaultSystemMessage } from './constants';
 import * as styled from './styled';
 
 /** The page used to view and edit tags in the administrative section. */
-export const SystemMessageForm: React.FC = () => {
+const SystemMessageForm: React.FC = () => {
   const [, api] = useSystemMessages();
   const navigate = useNavigate();
   const [systemMessage, setSystemMessage] =
@@ -163,3 +163,5 @@ export const SystemMessageForm: React.FC = () => {
     </styled.SystemMessageForm>
   );
 };
+
+export default SystemMessageForm;

--- a/app/editor/src/features/admin/tags/TagList.tsx
+++ b/app/editor/src/features/admin/tags/TagList.tsx
@@ -7,7 +7,7 @@ import { columns } from './constants';
 import * as styled from './styled';
 import { TagFilter } from './TagFilter';
 
-export const TagList: React.FC = () => {
+const TagList: React.FC = () => {
   const navigate = useNavigate();
   const [{ tags }, api] = useTags();
 
@@ -63,3 +63,5 @@ export const TagList: React.FC = () => {
     </styled.TagList>
   );
 };
+
+export default TagList;

--- a/app/editor/src/features/admin/tags/TagsForm.tsx
+++ b/app/editor/src/features/admin/tags/TagsForm.tsx
@@ -27,7 +27,7 @@ import { defaultTag } from './constants';
 import * as styled from './styled';
 
 /** The page used to view and edit tags in the administrative section. */
-export const TagsForm: React.FC = () => {
+const TagsForm: React.FC = () => {
   const [, api] = useTags();
   const { state } = useLocation();
   const { id } = useParams();
@@ -162,3 +162,5 @@ export const TagsForm: React.FC = () => {
     </styled.TagsForm>
   );
 };
+
+export default TagsForm;

--- a/app/editor/src/features/admin/topic-score-rules/TopicScoreRuleList.tsx
+++ b/app/editor/src/features/admin/topic-score-rules/TopicScoreRuleList.tsx
@@ -31,7 +31,7 @@ import { TopicScoreRulesSchema } from './validation';
  * Provides CRUD methods for rules.
  * @returns Component
  */
-export const TopicScoreRuleList: React.FC = () => {
+const TopicScoreRuleList: React.FC = () => {
   const [{ rules }, api] = useTopicScoreRules();
   const [{ series }] = useLookup();
   const [{ sourceOptions, seriesOptions }] = useLookupOptions();
@@ -343,3 +343,5 @@ export const TopicScoreRuleList: React.FC = () => {
     </styled.TopicScoreRuleList>
   );
 };
+
+export default TopicScoreRuleList;

--- a/app/editor/src/features/admin/topics/TopicList.tsx
+++ b/app/editor/src/features/admin/topics/TopicList.tsx
@@ -28,7 +28,7 @@ import { useColumns } from './useColumns';
  * Provides CRUD form for topics.
  * @returns Component
  */
-export const TopicList: React.FC = () => {
+const TopicList: React.FC = () => {
   const navigate = useNavigate();
   const { id } = useParams();
   const [, api] = useTopics();
@@ -204,3 +204,5 @@ export const TopicList: React.FC = () => {
     </styled.TopicList>
   );
 };
+
+export default TopicList;

--- a/app/editor/src/features/admin/users/UserForm.tsx
+++ b/app/editor/src/features/admin/users/UserForm.tsx
@@ -33,7 +33,7 @@ import * as styled from './styled';
  * Provides a User Form to manage, create, update and delete a user.
  * @returns React component containing administrative user form.
  */
-export const UserForm: React.FC = () => {
+const UserForm: React.FC = () => {
   const [, api] = useUsers();
   const { id } = useParams();
   const navigate = useNavigate();
@@ -214,3 +214,5 @@ export const UserForm: React.FC = () => {
     </styled.UserForm>
   );
 };
+
+export default UserForm;

--- a/app/editor/src/features/admin/users/UserList.tsx
+++ b/app/editor/src/features/admin/users/UserList.tsx
@@ -18,7 +18,7 @@ import { IUserListFilter } from './interfaces/IUserListFilter';
 import * as styled from './styled';
 import { UserFilter } from './UserFilter';
 
-export const UserList: React.FC = () => {
+const UserList: React.FC = () => {
   const navigate = useNavigate();
   const [{ users, userFilter }, { findUsers, storeFilter }] = useUsers();
 
@@ -99,3 +99,5 @@ export const UserList: React.FC = () => {
     </styled.UserList>
   );
 };
+
+export default UserList;

--- a/app/editor/src/features/admin/work-orders/WorkOrderForm.tsx
+++ b/app/editor/src/features/admin/work-orders/WorkOrderForm.tsx
@@ -34,7 +34,7 @@ import * as styled from './styled';
  * Provides a WorkOrder Form to manage, create, update and delete a workOrder.
  * @returns React component containing administrative workOrder form.
  */
-export const WorkOrderForm: React.FC = () => {
+const WorkOrderForm: React.FC = () => {
   const [, api] = useWorkOrders();
   const { id } = useParams();
   const navigate = useNavigate();
@@ -197,3 +197,5 @@ export const WorkOrderForm: React.FC = () => {
     </styled.WorkOrderForm>
   );
 };
+
+export default WorkOrderForm;

--- a/app/editor/src/features/admin/work-orders/WorkOrderList.tsx
+++ b/app/editor/src/features/admin/work-orders/WorkOrderList.tsx
@@ -14,7 +14,7 @@ import { WorkOrderListFilter } from './WorkOrderListFilter';
  * Provides a component for listing and filtering work orders.
  * @returns Component for listing and filtering work orders.
  */
-export const WorkOrderList = () => {
+const WorkOrderList = () => {
   const navigate = useNavigate();
   const [{ workOrders, workOrderFilter }, { findWorkOrders, storeFilter }] = useWorkOrders();
 
@@ -100,3 +100,5 @@ export const WorkOrderList = () => {
     </styled.WorkOrderList>
   );
 };
+
+export default WorkOrderList;

--- a/app/editor/src/features/clips/RequestClip.tsx
+++ b/app/editor/src/features/clips/RequestClip.tsx
@@ -29,7 +29,7 @@ export interface IRequestClipProps extends React.HTMLAttributes<HTMLDivElement> 
  * Provides a form to request generating a clip from a capture source.
  * @returns Component with form to request generating a clip.
  */
-export const RequestClip: React.FC<IRequestClipProps> = () => {
+const RequestClip: React.FC<IRequestClipProps> = () => {
   const [{ userInfo }] = useApp();
   const apiIngest = useApiEditorIngests();
   const apiIngestSchedule = useApiEditorIngestSchedules();
@@ -146,3 +146,5 @@ export const RequestClip: React.FC<IRequestClipProps> = () => {
     </styled.RequestClip>
   );
 };
+
+export default RequestClip;

--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -71,7 +71,7 @@ export interface IContentFormProps {
  * @param param0 Component properties.
  * @returns Edit/Create Form for Content
  */
-export const ContentForm: React.FC<IContentFormProps> = ({
+const ContentForm: React.FC<IContentFormProps> = ({
   contentType: initContentType = ContentTypeName.AudioVideo,
   combinedPath,
 }) => {
@@ -872,3 +872,5 @@ export const ContentForm: React.FC<IContentFormProps> = ({
     </styled.ContentForm>
   );
 };
+
+export default ContentForm;

--- a/app/editor/src/features/content/list-view/ContentListView.test.tsx
+++ b/app/editor/src/features/content/list-view/ContentListView.test.tsx
@@ -2,7 +2,7 @@ import { render, waitFor } from '@testing-library/react';
 import { mockContent, TestWrapper } from 'test/utils';
 import { ContentStatusName, ContentTypeName } from 'tno-core';
 
-import { ContentListView } from './ContentListView';
+import ContentListView from './ContentListView';
 
 jest.mock('store', () => ({
   useAppDispatch: jest.fn(),

--- a/app/editor/src/features/content/list-view/ContentListView.tsx
+++ b/app/editor/src/features/content/list-view/ContentListView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { lazy } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { HubMethodName, useApiHub, useApp, useChannel, useContent } from 'store/hooks';
 import { useContentStore } from 'store/slices';
@@ -20,19 +20,19 @@ import {
 } from 'tno-core';
 
 import { useTab } from '..';
-import { ContentForm } from '../form';
 import { ContentToolBar } from './components';
 import { defaultPage, getColumns } from './constants';
 import { IContentListAdvancedFilter, IContentListFilter } from './interfaces';
 import * as styled from './styled';
 import { makeFilter, queryToFilter, queryToFilterAdvanced } from './utils';
+const ContentForm = lazy(() => import('../form/ContentForm'));
 
 /**
  * ContentListView provides a way to list, search and select content for viewing and editing.
  * Also provides a combined view which splits the page into two columns.
  * @returns Component
  */
-export const ContentListView: React.FC = () => {
+const ContentListView: React.FC = () => {
   const [{ userInfo }] = useApp();
   const { id } = useParams();
   const [, { addContent, updateContent }] = useContentStore();
@@ -243,3 +243,5 @@ export const ContentListView: React.FC = () => {
     </styled.ContentListView>
   );
 };
+
+export default ContentListView;

--- a/app/editor/src/features/content/papers/Papers.tsx
+++ b/app/editor/src/features/content/papers/Papers.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { lazy } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { HubMethodName, useApiHub, useChannel, useContent } from 'store/hooks';
@@ -21,7 +21,6 @@ import {
 } from 'tno-core';
 
 import { useTab } from '..';
-import { ContentForm } from '../form';
 import { defaultPage } from '../list-view/constants';
 import { IContentListAdvancedFilter } from '../list-view/interfaces';
 import { ReportActions } from './components';
@@ -30,6 +29,7 @@ import { IPaperFilter } from './interfaces';
 import { PaperFilter } from './PaperFilter';
 import * as styled from './styled';
 import { makeFilter } from './utils';
+const ContentForm = lazy(() => import('../form/ContentForm'));
 
 export interface IPapersProps extends React.HTMLAttributes<HTMLDivElement> {}
 
@@ -38,7 +38,7 @@ export interface IPapersProps extends React.HTMLAttributes<HTMLDivElement> {}
  * @param props Component props.
  * @returns Component.
  */
-export const Papers: React.FC<IPapersProps> = (props) => {
+const Papers: React.FC<IPapersProps> = (props) => {
   const { id } = useParams();
   const navigate = useNavigate();
   const { combined, formType } = useCombinedView();
@@ -223,3 +223,5 @@ export const Papers: React.FC<IPapersProps> = (props) => {
     </styled.Papers>
   );
 };
+
+export default Papers;

--- a/app/editor/src/features/demo/DemoPage.tsx
+++ b/app/editor/src/features/demo/DemoPage.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 import { DemoCharts } from './DemoCharts';
 
-export const DemoPage: React.FC = () => {
+const DemoPage: React.FC = () => {
   return (
     <div>
       <DemoCharts />
     </div>
   );
 };
+
+export default DemoPage;

--- a/app/editor/src/features/login/Login.tsx
+++ b/app/editor/src/features/login/Login.tsx
@@ -6,7 +6,7 @@ import { useKeycloakWrapper } from 'tno-core';
  * If the user is already authenticated it will redirect to the home route.
  * @returns Login component.
  */
-export const Login = () => {
+const Login = () => {
   const keycloak = useKeycloakWrapper();
 
   if (keycloak.authenticated) {
@@ -14,3 +14,5 @@ export const Login = () => {
   }
   return <div>Anonymous user</div>;
 };
+
+export default Login;

--- a/app/editor/src/features/reports/ReportInstancePreview.tsx
+++ b/app/editor/src/features/reports/ReportInstancePreview.tsx
@@ -5,7 +5,7 @@ import { Col, IReportResultModel, Loading, Show } from 'tno-core';
 
 import * as styled from './styled';
 
-export const ReportInstancePreview: React.FC = () => {
+const ReportInstancePreview: React.FC = () => {
   const [{ previewReportInstance }] = useReportInstances();
   const { id } = useParams();
   const reportId = parseInt(id ?? '');
@@ -51,3 +51,5 @@ export const ReportInstancePreview: React.FC = () => {
     </styled.ReportPreview>
   );
 };
+
+export default ReportInstancePreview;

--- a/app/editor/src/features/reports/ReportPreview.tsx
+++ b/app/editor/src/features/reports/ReportPreview.tsx
@@ -5,7 +5,7 @@ import { Col, IReportResultModel, Loading, Show } from 'tno-core';
 
 import * as styled from './styled';
 
-export const ReportPreview: React.FC = () => {
+const ReportPreview: React.FC = () => {
   const [{ previewReport }] = useReports();
   const { id } = useParams();
   const reportId = parseInt(id ?? '');
@@ -51,3 +51,5 @@ export const ReportPreview: React.FC = () => {
     </styled.ReportPreview>
   );
 };
+
+export default ReportPreview;

--- a/app/editor/src/features/reports/ReportsRouter.tsx
+++ b/app/editor/src/features/reports/ReportsRouter.tsx
@@ -3,7 +3,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 
 import { CBRAReport } from '.';
 
-export const ReportsRouter: React.FC = () => {
+const ReportsRouter: React.FC = () => {
   return (
     <Routes>
       <Route index element={<Navigate to="cbra" />} />
@@ -11,3 +11,5 @@ export const ReportsRouter: React.FC = () => {
     </Routes>
   );
 };
+
+export default ReportsRouter;

--- a/app/editor/src/features/reports/av-overview/AVOverview.tsx
+++ b/app/editor/src/features/reports/av-overview/AVOverview.tsx
@@ -28,7 +28,7 @@ import * as styled from './styled';
 import { getIsEditable } from './utils';
 
 /** Evening overview section, contains table of items, and list of overview sections */
-export const AVOverview: React.FC = () => {
+const AVOverview: React.FC = () => {
   const [api] = useAVOverviewInstances();
   const navigate = useNavigate();
   const [params] = useSearchParams();
@@ -193,3 +193,5 @@ export const AVOverview: React.FC = () => {
     </styled.AVOverview>
   );
 };
+
+export default AVOverview;

--- a/app/editor/src/features/reports/av-overview/AVOverviewPreview.tsx
+++ b/app/editor/src/features/reports/av-overview/AVOverviewPreview.tsx
@@ -17,7 +17,7 @@ import {
 
 import * as styled from './styled';
 
-export const AVOverviewPreview: React.FC = () => {
+const AVOverviewPreview: React.FC = () => {
   const [{ getAVOverview, previewAVOverview, publishAVOverview }] = useAVOverviewInstances();
   const { toggle, isShowing } = useModal();
   const { id } = useParams();
@@ -103,3 +103,5 @@ export const AVOverviewPreview: React.FC = () => {
     </styled.AVOverviewPreview>
   );
 };
+
+export default AVOverviewPreview;

--- a/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
+++ b/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
@@ -57,9 +57,9 @@ export const OverviewGrid: React.FC<IOverviewGridProps> = ({ editable = true, in
     }).then((data) =>
       setClips(data.items.map((c) => new OptionItem(c.headline, c.id)) as IOptionItem[]),
     );
-    // only want to fire this based on section and index
+    // only want to fire once
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [index, values.sections]);
+  }, []);
 
   /** function that runs after a user drops an item in the list */
   const handleDrop = (droppedItem: any) => {

--- a/app/editor/src/features/router/AppRouter.tsx
+++ b/app/editor/src/features/router/AppRouter.tsx
@@ -1,24 +1,26 @@
-import { DefaultLayout } from 'components/layout';
-import { AccessRequest } from 'features/access-request';
-import { AdminRouter, WorkOrderForm, WorkOrderList } from 'features/admin';
-import { RequestClip } from 'features/clips';
-import { ContentForm, ContentListView, Papers } from 'features/content';
-import { DemoPage } from 'features/demo';
-import { Login } from 'features/login';
-import {
-  AVOverview,
-  AVOverviewPreview,
-  ReportInstancePreview,
-  ReportPreview,
-  ReportsRouter,
-} from 'features/reports';
-import { StorageListView } from 'features/storage';
-import React from 'react';
+import { AdminRouter } from 'features/admin';
+import React, { lazy, Suspense } from 'react';
 import { Navigate, Route, Routes, useNavigate } from 'react-router-dom';
 import { useApp } from 'store/hooks';
 import { Claim, ContentTypeName, InternalServerError, NotFound } from 'tno-core';
 
-import { PrivateRoute } from '.';
+const DefaultLayout = lazy(() => import('components/layout/DefaultLayout'));
+const AccessRequest = lazy(() => import('features/access-request/AccessRequest'));
+const WorkOrderForm = lazy(() => import('features/admin/work-orders/WorkOrderForm'));
+const WorkOrderList = lazy(() => import('features/admin/work-orders/WorkOrderList'));
+const RequestClip = lazy(() => import('features/clips/RequestClip'));
+const ContentForm = lazy(() => import('features/content/form/ContentForm'));
+const ContentListView = lazy(() => import('features/content/list-view/ContentListView'));
+const Papers = lazy(() => import('features/content/papers/Papers'));
+const DemoPage = lazy(() => import('features/demo/DemoPage'));
+const Login = lazy(() => import('features/login/Login'));
+const AVOverview = lazy(() => import('features/reports/av-overview/AVOverview'));
+const AVOverviewPreview = lazy(() => import('features/reports/av-overview/AVOverviewPreview'));
+const ReportInstancePreview = lazy(() => import('features/reports/ReportInstancePreview'));
+const ReportPreview = lazy(() => import('features/reports/ReportPreview'));
+const ReportsRouter = lazy(() => import('features/reports/ReportsRouter'));
+const StorageListView = lazy(() => import('features/storage/StorageListView'));
+const PrivateRoute = lazy(() => import('features/router/PrivateRoute'));
 
 export interface IAppRouter {
   name: string;
@@ -41,119 +43,126 @@ export const AppRouter: React.FC<IAppRouter> = ({ name }) => {
   }, [authenticated, navigate]);
 
   return (
-    <Routes>
-      <Route path="/" element={<DefaultLayout name={name} />}>
-        <Route path="/" element={<Navigate to="/contents" />} />
-        <Route path="login" element={<Login />} />
-        <Route path="welcome" element={<AccessRequest />} />
-        <Route path="access/request" element={<AccessRequest />} />
-        <Route
-          path="admin/*"
-          element={<PrivateRoute claims={Claim.administrator} element={<AdminRouter />} />}
-        />
-        <Route
-          path="contents"
-          element={
-            <PrivateRoute claims={Claim.editor} element={<ContentListView />}></PrivateRoute>
-          }
-        />
-        <Route
-          path="contents/:id"
-          element={<PrivateRoute claims={Claim.editor} element={<ContentForm />}></PrivateRoute>}
-        />
-        <Route
-          path="/contents/combined/:id"
-          element={
-            <PrivateRoute claims={Claim.editor} element={<ContentListView />}></PrivateRoute>
-          }
-        />
-        <Route
-          path="snippets/:id"
-          element={
-            <PrivateRoute
-              claims={Claim.editor}
-              element={<ContentForm contentType={ContentTypeName.AudioVideo} />}
-            ></PrivateRoute>
-          }
-        />
-        <Route
-          path="papers/:id"
-          element={
-            <PrivateRoute
-              claims={Claim.editor}
-              element={<ContentForm contentType={ContentTypeName.PrintContent} />}
-            ></PrivateRoute>
-          }
-        />
-        <Route
-          path="images/:id"
-          element={
-            <PrivateRoute
-              claims={Claim.editor}
-              element={<ContentForm contentType={ContentTypeName.Image} />}
-            ></PrivateRoute>
-          }
-        />
-        <Route
-          path="stories/:id"
-          element={
-            <PrivateRoute
-              claims={Claim.editor}
-              element={<ContentForm contentType={ContentTypeName.Story} />}
-            ></PrivateRoute>
-          }
-        />
-        <Route
-          path="papers"
-          element={<PrivateRoute claims={Claim.editor} element={<Papers />}></PrivateRoute>}
-        />
-        <Route
-          path="/papers/combined/:id"
-          element={<PrivateRoute claims={Claim.editor} element={<Papers />}></PrivateRoute>}
-        />
-        <Route
-          path="storage/locations/:id"
-          element={
-            <PrivateRoute claims={Claim.editor} element={<StorageListView />}></PrivateRoute>
-          }
-        />
-        <Route path="clips" element={<RequestClip />} />
-        <Route path="work/orders" element={<WorkOrderList />} />
-        <Route path="work/orders/:id" element={<WorkOrderForm />} />
+    <Suspense fallback={<div>Loading...</div>}>
+      <Routes>
+        <Route path="/" element={<DefaultLayout name={name} />}>
+          <Route path="/" element={<Navigate to="/contents" />} />
+          <Route path="login" element={<Login />} />
+          <Route path="welcome" element={<AccessRequest />} />
+          <Route path="access/request" element={<AccessRequest />} />
+          <Route
+            path="admin/*"
+            element={<PrivateRoute claims={Claim.administrator} element={<AdminRouter />} />}
+          />
+          <Route
+            path="contents"
+            element={
+              <PrivateRoute claims={Claim.editor} element={<ContentListView />}></PrivateRoute>
+            }
+          />
+          <Route
+            path="contents/:id"
+            element={<PrivateRoute claims={Claim.editor} element={<ContentForm />}></PrivateRoute>}
+          />
+          <Route
+            path="/contents/combined/:id"
+            element={
+              <PrivateRoute claims={Claim.editor} element={<ContentListView />}></PrivateRoute>
+            }
+          />
+          <Route
+            path="snippets/:id"
+            element={
+              <PrivateRoute
+                claims={Claim.editor}
+                element={<ContentForm contentType={ContentTypeName.AudioVideo} />}
+              ></PrivateRoute>
+            }
+          />
+          <Route
+            path="papers/:id"
+            element={
+              <PrivateRoute
+                claims={Claim.editor}
+                element={<ContentForm contentType={ContentTypeName.PrintContent} />}
+              ></PrivateRoute>
+            }
+          />
+          <Route
+            path="images/:id"
+            element={
+              <PrivateRoute
+                claims={Claim.editor}
+                element={<ContentForm contentType={ContentTypeName.Image} />}
+              ></PrivateRoute>
+            }
+          />
+          <Route
+            path="stories/:id"
+            element={
+              <PrivateRoute
+                claims={Claim.editor}
+                element={<ContentForm contentType={ContentTypeName.Story} />}
+              ></PrivateRoute>
+            }
+          />
+          <Route
+            path="papers"
+            element={<PrivateRoute claims={Claim.editor} element={<Papers />}></PrivateRoute>}
+          />
+          <Route
+            path="/papers/combined/:id"
+            element={<PrivateRoute claims={Claim.editor} element={<Papers />}></PrivateRoute>}
+          />
+          <Route
+            path="storage/locations/:id"
+            element={
+              <PrivateRoute claims={Claim.editor} element={<StorageListView />}></PrivateRoute>
+            }
+          />
+          <Route path="clips" element={<RequestClip />} />
+          <Route path="work/orders" element={<WorkOrderList />} />
+          <Route path="work/orders/:id" element={<WorkOrderForm />} />
 
-        <Route
-          path="report/instances/:id/preview"
-          element={
-            <PrivateRoute claims={Claim.editor} element={<ReportInstancePreview />}></PrivateRoute>
-          }
-        />
+          <Route
+            path="report/instances/:id/preview"
+            element={
+              <PrivateRoute
+                claims={Claim.editor}
+                element={<ReportInstancePreview />}
+              ></PrivateRoute>
+            }
+          />
 
-        <Route
-          path="reports/av/evening-overview"
-          element={<PrivateRoute claims={Claim.editor} element={<AVOverview />}></PrivateRoute>}
-        />
-        <Route
-          path="reports/av/evening-overview/:id"
-          element={
-            <PrivateRoute claims={Claim.editor} element={<AVOverviewPreview />}></PrivateRoute>
-          }
-        />
-        <Route
-          path="reports/:id/preview"
-          element={<PrivateRoute claims={Claim.editor} element={<ReportPreview />}></PrivateRoute>}
-        />
-        <Route
-          path="reports/*"
-          element={<PrivateRoute claims={Claim.administrator} element={<ReportsRouter />} />}
-        />
-        <Route
-          path="reports/*"
-          element={<PrivateRoute claims={Claim.administrator} element={<ReportsRouter />} />}
-        />
-        <Route path="demo" element={<DemoPage />} />
-        <Route path="error" element={<InternalServerError />} />
-        <Route path="*" element={<NotFound />} />
-      </Route>
-    </Routes>
+          <Route
+            path="reports/av/evening-overview"
+            element={<PrivateRoute claims={Claim.editor} element={<AVOverview />}></PrivateRoute>}
+          />
+          <Route
+            path="reports/av/evening-overview/:id"
+            element={
+              <PrivateRoute claims={Claim.editor} element={<AVOverviewPreview />}></PrivateRoute>
+            }
+          />
+          <Route
+            path="reports/:id/preview"
+            element={
+              <PrivateRoute claims={Claim.editor} element={<ReportPreview />}></PrivateRoute>
+            }
+          />
+          <Route
+            path="reports/*"
+            element={<PrivateRoute claims={Claim.administrator} element={<ReportsRouter />} />}
+          />
+          <Route
+            path="reports/*"
+            element={<PrivateRoute claims={Claim.administrator} element={<ReportsRouter />} />}
+          />
+          <Route path="demo" element={<DemoPage />} />
+          <Route path="error" element={<InternalServerError />} />
+          <Route path="*" element={<NotFound />} />
+        </Route>
+      </Routes>
+    </Suspense>
   );
 };

--- a/app/editor/src/features/router/PrivateRoute.tsx
+++ b/app/editor/src/features/router/PrivateRoute.tsx
@@ -34,7 +34,7 @@ interface IPrivateRouteProps {
  * @param param0 Route element attributes.
  * @returns PrivateRoute component.
  */
-export const PrivateRoute = ({
+const PrivateRoute = ({
   redirectTo = '/login',
   claims,
   roles,
@@ -61,3 +61,5 @@ export const PrivateRoute = ({
   }
   return element ? element : <>{children}</>;
 };
+
+export default PrivateRoute;

--- a/app/editor/src/features/storage/StorageListView.tsx
+++ b/app/editor/src/features/storage/StorageListView.tsx
@@ -4,7 +4,7 @@ import { useQuery } from 'tno-core';
 
 import { FileManager } from '.';
 
-export const StorageListView: React.FC = (props) => {
+const StorageListView: React.FC = (props) => {
   const { id } = useParams();
   const query = useQuery();
 
@@ -19,3 +19,5 @@ export const StorageListView: React.FC = (props) => {
     />
   );
 };
+
+export default StorageListView;


### PR DESCRIPTION
@Fosol - you can let me know what you think.

This is based off of https://web.dev/code-splitting-suspense/

Locally this appears to only take off milliseconds according to my lighthouse report but maybe it will have more of an affect in DEV/TEST. The annoying things was that React's `lazy` only supports default exports so I had to go through and change them. The other drawback is the imports are kind of ugly on the routers but maybe that is not an issue at the moment

This also reduces the amount of unused JS appearing in these reports, but not by as much as I would like.