### PR TITLE
Remove tooltip from list view

### DIFF
--- a/app/editor/src/features/content/list-view/constants/columns.tsx
+++ b/app/editor/src/features/content/list-view/constants/columns.tsx
@@ -20,7 +20,7 @@ export const getColumns = (
     name: 'headline',
     label: 'Headline',
     cell: (cell) => (
-      <CellEllipsis data-tooltip-id="main-tooltip" data-tooltip-content={cell.original.headline}>
+      <CellEllipsis>
         <Show visible={cell.row.original.hasTranscript}>
           <FaFeather />
         </Show>
@@ -32,20 +32,12 @@ export const getColumns = (
   {
     name: 'otherSource',
     label: 'Source',
-    cell: (cell) => (
-      <CellEllipsis data-tooltip-id="main-tooltip" data-tooltip-content={cell.original.otherSource}>
-        {cell.original.otherSource}
-      </CellEllipsis>
-    ),
+    cell: (cell) => <CellEllipsis>{cell.original.otherSource}</CellEllipsis>,
   },
   {
     name: 'product',
     label: 'Product',
-    cell: (cell) => (
-      <CellEllipsis data-tooltip-id="main-tooltip" data-tooltip-content={cell.original.product}>
-        {cell.original.product}
-      </CellEllipsis>
-    ),
+    cell: (cell) => <CellEllipsis>{cell.original.product}</CellEllipsis>,
     width: 1,
   },
   {
@@ -55,22 +47,14 @@ export const getColumns = (
       const value = `${cell.original.section ? `${cell.original.section}:` : ''}${
         cell.original.page
       }`;
-      return (
-        <CellEllipsis data-tooltip-id="main-tooltip" data-tooltip-content={value}>
-          {value}
-        </CellEllipsis>
-      );
+      return <CellEllipsis>{value}</CellEllipsis>;
     },
     width: 2,
   },
   {
     name: 'owner',
     label: 'User',
-    cell: (cell) => (
-      <CellEllipsis data-tooltip-id="main-tooltip" data-tooltip-content={cell.original.owner}>
-        {formatIdirUsername(cell.original.owner)}
-      </CellEllipsis>
-    ),
+    cell: (cell) => <CellEllipsis>{formatIdirUsername(cell.original.owner)}</CellEllipsis>,
     width: 1,
   },
   {

--- a/app/editor/src/features/content/papers/constants/columns.tsx
+++ b/app/editor/src/features/content/papers/constants/columns.tsx
@@ -19,11 +19,7 @@ export const getColumns = (
   {
     name: 'headline',
     label: 'Headline',
-    cell: (cell) => (
-      <CellEllipsis data-tooltip-id="main-tooltip" data-tooltip-content={cell.original.headline}>
-        {cell.original.headline}
-      </CellEllipsis>
-    ),
+    cell: (cell) => <CellEllipsis>{cell.original.headline}</CellEllipsis>,
     width: 6,
   },
   {
@@ -34,11 +30,7 @@ export const getColumns = (
   {
     name: 'product',
     label: 'Product',
-    cell: (cell) => (
-      <CellEllipsis data-tooltip-id="main-tooltip" data-tooltip-content={cell.original.product}>
-        {cell.original.product}
-      </CellEllipsis>
-    ),
+    cell: (cell) => <CellEllipsis>{cell.original.product}</CellEllipsis>,
     width: 2,
   },
   {
@@ -46,11 +38,7 @@ export const getColumns = (
     label: 'Page:Section',
     cell: (cell) => {
       const value = `${cell.original.page ? `${cell.original.page}:` : ''}${cell.original.section}`;
-      return (
-        <CellEllipsis data-tooltip-id="main-tooltip" data-tooltip-content={value}>
-          {value}
-        </CellEllipsis>
-      );
+      return <CellEllipsis>{value}</CellEllipsis>;
     },
     width: 2,
   },


### PR DESCRIPTION
Performance is current abysmal with react-tooltip, looking at reimplementing and making sure we are up to par with their most recent documentation. In the meantime since it is taking a little bit, I have removed the tooltips from the list view (maybe can reintroduce later if need be and performance is fixed). 

This bit of work will be two parts.

