### PR TITLE
TNO-1788 Change Publish Flow

### DIFF
--- a/app/editor/src/features/content/form/ContentStoryForm.tsx
+++ b/app/editor/src/features/content/form/ContentStoryForm.tsx
@@ -35,6 +35,7 @@ import { isSummaryRequired } from './utils';
 export interface IContentStoryFormProps {
   contentType: ContentTypeName;
   summaryRequired?: boolean;
+  setCreateAfterPublish?: (state: boolean) => void;
 }
 
 /**
@@ -45,6 +46,7 @@ export interface IContentStoryFormProps {
 export const ContentStoryForm: React.FC<IContentStoryFormProps> = ({
   contentType,
   summaryRequired: initSummaryRequired,
+  setCreateAfterPublish,
 }) => {
   const [{ series, sources }] = useLookup();
   const { values, setFieldValue } = useFormikContext<IContentForm>();
@@ -214,6 +216,7 @@ export const ContentStoryForm: React.FC<IContentStoryFormProps> = ({
           contentType={contentType}
           setShowExpandModal={setShowExpandModal}
           isSummaryRequired={summaryRequired}
+          setCreateAfterPublish={setCreateAfterPublish}
         />
       </Show>
       <Show

--- a/app/editor/src/features/content/form/MediaSummary.tsx
+++ b/app/editor/src/features/content/form/MediaSummary.tsx
@@ -16,6 +16,7 @@ export interface IMediaSummaryProps {
   contentType?: ContentTypeName;
   setShowExpandModal?: (show: boolean) => void;
   isSummaryRequired: boolean;
+  setCreateAfterPublish?: (state: boolean) => void;
 }
 
 /**
@@ -30,6 +31,7 @@ export const MediaSummary: React.FC<IMediaSummaryProps> = ({
   contentType,
   setShowExpandModal,
   isSummaryRequired,
+  setCreateAfterPublish,
 }) => {
   const { setFieldValue, values } = useFormikContext<IContentForm>();
   const [, { download }] = useContent();
@@ -56,6 +58,8 @@ export const MediaSummary: React.FC<IMediaSummaryProps> = ({
           setFieldValue('file', file);
           // Remove file reference.
           setFieldValue('fileReferences', []);
+          // Don't navigate to a new form after publishing files.
+          setCreateAfterPublish?.(false);
         }}
         onDownload={() => {
           download(values.id, file?.name ?? `${values.otherSource}-${values.id}`);

--- a/app/editor/src/features/content/form/styled/ContentForm.tsx
+++ b/app/editor/src/features/content/form/styled/ContentForm.tsx
@@ -4,6 +4,22 @@ export const ContentForm = styled.div`
   height: 100%;
   width: 100%;
 
+  .form-page {
+    height: calc(100% - 1rem);
+
+    > div {
+      height: 100%;
+
+      .form {
+        height: 100%;
+
+        > form {
+          height: 100%;
+        }
+      }
+    }
+  }
+
   .minimize-details {
     margin: 1em 0 0 0;
     padding: 0;

--- a/libs/npm/core/src/components/form/area/Area.tsx
+++ b/libs/npm/core/src/components/form/area/Area.tsx
@@ -1,6 +1,6 @@
 import * as styled from './styled';
 
-export interface IAreaProps {
+export interface IAreaProps extends React.HTMLAttributes<HTMLDivElement> {
   children?: React.ReactNode;
 }
 
@@ -8,6 +8,6 @@ export interface IAreaProps {
  * Custom div component used to contain the form for the Content View.
  * @returns Container area for the content form.
  */
-export const Area: React.FC<any> = ({ children }) => {
-  return <styled.Area>{children}</styled.Area>;
+export const Area: React.FC<any> = ({ children, ...rest }) => {
+  return <styled.Area {...rest}>{children}</styled.Area>;
 };


### PR DESCRIPTION
When creating new content with a new file the form will now default to staying on the same form after publishing.  There is a checkbox that can be used to override this behavior "Create new after publish".

## Summary

- Click 'Enter' in the prep time input to auto add to total minutes
- If content has a new file it will default the "Create new after publish" checkbox to `false`, otherwise it will default to `true`.

## Content Form

![image](https://github.com/bcgov/tno/assets/3180256/44461374-dbc6-48ff-b2e3-025f65754e4d)
