### PR TITLE
TNO-1744, 1745, 1746: Add content to folder from Today's Commentary, Top Stories, and My Ministers 

### DIFF
--- a/app/subscriber/src/components/folder-sub-menu/FolderSubMenu.tsx
+++ b/app/subscriber/src/components/folder-sub-menu/FolderSubMenu.tsx
@@ -1,0 +1,38 @@
+import { FolderMenu } from 'features/content/view-content/FolderMenu';
+import { Tooltip } from 'react-tooltip';
+import { IContentModel, IFolderContentModel } from 'tno-core';
+
+export interface IFolderSubMenuProps {
+  /**
+   * The content that has been selected to add to a folder
+   */
+  selectedContent: IContentModel[];
+}
+
+/** Component that will take selected content, convert it to folder content and render the folder menu. */
+export const FolderSubMenu: React.FC<IFolderSubMenuProps> = ({ selectedContent }) => {
+  /** transform the content to folder content before sending it to the API */
+  const toFolderContent = (content: IContentModel[]) => {
+    return content.map((item) => {
+      return {
+        ...item,
+        sortOrder: 0,
+        contentId: item.id,
+      } as IFolderContentModel;
+    });
+  };
+
+  return (
+    <Tooltip
+      clickable
+      variant="light"
+      className="folder-menu"
+      place="bottom"
+      openOnClick
+      style={{ opacity: '1', boxShadow: '0 0 8px #464545', zIndex: '999' }}
+      id="folder"
+    >
+      <FolderMenu content={toFolderContent(selectedContent)} />
+    </Tooltip>
+  );
+};

--- a/app/subscriber/src/components/folder-sub-menu/FolderSubMenu.tsx
+++ b/app/subscriber/src/components/folder-sub-menu/FolderSubMenu.tsx
@@ -12,7 +12,9 @@ export interface IFolderSubMenuProps {
   selectedContent: IContentModel[];
 }
 
