### PR TITLE
TNO-1724 Update My Reports

### DIFF
--- a/app/editor/src/features/admin/reports/ReportFormDetails.tsx
+++ b/app/editor/src/features/admin/reports/ReportFormDetails.tsx
@@ -63,6 +63,7 @@ export const ReportFormDetails: React.FC = () => {
             if (values.templateId === 0)
               setFieldValue('template.name', `${name}-${Date.now().toString()}`);
           }}
+          placeholder="Enter unique report name"
         />
         <FormikTextArea name="description" label="Description" />
         <FormikSelect

--- a/app/subscriber/src/features/my-reports/admin/ReportAdminSettings.tsx
+++ b/app/subscriber/src/features/my-reports/admin/ReportAdminSettings.tsx
@@ -44,7 +44,12 @@ export const ReportAdminSettings: React.FC = () => {
   return (
     <Col gap="1rem">
       <Box title="Identify your report" icon={<FaFileInvoice />}>
-        <FormikText name="name" label="Report Name:" required />
+        <FormikText
+          name="name"
+          label="Report Name:"
+          required
+          placeholder="Enter unique report name"
+        />
         <FormikTextArea name="description" label="Description:" />
       </Box>
       <Box title="Content Settings" icon={<FaFileInvoice />}>

--- a/app/subscriber/src/features/my-reports/hooks/useColumns.tsx
+++ b/app/subscriber/src/features/my-reports/hooks/useColumns.tsx
@@ -1,8 +1,8 @@
-import { FaEdit, FaTrash } from 'react-icons/fa';
-import { FaGear } from 'react-icons/fa6';
+import { FaEdit, FaFileAlt, FaTrash } from 'react-icons/fa';
+import { FaChartPie, FaGear } from 'react-icons/fa6';
 import { Link } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
-import { CellEllipsis, Checkbox, IReportModel, ITableHookColumn, Row } from 'tno-core';
+import { CellEllipsis, Checkbox, IReportModel, ITableHookColumn, Row, Show } from 'tno-core';
 
 import { isAutoSend, isAutoSendDisabled, setAutoSend } from '../utils';
 
@@ -30,11 +30,19 @@ export const useColumns = (
       name: 'name',
       width: 2,
       cell: (cell) => (
-        <CellEllipsis>
-          <Link to={`/reports/${cell.original.id}/edit`} title="Edit">
-            {cell.original.name}
-          </Link>
-        </CellEllipsis>
+        <Row gap="0.5rem" alignItems="center">
+          <Show visible={cell.original.sections.some((section) => section.settings.showCharts)}>
+            <FaChartPie className="primary-light-color" />
+          </Show>
+          <Show visible={!cell.original.sections.some((section) => section.settings.showCharts)}>
+            <FaFileAlt className="primary-light-color" />
+          </Show>
+          <CellEllipsis>
+            <Link to={`/reports/${cell.original.id}/edit`} title="Edit">
+              {cell.original.name}
+            </Link>
+          </CellEllipsis>
+        </Row>
       ),
     },
     {

--- a/app/subscriber/src/features/my-reports/styled/MyReports.tsx
+++ b/app/subscriber/src/features/my-reports/styled/MyReports.tsx
@@ -93,4 +93,8 @@ export const MyReports = styled(Col)`
       color: ${(props) => props.theme.css.sidebarIconHoverColor};
     }
   }
+
+  .primary-light-color {
+    color: ${(props) => props.theme.css.primaryLightColor};
+  }
 `;


### PR DESCRIPTION
Using an icon to indicate if the report contains media analytics (charts).  It's a basic check if the report has a section where the settings has `showCharts=true`.  This can be a false positive, but for now I think it'll be okay.

![image](https://github.com/bcgov/tno/assets/3180256/69506370-b23e-435a-b872-09bb26ada51d)
