### PR TITLE
TNO-1785 Fix m4a transcription

### DIFF
--- a/services/net/transcription/appsettings.json
+++ b/services/net/transcription/appsettings.json
@@ -19,7 +19,7 @@
     "VolumePath": "/data",
     "AzureRegion": "canadacentral",
     "AzureCognitiveServicesKey": "",
-    "ConvertToAudio": ["mp4", "mov"]
+    "ConvertToAudio": ["mp4", "mov", "m4a"]
   },
   "Auth": {
     "Keycloak": {


### PR DESCRIPTION
Added `m4a` format to auto convert to `mp3` before sending to Azure Cognitive Services.