-/** Component that will take selected content, convert it to folder content and render the folder menu. */
+/** Component that renders the button that gives users access to a sub menu that will allow them to add selected content to
+ * an existing folder. Or create a new one.
+ */
 export const FolderSubMenu: React.FC<IFolderSubMenuProps> = ({ selectedContent }) => {
   /** transform the content to folder content before sending it to the API */
   const toFolderContent = (content: IContentModel[]) => {

--- a/app/subscriber/src/components/folder-sub-menu/FolderSubMenu.tsx
+++ b/app/subscriber/src/components/folder-sub-menu/FolderSubMenu.tsx
@@ -1,6 +1,9 @@
 import { FolderMenu } from 'features/content/view-content/FolderMenu';
+import { FaFolderPlus } from 'react-icons/fa';
 import { Tooltip } from 'react-tooltip';
-import { IContentModel, IFolderContentModel } from 'tno-core';
+import { IContentModel, IFolderContentModel, Row } from 'tno-core';
+
+import * as styled from './styled';
 
 export interface IFolderSubMenuProps {
   /**
@@ -23,16 +26,21 @@ export const FolderSubMenu: React.FC<IFolderSubMenuProps> = ({ selectedContent }
   };
 
   return (
-    <Tooltip
-      clickable
-      variant="light"
-      className="folder-menu"
-      place="bottom"
-      openOnClick
-      style={{ opacity: '1', boxShadow: '0 0 8px #464545', zIndex: '999' }}
-      id="folder"
-    >
-      <FolderMenu content={toFolderContent(selectedContent)} />
-    </Tooltip>
+    <styled.FolderSubMenu>
+      <Row justifyContent="end">
+        <FaFolderPlus className="add-folder" data-tooltip-id="folder" />
+      </Row>
+      <Tooltip
+        clickable
+        variant="light"
+        className="folder-menu"
+        place="bottom"
+        openOnClick
+        style={{ opacity: '1', boxShadow: '0 0 8px #464545', zIndex: '999' }}
+        id="folder"
+      >
+        <FolderMenu content={toFolderContent(selectedContent)} />
+      </Tooltip>
+    </styled.FolderSubMenu>
   );
 };

--- a/app/subscriber/src/components/folder-sub-menu/index.ts
+++ b/app/subscriber/src/components/folder-sub-menu/index.ts
@@ -1,0 +1,1 @@
+export * from './FolderSubMenu';

--- a/app/subscriber/src/components/folder-sub-menu/styled/FolderSubMenu.tsx
+++ b/app/subscriber/src/components/folder-sub-menu/styled/FolderSubMenu.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const FolderSubMenu = styled.div`
+  /* add to folder button */
+  .add-folder {
+    height: 2em;
+    width: 2em;
+    &:hover {
+      cursor: pointer;
+      transform: scale(1.1);
+      color: ${(props) => props.theme.css.sideBarIconHoverColor};
+    }
+    color: ${(props) => props.theme.css.sideBarIconColor};
+  }
+`;

--- a/app/subscriber/src/components/folder-sub-menu/styled/index.ts
+++ b/app/subscriber/src/components/folder-sub-menu/styled/index.ts
@@ -1,0 +1,1 @@
+export * from './FolderSubMenu';

--- a/app/subscriber/src/features/content/view-content/ViewContentToolbar.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContentToolbar.tsx
@@ -1,3 +1,4 @@
+import { FolderSubMenu } from 'components/folder-sub-menu';
 import { Tags } from 'components/form/tags';
 import React from 'react';
 import {
@@ -12,7 +13,6 @@ import { Tooltip } from 'react-tooltip';
 import { IContentModel, ITagModel, Row } from 'tno-core';
 
 import { ActionNames } from './constants';
-import { FolderMenu } from './FolderMenu';
 import * as styled from './styled';
 
 export interface IViewContentToolbarProps {
@@ -71,16 +71,7 @@ export const ViewContentToolbar: React.FC<IViewContentToolbarProps> = ({ tags, c
             >
               {ActionNames.AddToFolder}
             </Tooltip>
-            <Tooltip
-              clickable
-              variant="light"
-              className="folder-menu"
-              place="bottom"
-              openOnClick
-              id="folder"
-            >
-              <FolderMenu content={[{ ...content, sortOrder: 0, contentId: content.id }]} />
-            </Tooltip>
+            <FolderSubMenu selectedContent={[content]} />
             <FaFileAlt
               data-tooltip-id="main-tooltip"
               data-tooltip-content={ActionNames.AddToReport}

--- a/app/subscriber/src/features/content/view-content/ViewContentToolbar.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContentToolbar.tsx
@@ -1,4 +1,3 @@
-import { FolderSubMenu } from 'components/folder-sub-menu';
 import { Tags } from 'components/form/tags';
 import React from 'react';
 import {
@@ -13,6 +12,7 @@ import { Tooltip } from 'react-tooltip';
 import { IContentModel, ITagModel, Row } from 'tno-core';
 
 import { ActionNames } from './constants';
+import { FolderMenu } from './FolderMenu';
 import * as styled from './styled';
 
 export interface IViewContentToolbarProps {
@@ -71,7 +71,17 @@ export const ViewContentToolbar: React.FC<IViewContentToolbarProps> = ({ tags, c
             >
               {ActionNames.AddToFolder}
             </Tooltip>
-            <FolderSubMenu selectedContent={[content]} />
+            <Tooltip
+              clickable
+              variant="light"
+              className="folder-menu"
+              place="bottom"
+              openOnClick
+              style={{ opacity: '1', boxShadow: '0 0 8px #464545', zIndex: '999' }}
+              id="folder"
+            >
+              <FolderMenu content={[{ ...content, sortOrder: 0, contentId: content.id }]} />
+            </Tooltip>
             <FaFileAlt
               data-tooltip-id="main-tooltip"
               data-tooltip-content={ActionNames.AddToReport}

--- a/app/subscriber/src/features/home/Home.tsx
+++ b/app/subscriber/src/features/home/Home.tsx
@@ -5,7 +5,6 @@ import {
   IContentListFilter,
 } from 'features/content/list-view/interfaces';
 import React from 'react';
-import { FaFolderPlus } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
 import { useContent } from 'store/hooks';
 import {
@@ -81,11 +80,8 @@ export const Home: React.FC = () => {
         <div className="show-media-label">SHOW MEDIA TYPE:</div>
         <HomeFilters />
       </Row>
-      <Row justifyContent="end">
-        <FaFolderPlus className="add-folder" data-tooltip-id="folder" />
-      </Row>
-      <DateFilter />
       <FolderSubMenu selectedContent={selected} />
+      <DateFilter />
       <Row className="table-container">
         <FlexboxTable
           rowId="id"

--- a/app/subscriber/src/features/home/Home.tsx
+++ b/app/subscriber/src/features/home/Home.tsx
@@ -1,20 +1,18 @@
 import { DateFilter } from 'components/date-filter';
+import { FolderSubMenu } from 'components/folder-sub-menu';
 import {
   IContentListAdvancedFilter,
   IContentListFilter,
 } from 'features/content/list-view/interfaces';
-import { FolderMenu } from 'features/content/view-content/FolderMenu';
 import React from 'react';
 import { FaFolderPlus } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
-import { Tooltip } from 'react-tooltip';
 import { useContent } from 'store/hooks';
 import {
   ContentStatus,
   ContentTypeName,
   FlexboxTable,
   IContentModel,
-  IFolderContentModel,
   ITableInternalRow,
   Page,
   Row,
@@ -72,17 +70,6 @@ export const Home: React.FC = () => {
     }
   };
 
-  /** transform the content to folder content before sending it to the API */
-  const toFolderContent = (content: IContentModel[]) => {
-    return content.map((item) => {
-      return {
-        ...item,
-        sortOrder: 0,
-        contentId: item.id,
-      } as IFolderContentModel;
-    });
-  };
-
   /** retrigger content fetch when change is applied */
   React.useEffect(() => {
     fetch({ ...filter, ...filterAdvanced });
@@ -98,17 +85,7 @@ export const Home: React.FC = () => {
         <FaFolderPlus className="add-folder" data-tooltip-id="folder" />
       </Row>
       <DateFilter />
-      <Tooltip
-        clickable
-        variant="light"
-        className="folder-menu"
-        place="bottom"
-        openOnClick
-        style={{ opacity: '1', boxShadow: '0 0 8px #464545' }}
-        id="folder"
-      >
-        <FolderMenu content={toFolderContent(selected)} />
-      </Tooltip>
+      <FolderSubMenu selectedContent={selected} />
       <Row className="table-container">
         <FlexboxTable
           rowId="id"

--- a/app/subscriber/src/features/home/styled/Home.tsx
+++ b/app/subscriber/src/features/home/styled/Home.tsx
@@ -53,16 +53,4 @@ export const Home = styled.div`
     }
     margin-bottom: 1em;
   }
-
-  /* add to folder button */
-  .add-folder {
-    height: 2em;
-    width: 2em;
-    &:hover {
-      cursor: pointer;
-      transform: scale(1.1);
-      color: ${(props) => props.theme.css.sideBarIconHoverColor};
-    }
-    color: ${(props) => props.theme.css.sideBarIconColor};
-  }
 `;

--- a/app/subscriber/src/features/my-minister/MyMinister.tsx
+++ b/app/subscriber/src/features/my-minister/MyMinister.tsx
@@ -1,3 +1,4 @@
+import { FolderSubMenu } from 'components/folder-sub-menu';
 import {
   IContentListAdvancedFilter,
   IContentListFilter,
@@ -9,18 +10,20 @@ import { useNavigate } from 'react-router-dom';
 import { useApp, useContent } from 'store/hooks';
 import { IMinisterModel } from 'store/hooks/subscriber/interfaces/IMinisterModel';
 import { useMinisters } from 'store/hooks/subscriber/useMinisters';
-import { FlexboxTable, IContentModel, Page, Row } from 'tno-core';
+import { FlexboxTable, IContentModel, ITableInternalRow, Page, Row } from 'tno-core';
 
 import * as styled from './styled';
 
 export const MyMinister: React.FC = () => {
   const [{ filter, filterAdvanced }, { findContent }] = useContent();
-  const [homeItems, setHomeItems] = React.useState<IContentModel[]>([]);
-  const [ministerNames, setMinisterNames] = React.useState<string[]>([]);
   const [{ userInfo }] = useApp();
   const [, api] = useMinisters();
-  const [ministers, setMinisters] = React.useState<IMinisterModel[]>([]);
   const navigate = useNavigate();
+  const [selected, setSelected] = React.useState<IContentModel[]>([]);
+  const [homeItems, setHomeItems] = React.useState<IContentModel[]>([]);
+  const [ministerNames, setMinisterNames] = React.useState<string[]>([]);
+  const [ministers, setMinisters] = React.useState<IMinisterModel[]>([]);
+  const [, setLoading] = React.useState(false);
 
   React.useEffect(() => {
     if (!ministers.length) {
@@ -30,7 +33,14 @@ export const MyMinister: React.FC = () => {
     }
   }, [api, ministers.length]);
 
-  const [, setLoading] = React.useState(false);
+  /** controls the checking and unchecking of rows in the list view */
+  const handleSelectedRowsChanged = (row: ITableInternalRow<IContentModel>) => {
+    if (row.isSelected) {
+      setSelected(row.table.rows.filter((r) => r.isSelected).map((r) => r.original));
+    } else {
+      setSelected((selected) => selected.filter((r) => r.id !== row.original.id));
+    }
+  };
 
   const fetch = React.useCallback(
     async (filter: IContentListFilter & Partial<IContentListAdvancedFilter>) => {
@@ -81,10 +91,12 @@ export const MyMinister: React.FC = () => {
   }, [ministerNames]);
   return (
     <styled.MyMinister>
+      <FolderSubMenu selectedContent={selected} />
       <Row className="table-container">
         <FlexboxTable
           rowId="id"
           columns={determineColumns('all')}
+          onSelectedChanged={handleSelectedRowsChanged}
           isMulti
           groupBy={(item) => item.original.source?.name ?? ''}
           onRowClick={(e: any) => {

--- a/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
+++ b/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
@@ -1,10 +1,11 @@
 import { DateFilter } from 'components/date-filter';
+import { FolderSubMenu } from 'components/folder-sub-menu';
 import { determineColumns } from 'features/home/constants';
 import moment from 'moment';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useContent } from 'store/hooks';
-import { ActionName, FlexboxTable, IContentModel, Row } from 'tno-core';
+import { ActionName, FlexboxTable, IContentModel, ITableInternalRow, Row } from 'tno-core';
 
 import * as styled from './styled';
 
@@ -13,6 +14,7 @@ export const TodaysCommentary: React.FC = () => {
   const [{ filterAdvanced }, { findContent }] = useContent();
   const navigate = useNavigate();
   const [commentary, setCommentary] = React.useState<IContentModel[]>([]);
+  const [selected, setSelected] = React.useState<IContentModel[]>([]);
 
   React.useEffect(() => {
     findContent({
@@ -24,14 +26,25 @@ export const TodaysCommentary: React.FC = () => {
     }).then((data) => setCommentary(data.items));
   }, [findContent, filterAdvanced]);
 
+  /** controls the checking and unchecking of rows in the list view */
+  const handleSelectedRowsChanged = (row: ITableInternalRow<IContentModel>) => {
+    if (row.isSelected) {
+      setSelected(row.table.rows.filter((r) => r.isSelected).map((r) => r.original));
+    } else {
+      setSelected((selected) => selected.filter((r) => r.id !== row.original.id));
+    }
+  };
+
   return (
     <styled.TodaysCommentary>
+      <FolderSubMenu selectedContent={selected} />
       <DateFilter />
       <Row className="table-container">
         <FlexboxTable
           rowId="id"
           columns={determineColumns('all')}
           isMulti
+          onSelectedChanged={handleSelectedRowsChanged}
           groupBy={(item) => item.original.source?.name ?? ''}
           onRowClick={(e: any) => {
             navigate(`/view/${e.original.id}`);

--- a/app/subscriber/src/features/top-stories/TopStories.tsx
+++ b/app/subscriber/src/features/top-stories/TopStories.tsx
@@ -3,7 +3,6 @@ import { FolderSubMenu } from 'components/folder-sub-menu';
 import { determineColumns } from 'features/home/constants';
 import moment from 'moment';
 import React from 'react';
-import { FaFolderPlus } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
 import { useContent } from 'store/hooks';
 import { ActionName, FlexboxTable, IContentModel, ITableInternalRow, Row } from 'tno-core';
@@ -38,11 +37,8 @@ export const TopStories: React.FC = () => {
 
   return (
     <styled.TopStories>
-      <Row justifyContent="end">
-        <FaFolderPlus className="add-folder" data-tooltip-id="folder" />
-      </Row>
-      <DateFilter />
       <FolderSubMenu selectedContent={selected} />
+      <DateFilter />
       <Row className="table-container">
         <FlexboxTable
           rowId="id"

--- a/app/subscriber/src/features/top-stories/TopStories.tsx
+++ b/app/subscriber/src/features/top-stories/TopStories.tsx
@@ -1,10 +1,12 @@
 import { DateFilter } from 'components/date-filter';
+import { FolderSubMenu } from 'components/folder-sub-menu';
 import { determineColumns } from 'features/home/constants';
 import moment from 'moment';
 import React from 'react';
+import { FaFolderPlus } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
 import { useContent } from 'store/hooks';
-import { ActionName, FlexboxTable, IContentModel, Row } from 'tno-core';
+import { ActionName, FlexboxTable, IContentModel, ITableInternalRow, Row } from 'tno-core';
 
 import * as styled from './styled';
 
@@ -13,6 +15,7 @@ export const TopStories: React.FC = () => {
   const [{ filterAdvanced }, { findContent }] = useContent();
   const navigate = useNavigate();
   const [topStories, setTopStories] = React.useState<IContentModel[]>([]);
+  const [selected, setSelected] = React.useState<IContentModel[]>([]);
 
   React.useEffect(() => {
     findContent({
@@ -24,9 +27,22 @@ export const TopStories: React.FC = () => {
     }).then((data) => setTopStories(data.items));
   }, [findContent, filterAdvanced]);
 
+  /** controls the checking and unchecking of rows in the list view */
+  const handleSelectedRowsChanged = (row: ITableInternalRow<IContentModel>) => {
+    if (row.isSelected) {
+      setSelected(row.table.rows.filter((r) => r.isSelected).map((r) => r.original));
+    } else {
+      setSelected((selected) => selected.filter((r) => r.id !== row.original.id));
+    }
+  };
+
   return (
     <styled.TopStories>
+      <Row justifyContent="end">
+        <FaFolderPlus className="add-folder" data-tooltip-id="folder" />
+      </Row>
       <DateFilter />
+      <FolderSubMenu selectedContent={selected} />
       <Row className="table-container">
         <FlexboxTable
           rowId="id"
@@ -38,6 +54,7 @@ export const TopStories: React.FC = () => {
           }}
           data={topStories}
           pageButtons={5}
+          onSelectedChanged={handleSelectedRowsChanged}
           showPaging={false}
         />
       </Row>

--- a/app/subscriber/src/features/top-stories/styled/TopStories.tsx
+++ b/app/subscriber/src/features/top-stories/styled/TopStories.tsx
@@ -1,5 +1,17 @@
 import styled from 'styled-components';
 export const TopStories = styled.div`
+  /* add to folder button */
+  .add-folder {
+    height: 2em;
+    width: 2em;
+    &:hover {
+      cursor: pointer;
+      transform: scale(1.1);
+      color: ${(props) => props.theme.css.sideBarIconHoverColor};
+    }
+    color: ${(props) => props.theme.css.sideBarIconColor};
+  }
+
   .table {
     width: 100%;
     .group {

--- a/app/subscriber/src/features/top-stories/styled/TopStories.tsx
+++ b/app/subscriber/src/features/top-stories/styled/TopStories.tsx
@@ -1,17 +1,5 @@
 import styled from 'styled-components';
 export const TopStories = styled.div`
-  /* add to folder button */
-  .add-folder {
-    height: 2em;
-    width: 2em;
-    &:hover {
-      cursor: pointer;
-      transform: scale(1.1);
-      color: ${(props) => props.theme.css.sideBarIconHoverColor};
-    }
-    color: ${(props) => props.theme.css.sideBarIconColor};
-  }
-
   .table {
     width: 100%;
     .group {


### PR DESCRIPTION
In this PR:
- made a reusable component as the button that renders the folder submenu and functionality is used in a couple of places
- simplified code
- added functionality to add selected content to folder to todays commentary, top stories, and my ministers
- behave the same as #1069 

![image](https://github.com/bcgov/tno/assets/15724124/7265ccfa-6845-46d3-bcf9-9fbb7c078f00)

![image](https://github.com/bcgov/tno/assets/15724124/f7e0107a-bd1d-4b08-aab9-a1b920b16927)

![image](https://github.com/bcgov/tno/assets/15724124/080f3984-b491-4377-8548-11a88ac683fe)

