### PR TITLE
Toast error when no content selected

### DIFF
--- a/app/subscriber/src/features/content/view-content/FolderMenu.tsx
+++ b/app/subscriber/src/features/content/view-content/FolderMenu.tsx
@@ -45,7 +45,8 @@ export const FolderMenu: React.FC<IFolderMenuProps> = ({ content }) => {
   };
 
   const handleUpdate = (folder: IFolderModel) => {
-    if (!!content) {
+    if (!content?.length) toast.error('No content selected');
+    if (!!content?.length) {
       updateFolder({
         ...folder,
         content: [...folder.content, ...content],


### PR DESCRIPTION
Realized I had not disabled the button when no content is selected; however, this is a unique case as it is using a tooltip (for the popout menu) that is given a `clickable` prop handled through the library. Essentially saying show on click instead of hover. 

Trying to come up with a clean way of disabling. But adding this in the meantime to advise users no content is selected