### PR TITLE
TNO-1823 Enhance Ingest services

### DIFF
--- a/api/net/TNO.API.csproj
+++ b/api/net/TNO.API.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\libs\net\css\TNO.CSS.csproj" />
     <ProjectReference Include="..\..\libs\net\core\TNO.Core.csproj" />
+    <ProjectReference Include="..\..\libs\net\css\TNO.CSS.csproj" />
     <ProjectReference Include="..\..\libs\net\dal\TNO.DAL.csproj" />
     <ProjectReference Include="..\..\libs\net\kafka\TNO.Kafka.csproj" />
     <ProjectReference Include="..\..\libs\net\keycloak\TNO.Keycloak.csproj" />

--- a/libs/net/ches/ChesService.cs
+++ b/libs/net/ches/ChesService.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
@@ -9,6 +7,8 @@ using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using TNO.Ches.Configuration;
 using TNO.Ches.Models;
 using TNO.Core.Exceptions;
@@ -103,7 +103,7 @@ namespace TNO.Ches
             }
             catch (HttpClientRequestException ex)
             {
-                _logger.LogError(ex, $"Failed to send/receive request: {ex.StatusCode} {url}");
+                _logger.LogError(ex, "Failed to send/receive request: {status} {url}", ex.StatusCode, url);
                 var response = await this.Client?.DeserializeAsync<Ches.Models.ErrorResponseModel>(ex.Response);
                 throw new ChesException(ex, this.Client, response);
             }
@@ -131,7 +131,7 @@ namespace TNO.Ches
             }
             catch (HttpClientRequestException ex)
             {
-                _logger.LogError(ex, $"Failed to send/receive request: {ex.StatusCode} {url}");
+                _logger.LogError(ex, "Failed to send/receive request: {status} {url}", ex.StatusCode, url);
                 var response = await this.Client?.DeserializeAsync<Ches.Models.ErrorResponseModel>(ex.Response);
                 throw new ChesException(ex, this.Client, response);
             }
@@ -163,7 +163,7 @@ namespace TNO.Ches
             }
             catch (HttpClientRequestException ex)
             {
-                _logger.LogError(ex, $"Failed to send/receive request: {ex.StatusCode} {url}");
+                _logger.LogError(ex, "Failed to send/receive request: {code} {url}", ex.StatusCode, url);
                 var response = await this.Client?.DeserializeAsync<Ches.Models.ErrorResponseModel>(ex.Response);
                 throw new ChesException(ex, this.Client, response);
             }
@@ -194,7 +194,7 @@ namespace TNO.Ches
             }
             catch (HttpClientRequestException ex)
             {
-                _logger.LogError(ex, $"Failed to send/receive request: {ex.StatusCode} {this.Options.AuthUrl}");
+                _logger.LogError(ex, "Failed to send/receive request: {code} {url}", ex.StatusCode, this.Options.AuthUrl);
                 var response = await this.Client?.DeserializeAsync<Ches.Models.ErrorResponseModel>(ex.Response);
                 throw new ChesException(ex, this.Client, response);
             }

--- a/libs/net/ches/Models/EmailModel.cs
+++ b/libs/net/ches/Models/EmailModel.cs
@@ -76,5 +76,39 @@ namespace TNO.Ches.Models
         /// </summary>
         public IEnumerable<IAttachment> Attachments { get; set; } = new List<AttachmentModel>();
         #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Creates a new instance of an EmailModel object.
+        /// </summary>
+        public EmailModel() { }
+
+        /// <summary>
+        /// Creates a new instance of an EmailModel object, initializes with specified parameters.
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <param name="subject"></param>
+        /// <param name="body"></param>
+        public EmailModel(string from, string to, string subject, string body)
+            : this(from, new[] { to }, subject, body)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of an EmailModel object, initializes with specified parameters.
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <param name="subject"></param>
+        /// <param name="body"></param>
+        public EmailModel(string from, string[] to, string subject, string body)
+        {
+            this.From = from;
+            this.To = to;
+            this.Subject = subject;
+            this.Body = body;
+        }
+        #endregion
     }
 }

--- a/libs/net/models/Areas/Subscriber/Models/Content/ContributorModel.cs
+++ b/libs/net/models/Areas/Subscriber/Models/Content/ContributorModel.cs
@@ -7,11 +7,7 @@ namespace TNO.API.Areas.Subscriber.Models.Content;
 /// </summary>
 public class ContributorModel : BaseTypeModel<int>
 {
-   #region Properties
-    /// <summary>
-    /// get/set - The primary key of the contributor.
-    /// </summary>
-    public int Id { get; set; }
+    #region Properties
 
     /// <summary>
     /// get/set - Foreign key to source.
@@ -22,26 +18,6 @@ public class ContributorModel : BaseTypeModel<int>
     /// get/set - The source.
     /// </summary>
     public SourceModel? Source { get; set; }
-
-    /// <summary>
-    /// get/set - The unique name of the model.
-    /// </summary>
-    public string Name { get; set; } = "";
-
-    /// <summary>
-    /// get/set - A description of the contributor.
-    /// </summary>
-    public string Description { get; set; } = "";
-
-    /// <summary>
-    /// get/set - Whether this model is enabled.
-    /// </summary>
-    public bool IsEnabled { get; set; }
-
-    /// <summary>
-    /// get/set - The sort order of the models.
-    /// </summary>
-    public int SortOrder { get; set; }
 
     /// <summary>
     /// get/set - Whether content should be automatically transcribed.
@@ -57,7 +33,7 @@ public class ContributorModel : BaseTypeModel<int>
     /// get/set - Whether the contributor is associated with the press gallery.
     /// </summary>
     public bool IsPress { get; set; }
-    
+
     #endregion
 
     #region Constructors

--- a/libs/net/services/Actions/Managers/IngestActionManager`.cs
+++ b/libs/net/services/Actions/Managers/IngestActionManager`.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.Options;
 using TNO.API.Areas.Services.Models.Ingest;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 using TNO.Core.Extensions;
 using TNO.Entities;
 using TNO.Models.Extensions;
@@ -36,10 +38,18 @@ public class IngestActionManager<TOptions> : ServiceActionManager<TOptions>, IIn
     /// </summary>
     /// <param name="ingest"></param>
     /// <param name="api"></param>
+    /// <param name="ches"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="action"></param>
     /// <param name="options"></param>
-    public IngestActionManager(IngestModel ingest, IApiService api, IIngestAction<TOptions> action, IOptions<TOptions> options)
-        : base(action, options)
+    public IngestActionManager(
+        IngestModel ingest,
+        IApiService api,
+        IChesService ches,
+        IOptions<ChesOptions> chesOptions,
+        IIngestAction<TOptions> action,
+        IOptions<TOptions> options)
+        : base(ches, chesOptions, action, options)
     {
         this.Ingest = ingest;
         this.Api = api;

--- a/libs/net/services/Config/ServiceOptions.cs
+++ b/libs/net/services/Config/ServiceOptions.cs
@@ -39,5 +39,15 @@ public class ServiceOptions
     /// get/set - The service timezone.
     /// </summary>
     public string TimeZone { get; set; } = "UTC";
+
+    /// <summary>
+    /// get/set - Whether to send emails on failure.
+    /// </summary>
+    public bool SendEmailOnFailure { get; set; } = false;
+
+    /// <summary>
+    /// get/set - Who to send email failures to.
+    /// </summary>
+    public string[] EmailTo { get; set; } = Array.Empty<string>();
     #endregion
 }

--- a/libs/net/services/Interfaces/IServiceActionManager.cs
+++ b/libs/net/services/Interfaces/IServiceActionManager.cs
@@ -47,5 +47,13 @@ public interface IServiceActionManager
     /// </summary>
     /// <returns></returns>
     public Task UpdateIngestConfigAsync(string propName, object propValue);
+
+    /// <summary>
+    /// Send email alert of failure.
+    /// </summary>
+    /// <param name="subject"></param>
+    /// <param name="ex"></param>
+    /// <returns></returns>
+    public Task SendEmailAsync(string subject, Exception ex);
     #endregion
 }

--- a/libs/net/services/Runners/BaseService.cs
+++ b/libs/net/services/Runners/BaseService.cs
@@ -1,4 +1,5 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -8,6 +9,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using TNO.Ches;
 using TNO.Core.Http;
 using TNO.Core.Http.Configuration;
 using TNO.Services.Config;
@@ -111,6 +113,8 @@ public abstract class BaseService
                 options.AddConsole();
             })
             .AddTransient<JwtSecurityTokenHandler>()
+            .AddChesService(this.Configuration.GetSection("CHES"))
+            .AddSingleton(new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Email, "") })))
             .Configure<AuthClientOptions>(this.Configuration.GetSection("Auth:Keycloak"))
             .Configure<OpenIdConnectOptions>(this.Configuration.GetSection("Auth:OIDC"))
             .AddTransient<IHttpRequestClient, HttpRequestClient>()

--- a/libs/net/services/Runners/IngestService.cs
+++ b/libs/net/services/Runners/IngestService.cs
@@ -9,12 +9,6 @@ namespace TNO.Services.Runners;
 /// </summary>
 public abstract class IngestService : BaseService
 {
-    #region Variables
-    #endregion
-
-    #region Properties
-    #endregion
-
     #region Constructors
     /// <summary>
     /// Creates a new instance of a IngestService object, initializes with arguments.
@@ -26,7 +20,6 @@ public abstract class IngestService : BaseService
     #endregion
 
     #region Methods
-
     /// <summary>
     /// Configure dependency injection.
     /// </summary>

--- a/libs/net/services/TNO.Services.csproj
+++ b/libs/net/services/TNO.Services.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ches\TNO.Ches.csproj" />
     <ProjectReference Include="..\core\TNO.Core.csproj" />
     <ProjectReference Include="..\elastic\TNO.Elastic.csproj" />
     <ProjectReference Include="..\kafka\TNO.Kafka.csproj" />

--- a/openshift/kustomize/services/capture/base/config-map.yaml
+++ b/openshift/kustomize/services/capture/base/config-map.yaml
@@ -18,3 +18,6 @@ type: Opaque
 data:
   MAX_FAIL_LIMIT: "5"
   VOLUME_PATH: /data
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
+  CHES_EMAIL_ENABLED: "true"
+  CHES_EMAIL_AUTHORIZED: "true"

--- a/openshift/kustomize/services/capture/base/deploy.yaml
+++ b/openshift/kustomize/services/capture/base/deploy.yaml
@@ -94,7 +94,13 @@ spec:
                 configMapKeyRef:
                   name: services
                   key: DATA_LOCATION
+            - name: Service__EmailTo
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: EMAIL_FAILURE_TO
 
+            # Authentication Configuration
             - name: Auth__Keycloak__Authority
               valueFrom:
                 configMapKeyRef:
@@ -122,6 +128,44 @@ spec:
                 configMapKeyRef:
                   name: capture-service
                   key: VOLUME_PATH
+
+            # CHES Configuration
+            - name: CHES__From
+              valueFrom:
+                configMapKeyRef:
+                  name: capture-service
+                  key: CHES_FROM
+            - name: CHES__EmailEnabled
+              valueFrom:
+                configMapKeyRef:
+                  name: capture-service
+                  key: CHES_EMAIL_ENABLED
+            - name: CHES__EmailAuthorized
+              valueFrom:
+                configMapKeyRef:
+                  name: capture-service
+                  key: CHES_EMAIL_AUTHORIZED
+
+            - name: CHES__AuthUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_AUTH_URL
+            - name: CHES__HostUri
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_HOST_URI
+            - name: CHES__Username
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: USERNAME
+            - name: CHES__Password
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: PASSWORD
           livenessProbe:
             httpGet:
               path: "/health"

--- a/openshift/kustomize/services/clip/base/config-map.yaml
+++ b/openshift/kustomize/services/clip/base/config-map.yaml
@@ -18,3 +18,6 @@ type: Opaque
 data:
   MAX_FAIL_LIMIT: "5"
   VOLUME_PATH: /data
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
+  CHES_EMAIL_ENABLED: "true"
+  CHES_EMAIL_AUTHORIZED: "true"

--- a/openshift/kustomize/services/clip/base/deploy.yaml
+++ b/openshift/kustomize/services/clip/base/deploy.yaml
@@ -94,7 +94,13 @@ spec:
                 configMapKeyRef:
                   name: services
                   key: DATA_LOCATION
+            - name: Service__EmailTo
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: EMAIL_FAILURE_TO
 
+            # Authentication Configuration
             - name: Auth__Keycloak__Authority
               valueFrom:
                 configMapKeyRef:
@@ -122,6 +128,44 @@ spec:
                 configMapKeyRef:
                   name: clip-service
                   key: VOLUME_PATH
+
+            # CHES Configuration
+            - name: CHES__From
+              valueFrom:
+                configMapKeyRef:
+                  name: clip-service
+                  key: CHES_FROM
+            - name: CHES__EmailEnabled
+              valueFrom:
+                configMapKeyRef:
+                  name: clip-service
+                  key: CHES_EMAIL_ENABLED
+            - name: CHES__EmailAuthorized
+              valueFrom:
+                configMapKeyRef:
+                  name: clip-service
+                  key: CHES_EMAIL_AUTHORIZED
+
+            - name: CHES__AuthUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_AUTH_URL
+            - name: CHES__HostUri
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_HOST_URI
+            - name: CHES__Username
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: USERNAME
+            - name: CHES__Password
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: PASSWORD
           livenessProbe:
             httpGet:
               path: "/health"

--- a/openshift/kustomize/services/content/base/config-map.yaml
+++ b/openshift/kustomize/services/content/base/config-map.yaml
@@ -21,3 +21,6 @@ data:
   UNPUBLISHED_INDEX: unpublished_content
   PUBLISHED_INDEX: content
   NOTIFICATION_TOPIC: ""
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
+  CHES_EMAIL_ENABLED: "true"
+  CHES_EMAIL_AUTHORIZED: "true"

--- a/openshift/kustomize/services/content/base/deploy.yaml
+++ b/openshift/kustomize/services/content/base/deploy.yaml
@@ -73,7 +73,13 @@ spec:
                 configMapKeyRef:
                   name: services
                   key: API_HOST_URL
+            - name: Service__EmailTo
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: EMAIL_FAILURE_TO
 
+            # Authentication Configuration
             - name: Auth__Keycloak__Authority
               valueFrom:
                 configMapKeyRef:
@@ -133,6 +139,44 @@ spec:
                 configMapKeyRef:
                   name: content-service
                   key: NOTIFICATION_TOPIC
+
+            # CHES Configuration
+            - name: CHES__From
+              valueFrom:
+                configMapKeyRef:
+                  name: content-service
+                  key: CHES_FROM
+            - name: CHES__EmailEnabled
+              valueFrom:
+                configMapKeyRef:
+                  name: content-service
+                  key: CHES_EMAIL_ENABLED
+            - name: CHES__EmailAuthorized
+              valueFrom:
+                configMapKeyRef:
+                  name: content-service
+                  key: CHES_EMAIL_AUTHORIZED
+
+            - name: CHES__AuthUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_AUTH_URL
+            - name: CHES__HostUri
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_HOST_URI
+            - name: CHES__Username
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: USERNAME
+            - name: CHES__Password
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: PASSWORD
           livenessProbe:
             httpGet:
               path: "/health"

--- a/openshift/kustomize/services/contentmigration-historic/base/config-map.yaml
+++ b/openshift/kustomize/services/contentmigration-historic/base/config-map.yaml
@@ -23,3 +23,6 @@ data:
   INGEST_TYPES: "TNO-AudioVideo,TNO-Image,TNO-PrintContent,TNO-Story"
   SUPPORTED_IMPORT_MIGRATION_TYPES: "Historic"
   DEFAULT_USERNAME_FOR_AUDIT: "contentmigrator"
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
+  CHES_EMAIL_ENABLED: "true"
+  CHES_EMAIL_AUTHORIZED: "true"

--- a/openshift/kustomize/services/contentmigration-historic/base/deploy.yaml
+++ b/openshift/kustomize/services/contentmigration-historic/base/deploy.yaml
@@ -78,7 +78,13 @@ spec:
                 configMapKeyRef:
                   name: services
                   key: DATA_LOCATION
+            - name: Service__EmailTo
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: EMAIL_FAILURE_TO
 
+            # Authentication Configuration
             - name: Auth__Keycloak__Authority
               valueFrom:
                 configMapKeyRef:
@@ -126,6 +132,45 @@ spec:
                 configMapKeyRef:
                   name: contentmigration-historic-service
                   key: DEFAULT_USERNAME_FOR_AUDIT
+
+            # CHES Configuration
+            - name: CHES__From
+              valueFrom:
+                configMapKeyRef:
+                  name: contentmigration-historic-service
+                  key: CHES_FROM
+            - name: CHES__EmailEnabled
+              valueFrom:
+                configMapKeyRef:
+                  name: contentmigration-historic-service
+                  key: CHES_EMAIL_ENABLED
+            - name: CHES__EmailAuthorized
+              valueFrom:
+                configMapKeyRef:
+                  name: contentmigration-historic-service
+                  key: CHES_EMAIL_AUTHORIZED
+
+            - name: CHES__AuthUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_AUTH_URL
+            - name: CHES__HostUri
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_HOST_URI
+            - name: CHES__Username
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: USERNAME
+            - name: CHES__Password
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: PASSWORD
+
             # Container TimeZone Configuration
             - name: TZ
               value: America/Vancouver

--- a/openshift/kustomize/services/contentmigration/base/config-map.yaml
+++ b/openshift/kustomize/services/contentmigration/base/config-map.yaml
@@ -23,3 +23,6 @@ data:
   INGEST_TYPES: "TNO-AudioVideo,TNO-Image,TNO-PrintContent,TNO-Story"
   SUPPORTED_IMPORT_MIGRATION_TYPES: "Recent"
   DEFAULT_USERNAME_FOR_AUDIT: "contentmigrator"
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
+  CHES_EMAIL_ENABLED: "true"
+  CHES_EMAIL_AUTHORIZED: "true"

--- a/openshift/kustomize/services/contentmigration/base/deploy.yaml
+++ b/openshift/kustomize/services/contentmigration/base/deploy.yaml
@@ -78,7 +78,13 @@ spec:
                 configMapKeyRef:
                   name: services
                   key: DATA_LOCATION
+            - name: Service__EmailTo
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: EMAIL_FAILURE_TO
 
+            # Authentication Configuration
             - name: Auth__Keycloak__Authority
               valueFrom:
                 configMapKeyRef:
@@ -126,6 +132,45 @@ spec:
                 configMapKeyRef:
                   name: contentmigration-service
                   key: DEFAULT_USERNAME_FOR_AUDIT
+
+            # CHES Configuration
+            - name: CHES__From
+              valueFrom:
+                configMapKeyRef:
+                  name: contentmigration-service
+                  key: CHES_FROM
+            - name: CHES__EmailEnabled
+              valueFrom:
+                configMapKeyRef:
+                  name: contentmigration-service
+                  key: CHES_EMAIL_ENABLED
+            - name: CHES__EmailAuthorized
+              valueFrom:
+                configMapKeyRef:
+                  name: contentmigration-service
+                  key: CHES_EMAIL_AUTHORIZED
+
+            - name: CHES__AuthUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_AUTH_URL
+            - name: CHES__HostUri
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_HOST_URI
+            - name: CHES__Username
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: USERNAME
+            - name: CHES__Password
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: PASSWORD
+
             # Container TimeZone Configuration
             - name: TZ
               value: America/Vancouver

--- a/openshift/kustomize/services/filecopy/base/config-map.yaml
+++ b/openshift/kustomize/services/filecopy/base/config-map.yaml
@@ -20,3 +20,6 @@ data:
   MAX_FAIL_LIMIT: "5"
   TOPICS: file-request
   VOLUME_PATH: /data
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
+  CHES_EMAIL_ENABLED: "true"
+  CHES_EMAIL_AUTHORIZED: "true"

--- a/openshift/kustomize/services/filecopy/base/deploy.yaml
+++ b/openshift/kustomize/services/filecopy/base/deploy.yaml
@@ -73,7 +73,13 @@ spec:
                 configMapKeyRef:
                   name: services
                   key: API_HOST_URL
+            - name: Service__EmailTo
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: EMAIL_FAILURE_TO
 
+            # Authentication Configuration
             - name: Auth__Keycloak__Authority
               valueFrom:
                 configMapKeyRef:
@@ -139,6 +145,44 @@ spec:
                 configMapKeyRef:
                   name: filecopy-service
                   key: VOLUME_PATH
+
+            # CHES Configuration
+            - name: CHES__From
+              valueFrom:
+                configMapKeyRef:
+                  name: filecopy-service
+                  key: CHES_FROM
+            - name: CHES__EmailEnabled
+              valueFrom:
+                configMapKeyRef:
+                  name: filecopy-service
+                  key: CHES_EMAIL_ENABLED
+            - name: CHES__EmailAuthorized
+              valueFrom:
+                configMapKeyRef:
+                  name: filecopy-service
+                  key: CHES_EMAIL_AUTHORIZED
+
+            - name: CHES__AuthUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_AUTH_URL
+            - name: CHES__HostUri
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_HOST_URI
+            - name: CHES__Username
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: USERNAME
+            - name: CHES__Password
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: PASSWORD
           livenessProbe:
             httpGet:
               path: "/health"

--- a/openshift/kustomize/services/filemonitor/base/config-map.yaml
+++ b/openshift/kustomize/services/filemonitor/base/config-map.yaml
@@ -20,3 +20,6 @@ data:
   VOLUME_PATH: /data
   KEY_PATH: ../keys
   TOPICS: ""
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
+  CHES_EMAIL_ENABLED: "true"
+  CHES_EMAIL_AUTHORIZED: "true"

--- a/openshift/kustomize/services/filemonitor/base/deploy.yaml
+++ b/openshift/kustomize/services/filemonitor/base/deploy.yaml
@@ -86,7 +86,13 @@ spec:
                 configMapKeyRef:
                   name: services
                   key: DATA_LOCATION
+            - name: Service__EmailTo
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: EMAIL_FAILURE_TO
 
+            # Authentication Configuration
             - name: Auth__Keycloak__Authority
               valueFrom:
                 configMapKeyRef:
@@ -128,6 +134,44 @@ spec:
                 secretKeyRef:
                   name: ssh-key
                   key: id_rsa
+
+            # CHES Configuration
+            - name: CHES__From
+              valueFrom:
+                configMapKeyRef:
+                  name: filemonitor-service
+                  key: CHES_FROM
+            - name: CHES__EmailEnabled
+              valueFrom:
+                configMapKeyRef:
+                  name: filemonitor-service
+                  key: CHES_EMAIL_ENABLED
+            - name: CHES__EmailAuthorized
+              valueFrom:
+                configMapKeyRef:
+                  name: filemonitor-service
+                  key: CHES_EMAIL_AUTHORIZED
+
+            - name: CHES__AuthUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_AUTH_URL
+            - name: CHES__HostUri
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_HOST_URI
+            - name: CHES__Username
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: USERNAME
+            - name: CHES__Password
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: PASSWORD
           livenessProbe:
             httpGet:
               path: "/health"

--- a/openshift/kustomize/services/image/base/config-map.yaml
+++ b/openshift/kustomize/services/image/base/config-map.yaml
@@ -20,3 +20,6 @@ data:
   VOLUME_PATH: /data
   KEY_PATH: ../keys
   TOPICS: ""
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
+  CHES_EMAIL_ENABLED: "true"
+  CHES_EMAIL_AUTHORIZED: "true"

--- a/openshift/kustomize/services/image/base/deploy.yaml
+++ b/openshift/kustomize/services/image/base/deploy.yaml
@@ -86,7 +86,13 @@ spec:
                 configMapKeyRef:
                   name: services
                   key: DATA_LOCATION
+            - name: Service__EmailTo
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: EMAIL_FAILURE_TO
 
+            # Authentication Configuration
             - name: Auth__Keycloak__Authority
               valueFrom:
                 configMapKeyRef:
@@ -128,6 +134,44 @@ spec:
                 secretKeyRef:
                   name: ssh-key
                   key: id_rsa
+
+            # CHES Configuration
+            - name: CHES__From
+              valueFrom:
+                configMapKeyRef:
+                  name: image-service
+                  key: CHES_FROM
+            - name: CHES__EmailEnabled
+              valueFrom:
+                configMapKeyRef:
+                  name: image-service
+                  key: CHES_EMAIL_ENABLED
+            - name: CHES__EmailAuthorized
+              valueFrom:
+                configMapKeyRef:
+                  name: image-service
+                  key: CHES_EMAIL_AUTHORIZED
+
+            - name: CHES__AuthUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_AUTH_URL
+            - name: CHES__HostUri
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_HOST_URI
+            - name: CHES__Username
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: USERNAME
+            - name: CHES__Password
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: PASSWORD
           livenessProbe:
             httpGet:
               path: "/health"

--- a/openshift/kustomize/services/indexing/base/config-map.yaml
+++ b/openshift/kustomize/services/indexing/base/config-map.yaml
@@ -23,3 +23,6 @@ data:
   UNPUBLISHED_INDEX: unpublished_content
   PUBLISHED_INDEX: content
   NOTIFICATION_TOPIC: notify
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
+  CHES_EMAIL_ENABLED: "true"
+  CHES_EMAIL_AUTHORIZED: "true"

--- a/openshift/kustomize/services/indexing/base/deploy.yaml
+++ b/openshift/kustomize/services/indexing/base/deploy.yaml
@@ -66,7 +66,13 @@ spec:
                 configMapKeyRef:
                   name: services
                   key: API_HOST_URL
+            - name: Service__EmailTo
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: EMAIL_FAILURE_TO
 
+            # Authentication Configuration
             - name: Auth__Keycloak__Authority
               valueFrom:
                 configMapKeyRef:
@@ -159,6 +165,44 @@ spec:
                 configMapKeyRef:
                   name: indexing-service
                   key: NOTIFICATION_TOPIC
+
+            # CHES Configuration
+            - name: CHES__From
+              valueFrom:
+                configMapKeyRef:
+                  name: indexing-service
+                  key: CHES_FROM
+            - name: CHES__EmailEnabled
+              valueFrom:
+                configMapKeyRef:
+                  name: indexing-service
+                  key: CHES_EMAIL_ENABLED
+            - name: CHES__EmailAuthorized
+              valueFrom:
+                configMapKeyRef:
+                  name: indexing-service
+                  key: CHES_EMAIL_AUTHORIZED
+
+            - name: CHES__AuthUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_AUTH_URL
+            - name: CHES__HostUri
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_HOST_URI
+            - name: CHES__Username
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: USERNAME
+            - name: CHES__Password
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: PASSWORD
           livenessProbe:
             httpGet:
               path: "/health"

--- a/openshift/kustomize/services/nlp/base/config-map.yaml
+++ b/openshift/kustomize/services/nlp/base/config-map.yaml
@@ -20,3 +20,6 @@ data:
   MAX_FAIL_LIMIT: "5"
   TOPICS: nlp
   INDEXING_TOPIC: index
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
+  CHES_EMAIL_ENABLED: "true"
+  CHES_EMAIL_AUTHORIZED: "true"

--- a/openshift/kustomize/services/nlp/base/deploy.yaml
+++ b/openshift/kustomize/services/nlp/base/deploy.yaml
@@ -66,7 +66,13 @@ spec:
                 configMapKeyRef:
                   name: services
                   key: API_HOST_URL
+            - name: Service__EmailTo
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: EMAIL_FAILURE_TO
 
+            # Authentication Configuration
             - name: Auth__Keycloak__Authority
               valueFrom:
                 configMapKeyRef:
@@ -121,6 +127,44 @@ spec:
                 configMapKeyRef:
                   name: nlp-service
                   key: INDEXING_TOPIC
+
+            # CHES Configuration
+            - name: CHES__From
+              valueFrom:
+                configMapKeyRef:
+                  name: nlp-service
+                  key: CHES_FROM
+            - name: CHES__EmailEnabled
+              valueFrom:
+                configMapKeyRef:
+                  name: nlp-service
+                  key: CHES_EMAIL_ENABLED
+            - name: CHES__EmailAuthorized
+              valueFrom:
+                configMapKeyRef:
+                  name: nlp-service
+                  key: CHES_EMAIL_AUTHORIZED
+
+            - name: CHES__AuthUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_AUTH_URL
+            - name: CHES__HostUri
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_HOST_URI
+            - name: CHES__Username
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: USERNAME
+            - name: CHES__Password
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: PASSWORD
           livenessProbe:
             httpGet:
               path: "/health"

--- a/openshift/kustomize/services/notification/base/config-map.yaml
+++ b/openshift/kustomize/services/notification/base/config-map.yaml
@@ -18,7 +18,7 @@ data:
   KAFKA_CLIENT_ID: Notification
   MAX_FAIL_LIMIT: "5"
   TOPICS: notify
-  CHES_FROM: Media Monitoring Insights and Analysis <mmia@gov.bc.ca>
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
   CHES_EMAIL_ENABLED: "true"
   CHES_EMAIL_AUTHORIZED: "true"
   MMIA_BASE_URL: ""

--- a/openshift/kustomize/services/notification/base/deploy.yaml
+++ b/openshift/kustomize/services/notification/base/deploy.yaml
@@ -66,7 +66,13 @@ spec:
                 configMapKeyRef:
                   name: services
                   key: API_HOST_URL
+            - name: Service__EmailTo
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: EMAIL_FAILURE_TO
 
+            # Authentication Configuration
             - name: Auth__Keycloak__Authority
               valueFrom:
                 configMapKeyRef:
@@ -116,6 +122,39 @@ spec:
                   name: services
                   key: KAFKA_BOOTSTRAP_SERVERS
 
+            # Notification Service Configuration
+            - name: Service__MaxFailLimit
+              valueFrom:
+                configMapKeyRef:
+                  name: notification-service
+                  key: MAX_FAIL_LIMIT
+            - name: Service__Topics
+              valueFrom:
+                configMapKeyRef:
+                  name: notification-service
+                  key: TOPICS
+
+            - name: Reporting__MmiaUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: notification-service
+                  key: MMIA_BASE_URL
+            - name: Reporting__ViewContentUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: notification-service
+                  key: MMIA_VIEW_CONTENT_URL
+            - name: Reporting__RequestTranscriptUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: notification-service
+                  key: MMIA_REQUEST_TRANSCRIPT_URL
+            - name: Reporting__AddToReportUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: notification-service
+                  key: MMIA_ADD_TO_REPORT_URL
+
             # CHES Configuration
             - name: CHES__From
               valueFrom:
@@ -153,39 +192,6 @@ spec:
                 secretKeyRef:
                   name: ches
                   key: PASSWORD
-
-            # Notification Service Configuration
-            - name: Service__MaxFailLimit
-              valueFrom:
-                configMapKeyRef:
-                  name: notification-service
-                  key: MAX_FAIL_LIMIT
-            - name: Service__Topics
-              valueFrom:
-                configMapKeyRef:
-                  name: notification-service
-                  key: TOPICS
-
-            - name: Reporting__MmiaUrl
-              valueFrom:
-                configMapKeyRef:
-                  name: notification-service
-                  key: MMIA_BASE_URL
-            - name: Reporting__ViewContentUrl
-              valueFrom:
-                configMapKeyRef:
-                  name: notification-service
-                  key: MMIA_VIEW_CONTENT_URL
-            - name: Reporting__RequestTranscriptUrl
-              valueFrom:
-                configMapKeyRef:
-                  name: notification-service
-                  key: MMIA_REQUEST_TRANSCRIPT_URL
-            - name: Reporting__AddToReportUrl
-              valueFrom:
-                configMapKeyRef:
-                  name: notification-service
-                  key: MMIA_ADD_TO_REPORT_URL
           livenessProbe:
             httpGet:
               path: "/health"

--- a/openshift/kustomize/services/notification/overlays/dev/config-map.yaml
+++ b/openshift/kustomize/services/notification/overlays/dev/config-map.yaml
@@ -18,7 +18,7 @@ data:
   KAFKA_CLIENT_ID: Notification
   MAX_FAIL_LIMIT: "5"
   TOPICS: notify
-  CHES_FROM: Media Monitoring Insights and Analysis <mmia@gov.bc.ca>
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
   CHES_EMAIL_ENABLED: "true"
   CHES_EMAIL_AUTHORIZED: "false"
   MMIA_BASE_URL: "https://dev.mmia.gov.bc.ca/"

--- a/openshift/kustomize/services/notification/overlays/prod/config-map.yaml
+++ b/openshift/kustomize/services/notification/overlays/prod/config-map.yaml
@@ -18,7 +18,7 @@ data:
   KAFKA_CLIENT_ID: Notification
   MAX_FAIL_LIMIT: "5"
   TOPICS: notify
-  CHES_FROM: Media Monitoring Insights and Analysis <mmia@gov.bc.ca>
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
   CHES_EMAIL_ENABLED: "true"
   CHES_EMAIL_AUTHORIZED: "true"
   MMIA_BASE_URL: "https://mmia.gov.bc.ca/"

--- a/openshift/kustomize/services/notification/overlays/test/config-map.yaml
+++ b/openshift/kustomize/services/notification/overlays/test/config-map.yaml
@@ -18,7 +18,7 @@ data:
   KAFKA_CLIENT_ID: Notification
   MAX_FAIL_LIMIT: "5"
   TOPICS: notify
-  CHES_FROM: Media Monitoring Insights and Analysis <mmia@gov.bc.ca>
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
   CHES_EMAIL_ENABLED: "true"
   CHES_EMAIL_AUTHORIZED: "false"
   MMIA_BASE_URL: "https://test.mmia.gov.bc.ca/"

--- a/openshift/kustomize/services/reporting/base/config-map.yaml
+++ b/openshift/kustomize/services/reporting/base/config-map.yaml
@@ -18,7 +18,7 @@ data:
   KAFKA_CLIENT_ID: Reporting
   MAX_FAIL_LIMIT: "5"
   TOPICS: reporting
-  CHES_FROM: Media Monitoring Insights and Analysis <mmia@gov.bc.ca>
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
   CHES_EMAIL_ENABLED: "true"
   CHES_EMAIL_AUTHORIZED: "true"
   CHARTS_URL: http://charts-api:8080

--- a/openshift/kustomize/services/reporting/base/deploy.yaml
+++ b/openshift/kustomize/services/reporting/base/deploy.yaml
@@ -66,7 +66,13 @@ spec:
                 configMapKeyRef:
                   name: services
                   key: API_HOST_URL
+            - name: Service__EmailTo
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: EMAIL_FAILURE_TO
 
+            # Authentication Configuration
             - name: Auth__Keycloak__Authority
               valueFrom:
                 configMapKeyRef:
@@ -116,6 +122,40 @@ spec:
                   name: services
                   key: KAFKA_BOOTSTRAP_SERVERS
 
+            # Reporting Configuration
+            - name: Reporting__MmiaUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: reporting-service
+                  key: MMIA_BASE_URL
+            - name: Reporting__ViewContentUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: reporting-service
+                  key: MMIA_VIEW_CONTENT_URL
+            - name: Reporting__RequestTranscriptUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: reporting-service
+                  key: MMIA_REQUEST_TRANSCRIPT_URL
+            - name: Reporting__AddToReportUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: reporting-service
+                  key: MMIA_ADD_TO_REPORT_URL
+
+            # Service Configuration
+            - name: Service__MaxFailLimit
+              valueFrom:
+                configMapKeyRef:
+                  name: reporting-service
+                  key: MAX_FAIL_LIMIT
+            - name: Service__Topics
+              valueFrom:
+                configMapKeyRef:
+                  name: reporting-service
+                  key: TOPICS
+
             # CHES Configuration
             - name: CHES__From
               valueFrom:
@@ -160,38 +200,6 @@ spec:
                   name: reporting-service
                   key: CHARTS_URL
 
-            - name: Reporting__MmiaUrl
-              valueFrom:
-                configMapKeyRef:
-                  name: reporting-service
-                  key: MMIA_BASE_URL
-            - name: Reporting__ViewContentUrl
-              valueFrom:
-                configMapKeyRef:
-                  name: reporting-service
-                  key: MMIA_VIEW_CONTENT_URL
-            - name: Reporting__RequestTranscriptUrl
-              valueFrom:
-                configMapKeyRef:
-                  name: reporting-service
-                  key: MMIA_REQUEST_TRANSCRIPT_URL
-            - name: Reporting__AddToReportUrl
-              valueFrom:
-                configMapKeyRef:
-                  name: reporting-service
-                  key: MMIA_ADD_TO_REPORT_URL
-
-            # Notification Service Configuration
-            - name: Service__MaxFailLimit
-              valueFrom:
-                configMapKeyRef:
-                  name: reporting-service
-                  key: MAX_FAIL_LIMIT
-            - name: Service__Topics
-              valueFrom:
-                configMapKeyRef:
-                  name: reporting-service
-                  key: TOPICS
           livenessProbe:
             httpGet:
               path: "/health"

--- a/openshift/kustomize/services/reporting/overlays/dev/config-map.yaml
+++ b/openshift/kustomize/services/reporting/overlays/dev/config-map.yaml
@@ -18,7 +18,7 @@ data:
   KAFKA_CLIENT_ID: Reporting
   MAX_FAIL_LIMIT: "5"
   TOPICS: reporting
-  CHES_FROM: Media Monitoring Insights and Analysis <mmia@gov.bc.ca>
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
   CHES_EMAIL_ENABLED: "true"
   CHES_EMAIL_AUTHORIZED: "false"
 

--- a/openshift/kustomize/services/reporting/overlays/prod/config-map.yaml
+++ b/openshift/kustomize/services/reporting/overlays/prod/config-map.yaml
@@ -18,7 +18,7 @@ data:
   KAFKA_CLIENT_ID: Reporting
   MAX_FAIL_LIMIT: "5"
   TOPICS: reporting
-  CHES_FROM: Media Monitoring Insights and Analysis <mmia@gov.bc.ca>
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
   CHES_EMAIL_ENABLED: "true"
   CHES_EMAIL_AUTHORIZED: "true"
   MMIA_BASE_URL: "https://mmia.gov.bc.ca/"

--- a/openshift/kustomize/services/reporting/overlays/test/config-map.yaml
+++ b/openshift/kustomize/services/reporting/overlays/test/config-map.yaml
@@ -18,7 +18,7 @@ data:
   KAFKA_CLIENT_ID: Reporting
   MAX_FAIL_LIMIT: "5"
   TOPICS: reporting
-  CHES_FROM: Media Monitoring Insights and Analysis <mmia@gov.bc.ca>
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
   CHES_EMAIL_ENABLED: "true"
   CHES_EMAIL_AUTHORIZED: "false"
   MMIA_BASE_URL: "https://test.mmia.gov.bc.ca/"

--- a/openshift/kustomize/services/scheduler/base/config-map.yaml
+++ b/openshift/kustomize/services/scheduler/base/config-map.yaml
@@ -20,3 +20,6 @@ data:
   EVENT_TYPES: |
     - Notification
     - Report
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
+  CHES_EMAIL_ENABLED: "true"
+  CHES_EMAIL_AUTHORIZED: "true"

--- a/openshift/kustomize/services/scheduler/base/deploy.yaml
+++ b/openshift/kustomize/services/scheduler/base/deploy.yaml
@@ -66,7 +66,13 @@ spec:
                 configMapKeyRef:
                   name: services
                   key: API_HOST_URL
+            - name: Service__EmailTo
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: EMAIL_FAILURE_TO
 
+            # Authentication Configuration
             - name: Auth__Keycloak__Authority
               valueFrom:
                 configMapKeyRef:
@@ -127,6 +133,44 @@ spec:
                 configMapKeyRef:
                   name: scheduler-service
                   key: EVENT_TYPES
+
+            # CHES Configuration
+            - name: CHES__From
+              valueFrom:
+                configMapKeyRef:
+                  name: scheduler-service
+                  key: CHES_FROM
+            - name: CHES__EmailEnabled
+              valueFrom:
+                configMapKeyRef:
+                  name: scheduler-service
+                  key: CHES_EMAIL_ENABLED
+            - name: CHES__EmailAuthorized
+              valueFrom:
+                configMapKeyRef:
+                  name: scheduler-service
+                  key: CHES_EMAIL_AUTHORIZED
+
+            - name: CHES__AuthUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_AUTH_URL
+            - name: CHES__HostUri
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_HOST_URI
+            - name: CHES__Username
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: USERNAME
+            - name: CHES__Password
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: PASSWORD
           livenessProbe:
             httpGet:
               path: "/health"

--- a/openshift/kustomize/services/services-config-map.yaml
+++ b/openshift/kustomize/services/services-config-map.yaml
@@ -22,3 +22,6 @@ data:
   KAFKA_BOOTSTRAP_SERVERS: kafka-broker-0.kafka-headless:9092,kafka-broker-1.kafka-headless:9092,kafka-broker-2.kafka-headless:9092
 
   DATA_LOCATION: Openshift
+
+  EMAIL_FAILURE_TO: |
+    - jeremy.foster@fosol.ca

--- a/openshift/kustomize/services/syndication/base/config-map.yaml
+++ b/openshift/kustomize/services/syndication/base/config-map.yaml
@@ -17,3 +17,6 @@ metadata:
 type: Opaque
 data:
   MAX_FAIL_LIMIT: "5"
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
+  CHES_EMAIL_ENABLED: "true"
+  CHES_EMAIL_AUTHORIZED: "true"

--- a/openshift/kustomize/services/syndication/base/deploy.yaml
+++ b/openshift/kustomize/services/syndication/base/deploy.yaml
@@ -87,7 +87,13 @@ spec:
                 configMapKeyRef:
                   name: services
                   key: DATA_LOCATION
+            - name: Service__EmailTo
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: EMAIL_FAILURE_TO
 
+            # Authentication Configuration
             - name: Auth__Keycloak__Authority
               valueFrom:
                 configMapKeyRef:
@@ -110,6 +116,44 @@ spec:
                 configMapKeyRef:
                   name: syndication-service
                   key: MAX_FAIL_LIMIT
+
+            # CHES Configuration
+            - name: CHES__From
+              valueFrom:
+                configMapKeyRef:
+                  name: syndication-service
+                  key: CHES_FROM
+            - name: CHES__EmailEnabled
+              valueFrom:
+                configMapKeyRef:
+                  name: syndication-service
+                  key: CHES_EMAIL_ENABLED
+            - name: CHES__EmailAuthorized
+              valueFrom:
+                configMapKeyRef:
+                  name: syndication-service
+                  key: CHES_EMAIL_AUTHORIZED
+
+            - name: CHES__AuthUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_AUTH_URL
+            - name: CHES__HostUri
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_HOST_URI
+            - name: CHES__Username
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: USERNAME
+            - name: CHES__Password
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: PASSWORD
           livenessProbe:
             httpGet:
               path: "/health"

--- a/openshift/kustomize/services/transcription/base/config-map.yaml
+++ b/openshift/kustomize/services/transcription/base/config-map.yaml
@@ -21,3 +21,6 @@ data:
   TOPICS: transcribe
   VOLUME_PATH: /data
   NOTIFICATION_TOPIC: ""
+  CHES_FROM: Media Monitoring Insights <mmia@gov.bc.ca>
+  CHES_EMAIL_ENABLED: "true"
+  CHES_EMAIL_AUTHORIZED: "true"

--- a/openshift/kustomize/services/transcription/base/deploy.yaml
+++ b/openshift/kustomize/services/transcription/base/deploy.yaml
@@ -73,7 +73,13 @@ spec:
                 configMapKeyRef:
                   name: services
                   key: API_HOST_URL
+            - name: Service__EmailTo
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: EMAIL_FAILURE_TO
 
+            # Authentication Configuration
             - name: Auth__Keycloak__Authority
               valueFrom:
                 configMapKeyRef:
@@ -156,6 +162,44 @@ spec:
                 configMapKeyRef:
                   name: transcription-service
                   key: NOTIFICATION_TOPIC
+
+            # CHES Configuration
+            - name: CHES__From
+              valueFrom:
+                configMapKeyRef:
+                  name: transcription-service
+                  key: CHES_FROM
+            - name: CHES__EmailEnabled
+              valueFrom:
+                configMapKeyRef:
+                  name: transcription-service
+                  key: CHES_EMAIL_ENABLED
+            - name: CHES__EmailAuthorized
+              valueFrom:
+                configMapKeyRef:
+                  name: transcription-service
+                  key: CHES_EMAIL_AUTHORIZED
+
+            - name: CHES__AuthUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_AUTH_URL
+            - name: CHES__HostUri
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_HOST_URI
+            - name: CHES__Username
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: USERNAME
+            - name: CHES__Password
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: PASSWORD
           livenessProbe:
             httpGet:
               path: "/health"

--- a/services/net/capture/CaptureIngestActionManager.cs
+++ b/services/net/capture/CaptureIngestActionManager.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.Options;
 using TNO.API.Areas.Services.Models.Ingest;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 using TNO.Models.Extensions;
 using TNO.Services.Capture.Config;
 using TNO.Services.Command;
@@ -18,9 +20,17 @@ public class CaptureIngestActionManager : CommandIngestActionManager<CaptureOpti
     /// <param name="ingest"></param>
     /// <param name="action"></param>
     /// <param name="api"></param>
+    /// <param name="ches"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="options"></param>
-    public CaptureIngestActionManager(IngestModel ingest, IApiService api, IIngestAction<CaptureOptions> action, IOptions<CaptureOptions> options)
-        : base(ingest, api, action, options)
+    public CaptureIngestActionManager(
+        IngestModel ingest,
+        IApiService api,
+        IChesService ches,
+        IOptions<ChesOptions> chesOptions,
+        IIngestAction<CaptureOptions> action,
+        IOptions<CaptureOptions> options)
+        : base(ingest, api, ches, chesOptions, action, options)
     {
     }
     #endregion

--- a/services/net/capture/appsettings.Development.json
+++ b/services/net/capture/appsettings.Development.json
@@ -9,6 +9,13 @@
   "Service": {
     "MaxFailLimit": 5
   },
+  "CHES": {
+    "AuthUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-dev.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Auth": {
     "Keycloak": {
       "Authority": "https://dev.loginproxy.gov.bc.ca/auth",

--- a/services/net/capture/appsettings.Staging.json
+++ b/services/net/capture/appsettings.Staging.json
@@ -9,6 +9,13 @@
   "Service": {
     "MaxFailLimit": 5
   },
+  "CHES": {
+    "AuthUrl": "https://test.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-test.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Auth": {
     "Keycloak": {
       "Authority": "https://test.loginproxy.gov.bc.ca/auth",

--- a/services/net/capture/appsettings.json
+++ b/services/net/capture/appsettings.json
@@ -19,7 +19,15 @@
     "Command": "ffmpeg",
     "IngestTypes": "Audio, Video",
     "ServiceTypes": "stream",
-    "ReuseIngests": true
+    "ReuseIngests": true,
+    "SendEmailOnFailure": true
+  },
+  "CHES": {
+    "AuthUrl": "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
   },
   "Auth": {
     "Keycloak": {

--- a/services/net/clip/ClipIngestActionManager.cs
+++ b/services/net/clip/ClipIngestActionManager.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using TNO.API.Areas.Services.Models.Ingest;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 using TNO.Core.Exceptions;
 using TNO.Models.Extensions;
 using TNO.Services.Clip.Config;
@@ -24,10 +26,19 @@ public class ClipIngestActionManager : CommandIngestActionManager<ClipOptions>
     /// <param name="dataSource"></param>
     /// <param name="action"></param>
     /// <param name="api"></param>
+    /// <param name="ches"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="options"></param>
     /// <param name="logger"></param>
-    public ClipIngestActionManager(IngestModel dataSource, IApiService api, IIngestAction<ClipOptions> action, IOptions<ClipOptions> options, ILogger<ClipIngestActionManager> logger)
-        : base(dataSource, api, action, options)
+    public ClipIngestActionManager(
+        IngestModel dataSource,
+        IApiService api,
+        IChesService ches,
+        IOptions<ChesOptions> chesOptions,
+        IIngestAction<ClipOptions> action,
+        IOptions<ClipOptions> options,
+        ILogger<ClipIngestActionManager> logger)
+        : base(dataSource, api, ches, chesOptions, action, options)
     {
         _logger = logger;
     }

--- a/services/net/clip/appsettings.Development.json
+++ b/services/net/clip/appsettings.Development.json
@@ -10,6 +10,13 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://host.docker.internal:40010/api"
   },
+  "CHES": {
+    "AuthUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-dev.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Auth": {
     "Keycloak": {
       "Authority": "https://dev.loginproxy.gov.bc.ca/auth",

--- a/services/net/clip/appsettings.Staging.json
+++ b/services/net/clip/appsettings.Staging.json
@@ -10,6 +10,13 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080"
   },
+  "CHES": {
+    "AuthUrl": "https://test.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-test.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Auth": {
     "Keycloak": {
       "Authority": "https://test.loginproxy.gov.bc.ca/auth",

--- a/services/net/clip/appsettings.json
+++ b/services/net/clip/appsettings.json
@@ -17,7 +17,15 @@
     "TimeZone": "Pacific Standard Time",
     "VolumePath": "/data",
     "Command": "ffmpeg",
-    "IngestTypes": "Audio, Video"
+    "IngestTypes": "Audio, Video",
+    "SendEmailOnFailure": true
+  },
+  "CHES": {
+    "AuthUrl": "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
   },
   "Auth": {
     "Keycloak": {

--- a/services/net/command/CommandIngestActionManager.cs
+++ b/services/net/command/CommandIngestActionManager.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.Options;
 using TNO.API.Areas.Services.Models.Ingest;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 using TNO.Services.Actions.Managers;
 using TNO.Services.Command.Config;
 
@@ -17,9 +19,17 @@ public class CommandIngestActionManager : IngestActionManager<CommandOptions>
     /// <param name="ingest"></param>
     /// <param name="action"></param>
     /// <param name="api"></param>
+    /// <param name="ches"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="options"></param>
-    public CommandIngestActionManager(IngestModel ingest, IApiService api, IIngestAction<CommandOptions> action, IOptions<CommandOptions> options)
-        : base(ingest, api, action, options)
+    public CommandIngestActionManager(
+        IngestModel ingest,
+        IApiService api,
+        IChesService ches,
+        IOptions<ChesOptions> chesOptions,
+        IIngestAction<CommandOptions> action,
+        IOptions<CommandOptions> options)
+        : base(ingest, api, ches, chesOptions, action, options)
     {
     }
     #endregion

--- a/services/net/command/CommandIngestActionManager`.cs
+++ b/services/net/command/CommandIngestActionManager`.cs
@@ -1,6 +1,8 @@
-using Microsoft.Extensions.Options;
 using System.Text.Json;
+using Microsoft.Extensions.Options;
 using TNO.API.Areas.Services.Models.Ingest;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 using TNO.Services.Actions.Managers;
 using TNO.Services.Command.Config;
 
@@ -19,9 +21,17 @@ public abstract class CommandIngestActionManager<TOptions> : IngestActionManager
     /// <param name="ingest"></param>
     /// <param name="action"></param>
     /// <param name="api"></param>
+    /// <param name="ches"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="options"></param>
-    public CommandIngestActionManager(IngestModel ingest, IApiService api, IIngestAction<TOptions> action, IOptions<TOptions> options)
-        : base(ingest, api, action, options)
+    public CommandIngestActionManager(
+        IngestModel ingest,
+        IApiService api,
+        IChesService ches,
+        IOptions<ChesOptions> chesOptions,
+        IIngestAction<TOptions> action,
+        IOptions<TOptions> options)
+        : base(ingest, api, ches, chesOptions, action, options)
     {
     }
     #endregion

--- a/services/net/content/appsettings.Development.json
+++ b/services/net/content/appsettings.Development.json
@@ -9,6 +9,13 @@
   "Service": {
     "MaxFailLimit": 5
   },
+  "CHES": {
+    "AuthUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-dev.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Auth": {
     "Keycloak": {
       "Authority": "https://dev.loginproxy.gov.bc.ca/auth",

--- a/services/net/content/appsettings.Staging.json
+++ b/services/net/content/appsettings.Staging.json
@@ -9,6 +9,13 @@
   "Service": {
     "MaxFailLimit": 5
   },
+  "CHES": {
+    "AuthUrl": "https://test.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-test.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Auth": {
     "Keycloak": {
       "Authority": "https://test.loginproxy.gov.bc.ca/auth",

--- a/services/net/content/appsettings.json
+++ b/services/net/content/appsettings.json
@@ -15,7 +15,15 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
     "TimeZone": "Pacific Standard Time",
-    "VolumePath": "/data"
+    "VolumePath": "/data",
+    "SendEmailOnFailure": true
+  },
+  "CHES": {
+    "AuthUrl": "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
   },
   "Auth": {
     "Keycloak": {

--- a/services/net/contentmigration/ContentMigrationAction.cs
+++ b/services/net/contentmigration/ContentMigrationAction.cs
@@ -498,7 +498,10 @@ public class ContentMigrationAction : IngestAction<ContentMigrationOptions>
         {
             // Reached limit return to ingest manager.
             if (manager.Ingest.FailedAttempts + 1 >= manager.Ingest.RetryLimit)
+            {
+                await manager.SendEmailAsync($"Ingest Failure - {manager.Ingest.Name}", ex);
                 throw;
+            }
 
             this.Logger.LogError(ex, "Failed to ingest item for ingest '{name}'", manager.Ingest.Name);
             await manager.RecordFailureAsync();

--- a/services/net/contentmigration/ContentMigrationIngestActionManager.cs
+++ b/services/net/contentmigration/ContentMigrationIngestActionManager.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.Options;
 using TNO.API.Areas.Services.Models.Ingest;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 using TNO.Services.Actions.Managers;
 using TNO.Services.ContentMigration.Config;
 
@@ -20,9 +22,17 @@ public class ContentMigrationIngestActionManager : IngestActionManager<ContentMi
     /// <param name="ingest"></param>
     /// <param name="action"></param>
     /// <param name="api"></param>
+    /// <param name="ches"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="options"></param>
-    public ContentMigrationIngestActionManager(IngestModel ingest, IApiService api, IIngestAction<ContentMigrationOptions> action, IOptions<ContentMigrationOptions> options)
-        : base(ingest, api, action, options)
+    public ContentMigrationIngestActionManager(
+        IngestModel ingest,
+        IApiService api,
+        IChesService ches,
+        IOptions<ChesOptions> chesOptions,
+        IIngestAction<ContentMigrationOptions> action,
+        IOptions<ContentMigrationOptions> options)
+        : base(ingest, api, ches, chesOptions, action, options)
     {
     }
     #endregion

--- a/services/net/contentmigration/appsettings.Development.json
+++ b/services/net/contentmigration/appsettings.Development.json
@@ -10,6 +10,13 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://host.docker.internal:40010/api"
   },
+  "CHES": {
+    "AuthUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-dev.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Auth": {
     "Keycloak": {
       "Authority": "https://dev.loginproxy.gov.bc.ca/auth",

--- a/services/net/contentmigration/appsettings.Staging.json
+++ b/services/net/contentmigration/appsettings.Staging.json
@@ -10,6 +10,13 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080"
   },
+  "CHES": {
+    "AuthUrl": "https://test.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-test.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Auth": {
     "Keycloak": {
       "Authority": "https://test.loginproxy.gov.bc.ca/auth",

--- a/services/net/contentmigration/appsettings.json
+++ b/services/net/contentmigration/appsettings.json
@@ -17,13 +17,13 @@
     "IngestTypes": "TNO-Image,TNO-PrintContent,TNO-AudioVideo,TNO-Story",
     "TimeZone": "Pacific Standard Time",
     "OracleConnection": {
-      "Hostname":"",
-      "Port":1521,
-      "Sid":"",
-      "UserId":"",
-      "Password":""
+      "Hostname": "",
+      "Port": 1521,
+      "Sid": "",
+      "UserId": "",
+      "Password": ""
     },
-    "MediaHostRootUri":"https://tno.gov.bc.ca/av",
+    "MediaHostRootUri": "https://tno.gov.bc.ca/av",
     "ActionNameMappings": {
       "TopStory": "Top Story"
     },
@@ -45,7 +45,7 @@
       }
     },
     "PaperMigrator": {
-      "SupportedIngests": ["TNO-Story","TNO-PrintContent"],
+      "SupportedIngests": ["TNO-Story", "TNO-PrintContent"],
       "IngestSourceMappings": {
         "Abbottsford Times": "AT",
         "Agassiz Observer": "AGASSIZ",
@@ -65,10 +65,10 @@
         "Global News Okanagon RSS": "BC 1",
         "Global News RSS": "BC 1",
         "Goldstream Gazette": "GG",
-        "Kelowna Capital News":"KCN",
-        "Kelowna Capital News Daily":"KCN",
+        "Kelowna Capital News": "KCN",
+        "Kelowna Capital News Daily": "KCN",
         "Kimberley Daily Bulletin": "KDB",
-        "Kitimat Sentinel":"KS",
+        "Kitimat Sentinel": "KS",
         "Langley Advance": "LA",
         "Maple Ridge - Pitt Meadows News": "MRN",
         "Maple Ridge-Pitt Meadows Times": "MRN",
@@ -76,23 +76,23 @@
         "Montreal G": "MG",
         "National Post - Outside Toronto": "NPOST",
         "National Post Business": "NPOST",
-        "Parksville Qualicum News":"PQN",
+        "Parksville Qualicum News": "PQN",
         "Penticton Western": "PW",
-        "Revelstoke Times Review":"RTR",
-        "StarMetro (Vancouver, BC)":"STARMETRO",
-        "Surrey Leader":"SURN",
-        "Surrey Now":"SURN",
-        "Surrey Now Leader":"SURN",
-        "The Daily Courier (Kelowna )":"KELOWNA",
-        "The Daily Courier (Kelowna)":"KELOWNA",
-        "The Delta Optimist":"DO",
+        "Revelstoke Times Review": "RTR",
+        "StarMetro (Vancouver, BC)": "STARMETRO",
+        "Surrey Leader": "SURN",
+        "Surrey Now": "SURN",
+        "Surrey Now Leader": "SURN",
+        "The Daily Courier (Kelowna )": "KELOWNA",
+        "The Daily Courier (Kelowna)": "KELOWNA",
+        "The Delta Optimist": "DO",
         "The Hook Home": "TYEE",
         "The Northern View": "NV",
-        "The Tri-City News":"TCN",
+        "The Tri-City News": "TCN",
         "Victoria Times-Colonist": "TC",
         "Vancouver Province": "PROVO",
-        "Victoria Weekend Edition":"VW",
-        "West K News":"WKN"
+        "Victoria Weekend Edition": "VW",
+        "West K News": "WKN"
       },
       "ProductMappings": {
         "Newspaper": "Daily Print",
@@ -101,7 +101,15 @@
         "Internet": "Online",
         "Scrum": "Events"
       }
-    }
+    },
+    "SendEmailOnFailure": true
+  },
+  "CHES": {
+    "AuthUrl": "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
   },
   "Auth": {
     "Keycloak": {

--- a/services/net/filecopy/appsettings.Development.json
+++ b/services/net/filecopy/appsettings.Development.json
@@ -10,6 +10,13 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://host.docker.internal:40010/api"
   },
+  "CHES": {
+    "AuthUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-dev.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Kafka": {
     "Consumer": {
       "BootstrapServers": "host.docker.internal:40102"

--- a/services/net/filecopy/appsettings.Staging.json
+++ b/services/net/filecopy/appsettings.Staging.json
@@ -10,6 +10,13 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080"
   },
+  "CHES": {
+    "AuthUrl": "https://test.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-test.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Kafka": {
     "Consumer": {
       "BootstrapServers": "kafka-broker-0.kafka-headless:9092,kafka-broker-1.kafka-headless:9092,kafka-broker-2.kafka-headless:9092"

--- a/services/net/filecopy/appsettings.json
+++ b/services/net/filecopy/appsettings.json
@@ -16,7 +16,15 @@
     "ApiUrl": "http://api:8080",
     "TimeZone": "Pacific Standard Time",
     "Topics": "file-request",
-    "VolumePath": "/data"
+    "VolumePath": "/data",
+    "SendEmailOnFailure": true
+  },
+  "CHES": {
+    "AuthUrl": "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
   },
   "Auth": {
     "Keycloak": {

--- a/services/net/filemonitor/FileMonitorIngestActionManager.cs
+++ b/services/net/filemonitor/FileMonitorIngestActionManager.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.Options;
 using TNO.API.Areas.Services.Models.Ingest;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 using TNO.Models.Extensions;
 using TNO.Services.Actions.Managers;
 using TNO.Services.FileMonitor.Config;
@@ -16,11 +18,19 @@ public class FileMonitorIngestActionManager : IngestActionManager<FileMonitorOpt
     /// Creates a new instance of a FileMonitorIngestActionManager object, initializes with specified parameters.
     /// </summary>
     /// <param name="ingest"></param>
-    /// <param name="action"></param>
     /// <param name="api"></param>
+    /// <param name="ches"></param>
+    /// <param name="chesOptions"></param>
+    /// <param name="action"></param>
     /// <param name="options"></param>
-    public FileMonitorIngestActionManager(IngestModel ingest, IApiService api, IIngestAction<FileMonitorOptions> action, IOptions<FileMonitorOptions> options)
-        : base(ingest, api, action, options)
+    public FileMonitorIngestActionManager(
+        IngestModel ingest,
+        IApiService api,
+        IChesService ches,
+        IOptions<ChesOptions> chesOptions,
+        IIngestAction<FileMonitorOptions> action,
+        IOptions<FileMonitorOptions> options)
+        : base(ingest, api, ches, chesOptions, action, options)
     {
     }
     #endregion

--- a/services/net/filemonitor/FilemonitorAction.cs
+++ b/services/net/filemonitor/FilemonitorAction.cs
@@ -269,7 +269,10 @@ public class FileMonitorAction : IngestAction<FileMonitorOptions>
         {
             // Reached limit return to ingest manager.
             if (manager.Ingest.FailedAttempts + 1 >= manager.Ingest.RetryLimit)
+            {
+                await manager.SendEmailAsync($"Ingest Failure - {manager.Ingest.Name}", ex);
                 throw;
+            }
 
             this.Logger.LogError(ex, "Failed to ingest item for ingest '{name}'", manager.Ingest.Name);
             await manager.RecordFailureAsync();

--- a/services/net/filemonitor/appsettings.Development.json
+++ b/services/net/filemonitor/appsettings.Development.json
@@ -10,6 +10,13 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://host.docker.internal:40010/api"
   },
+  "CHES": {
+    "AuthUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-dev.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Auth": {
     "Keycloak": {
       "Authority": "https://dev.loginproxy.gov.bc.ca/auth",

--- a/services/net/filemonitor/appsettings.Staging.json
+++ b/services/net/filemonitor/appsettings.Staging.json
@@ -10,6 +10,13 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080"
   },
+  "CHES": {
+    "AuthUrl": "https://test.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-test.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Auth": {
     "Keycloak": {
       "Authority": "https://test.loginproxy.gov.bc.ca/auth",

--- a/services/net/filemonitor/appsettings.json
+++ b/services/net/filemonitor/appsettings.json
@@ -14,7 +14,15 @@
     "VolumePath": "/data",
     "IngestTypes": "Paper",
     "TimeZone": "Pacific Standard Time",
-    "PrivateKeysPath": "keys"
+    "PrivateKeysPath": "keys",
+    "SendEmailOnFailure": true
+  },
+  "CHES": {
+    "AuthUrl": "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
   },
   "Auth": {
     "Keycloak": {

--- a/services/net/image/ImageIngestActionManager.cs
+++ b/services/net/image/ImageIngestActionManager.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.Options;
 using TNO.API.Areas.Services.Models.Ingest;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 using TNO.Services.Actions.Managers;
 using TNO.Services.Image.Config;
 
@@ -20,9 +22,17 @@ public class ImageIngestActionManager : IngestActionManager<ImageOptions>
     /// <param name="dataSource"></param>
     /// <param name="action"></param>
     /// <param name="api"></param>
+    /// <param name="ches"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="options"></param>
-    public ImageIngestActionManager(IngestModel dataSource, IApiService api, IIngestAction<ImageOptions> action, IOptions<ImageOptions> options)
-        : base(dataSource, api, action, options)
+    public ImageIngestActionManager(
+        IngestModel dataSource,
+        IApiService api,
+        IChesService ches,
+        IOptions<ChesOptions> chesOptions,
+        IIngestAction<ImageOptions> action,
+        IOptions<ImageOptions> options)
+        : base(dataSource, api, ches, chesOptions, action, options)
     {
     }
     #endregion

--- a/services/net/image/appsettings.Development.json
+++ b/services/net/image/appsettings.Development.json
@@ -10,6 +10,13 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://host.docker.internal:40010/api"
   },
+  "CHES": {
+    "AuthUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-dev.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Auth": {
     "Keycloak": {
       "Authority": "https://dev.loginproxy.gov.bc.ca/auth",

--- a/services/net/image/appsettings.Staging.json
+++ b/services/net/image/appsettings.Staging.json
@@ -10,6 +10,13 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080"
   },
+  "CHES": {
+    "AuthUrl": "https://test.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-test.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Auth": {
     "Keycloak": {
       "Authority": "https://test.loginproxy.gov.bc.ca/auth",

--- a/services/net/image/appsettings.json
+++ b/services/net/image/appsettings.json
@@ -18,7 +18,15 @@
     "VolumePath": "/data",
     "Command": "ffmpeg",
     "IngestTypes": "Front Page",
-    "PrivateKeysPath": "keys"
+    "PrivateKeysPath": "keys",
+    "SendEmailOnFailure": true
+  },
+  "CHES": {
+    "AuthUrl": "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
   },
   "Auth": {
     "Keycloak": {

--- a/services/net/indexing/appsettings.Development.json
+++ b/services/net/indexing/appsettings.Development.json
@@ -11,6 +11,13 @@
     "ApiUrl": "http://host.docker.internal:40010/api",
     "ElasticsearchUri": "http://host.docker.internal:40003"
   },
+  "CHES": {
+    "AuthUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-dev.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Kafka": {
     "Admin": {
       "BootstrapServers": "host.docker.internal:40102"

--- a/services/net/indexing/appsettings.Staging.json
+++ b/services/net/indexing/appsettings.Staging.json
@@ -9,6 +9,13 @@
   "Service": {
     "MaxFailLimit": 5
   },
+  "CHES": {
+    "AuthUrl": "https://test.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-test.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Kafka": {
     "Admin": {
       "BootstrapServers": "kafka-broker-0.kafka-headless:9092,kafka-broker-1.kafka-headless:9092,kafka-broker-2.kafka-headless:9092"

--- a/services/net/indexing/appsettings.json
+++ b/services/net/indexing/appsettings.json
@@ -20,7 +20,15 @@
     "UnpublishedIndex": "unpublished_content",
     "PublishedIndex": "content",
     "NotificationTopic": "notify",
-    "HubTopic": "hub"
+    "HubTopic": "hub",
+    "SendEmailOnFailure": true
+  },
+  "CHES": {
+    "AuthUrl": "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
   },
   "Auth": {
     "Keycloak": {

--- a/services/net/nlp/appsettings.Development.json
+++ b/services/net/nlp/appsettings.Development.json
@@ -10,6 +10,13 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://host.docker.internal:40010/api"
   },
+  "CHES": {
+    "AuthUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-dev.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Kafka": {
     "Consumer": {
       "BootstrapServers": "host.docker.internal:40102"

--- a/services/net/nlp/appsettings.Staging.json
+++ b/services/net/nlp/appsettings.Staging.json
@@ -10,6 +10,13 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://host.docker.internal:40010/api"
   },
+  "CHES": {
+    "AuthUrl": "https://test.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-test.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Kafka": {
     "Consumer": {
       "BootstrapServers": "kafka-broker-0.kafka-headless:9092,kafka-broker-1.kafka-headless:9092,kafka-broker-2.kafka-headless:9092"

--- a/services/net/nlp/appsettings.json
+++ b/services/net/nlp/appsettings.json
@@ -16,7 +16,15 @@
     "ApiUrl": "http://api:8080/api",
     "TimeZone": "Pacific Standard Time",
     "Topics": "nlp",
-    "IndexingTopic": "index"
+    "IndexingTopic": "index",
+    "SendEmailOnFailure": true
+  },
+  "CHES": {
+    "AuthUrl": "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
   },
   "Auth": {
     "Keycloak": {

--- a/services/net/notification/NotificationService.cs
+++ b/services/net/notification/NotificationService.cs
@@ -47,8 +47,6 @@ public class NotificationService : KafkaConsumerService
             .Configure<ReportingOptions>(this.Configuration.GetSection("Reporting"))
             .AddTransient<IKafkaListener<string, NotificationRequestModel>, KafkaListener<string, NotificationRequestModel>>()
             .AddTransient<INotificationValidator, NotificationValidator>()
-            .AddChesSingletonService(this.Configuration.GetSection("CHES"))
-            .AddSingleton(new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Email, "") })))
             .AddScoped<IServiceManager, NotificationManager>()
             .AddTemplateEngine(this.Configuration);
 

--- a/services/net/notification/TNO.Services.Notification.csproj
+++ b/services/net/notification/TNO.Services.Notification.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\libs\net\ches\TNO.Ches.csproj" />
     <ProjectReference Include="..\..\..\libs\net\services\TNO.Services.csproj" />
     <ProjectReference Include="..\..\..\libs\net\kafka\TNO.Kafka.csproj" />
     <ProjectReference Include="..\..\..\libs\net\template\TNO.TemplateEngine.csproj" />

--- a/services/net/notification/appsettings.Development.json
+++ b/services/net/notification/appsettings.Development.json
@@ -8,7 +8,7 @@
   },
   "Service": {
     "MaxFailLimit": 5,
-    "ApiUrl": "http://host.docker.internal:40010/api",
+    "ApiUrl": "http://host.docker.internal:40010/api"
   },
   "Reporting": {
     "MmiaUrl": "https://dev.mmia.gov.bc.ca",
@@ -19,7 +19,7 @@
   "CHES": {
     "AuthUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
     "HostUri": "https://ches-dev.api.gov.bc.ca/api/v1",
-    "From": "Media Monitoring Insights and Analysis <mmia@gov.bc.ca>",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
     "EmailEnabled": true,
     "EmailAuthorized": false
   },

--- a/services/net/notification/appsettings.Staging.json
+++ b/services/net/notification/appsettings.Staging.json
@@ -19,7 +19,7 @@
   "CHES": {
     "AuthUrl": "https://test.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
     "HostUri": "https://ches-test.api.gov.bc.ca/api/v1",
-    "From": "Media Monitoring Insights and Analysis <mmia@gov.bc.ca>",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
     "EmailEnabled": true,
     "EmailAuthorized": false
   },

--- a/services/net/notification/appsettings.json
+++ b/services/net/notification/appsettings.json
@@ -20,12 +20,13 @@
     "ViewContentUrl": "https://mmia.gov.bc.ca/view/",
     "RequestTranscriptUrl": "https://mmia.gov.bc.ca/api/subscriber/work/orders/transcribe/",
     "AddToReportUrl": "https://mmia.gov.bc.ca",
-    "AlertId": 1
+    "AlertId": 1,
+    "SendEmailOnFailure": true
   },
   "CHES": {
     "AuthUrl": "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
     "HostUri": "https://ches.api.gov.bc.ca/api/v1",
-    "From": "Media Monitoring Insights and Analysis <mmia@gov.bc.ca>",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
     "EmailEnabled": true,
     "EmailAuthorized": false
   },

--- a/services/net/reporting/ReportingService.cs
+++ b/services/net/reporting/ReportingService.cs
@@ -44,8 +44,6 @@ public class ReportingService : KafkaConsumerService
         services
             .Configure<ReportingOptions>(this.Configuration.GetSection("Service"))
             .AddTransient<IKafkaListener<string, ReportRequestModel>, KafkaListener<string, ReportRequestModel>>()
-            .AddChesSingletonService(this.Configuration.GetSection("CHES"))
-            .AddSingleton(new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Email, "") })))
             .AddScoped<IServiceManager, ReportingManager>()
             .AddTemplateEngine(this.Configuration);
 

--- a/services/net/reporting/TNO.Services.Reporting.csproj
+++ b/services/net/reporting/TNO.Services.Reporting.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\libs\net\ches\TNO.Ches.csproj" />
     <ProjectReference Include="..\..\..\libs\net\services\TNO.Services.csproj" />
     <ProjectReference Include="..\..\..\libs\net\kafka\TNO.Kafka.csproj" />
     <ProjectReference Include="..\..\..\libs\net\template\TNO.TemplateEngine.csproj" />

--- a/services/net/reporting/appsettings.Development.json
+++ b/services/net/reporting/appsettings.Development.json
@@ -18,7 +18,7 @@
   "CHES": {
     "AuthUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
     "HostUri": "https://ches-dev.api.gov.bc.ca/api/v1",
-    "From": "Media Monitoring Insights and Analysis <mmia@gov.bc.ca>",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
     "EmailEnabled": true,
     "EmailAuthorized": false
   },

--- a/services/net/reporting/appsettings.Staging.json
+++ b/services/net/reporting/appsettings.Staging.json
@@ -18,7 +18,7 @@
   "CHES": {
     "AuthUrl": "https://test.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
     "HostUri": "https://ches-test.api.gov.bc.ca/api/v1",
-    "From": "Media Monitoring Insights and Analysis <mmia@gov.bc.ca>",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
     "EmailEnabled": true,
     "EmailAuthorized": false
   },

--- a/services/net/reporting/appsettings.json
+++ b/services/net/reporting/appsettings.json
@@ -15,7 +15,8 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
     "TimeZone": "Pacific Standard Time",
-    "Topics": "reporting"
+    "Topics": "reporting",
+    "SendEmailOnFailure": true
   },
   "Reporting": {
     "MmiaUrl": "https://mmia.gov.bc.ca",
@@ -25,7 +26,7 @@
   "CHES": {
     "AuthUrl": "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
     "HostUri": "https://ches.api.gov.bc.ca/api/v1",
-    "From": "Media Monitoring Insights and Analysis <mmia@gov.bc.ca>",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
     "EmailEnabled": true,
     "EmailAuthorized": false
   },

--- a/services/net/scheduler/appsettings.Development.json
+++ b/services/net/scheduler/appsettings.Development.json
@@ -15,5 +15,12 @@
     "OIDC": {
       "Token": "/realms/standard/protocol/openid-connect/token"
     }
+  },
+  "CHES": {
+    "AuthUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-dev.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
   }
 }

--- a/services/net/scheduler/appsettings.Staging.json
+++ b/services/net/scheduler/appsettings.Staging.json
@@ -15,5 +15,12 @@
     "OIDC": {
       "Token": "/realms/standard/protocol/openid-connect/token"
     }
+  },
+  "CHES": {
+    "AuthUrl": "https://test.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-test.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
   }
 }

--- a/services/net/scheduler/appsettings.json
+++ b/services/net/scheduler/appsettings.json
@@ -15,7 +15,15 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080",
     "TimeZone": "Pacific Standard Time",
-    "EventTypes": ["Notification", "Report"]
+    "EventTypes": ["Notification", "Report"],
+    "SendEmailOnFailure": true
+  },
+  "CHES": {
+    "AuthUrl": "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
   },
   "Auth": {
     "Keycloak": {

--- a/services/net/syndication/Config/SyndicationOptions.cs
+++ b/services/net/syndication/Config/SyndicationOptions.cs
@@ -9,14 +9,20 @@ public class SyndicationOptions : IngestServiceOptions
 {
     #region Properties
     /// <summary>
-    /// get/set - The invalid characters and their expected format so this could be cleaned up 
+    /// get/set - The invalid characters and their expected format so this could be cleaned up
     /// before importing, and it should look like this - "{search1}:_{replace1}__{search2}:_{replace2}"
     /// </summary>
     public string InvalidEncodings { get; set; } = "";
 
     /// <summary>
     /// get - The key value set from InvalidEncodings ["{search1}:_{replace1}", "{search2}:_{replace2}"]
-    /// </summary>    
+    /// </summary>
     public string[]? EncodingSets => InvalidEncodings?.Split("__", StringSplitOptions.RemoveEmptyEntries);
+
+    /// <summary>
+    /// get/set - Number of seconds before content is considered stuck in limbo and another message should be sent to Kafka.
+    /// Defaults to 5 minutes.
+    /// </summary>
+    public int RetryAfterSeconds { get; set; } = 300;
     #endregion
 }

--- a/services/net/syndication/SyndicationIngestActionManager.cs
+++ b/services/net/syndication/SyndicationIngestActionManager.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.Options;
 using TNO.API.Areas.Services.Models.Ingest;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 using TNO.Models.Extensions;
 using TNO.Services.Actions.Managers;
 using TNO.Services.Syndication.Config;
@@ -18,9 +20,17 @@ public class SyndicationIngestActionManager : IngestActionManager<SyndicationOpt
     /// <param name="ingest"></param>
     /// <param name="action"></param>
     /// <param name="api"></param>
+    /// <param name="ches"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="options"></param>
-    public SyndicationIngestActionManager(IngestModel ingest, IApiService api, IIngestAction<SyndicationOptions> action, IOptions<SyndicationOptions> options)
-        : base(ingest, api, action, options)
+    public SyndicationIngestActionManager(
+        IngestModel ingest,
+        IApiService api,
+        IChesService ches,
+        IOptions<ChesOptions> chesOptions,
+        IIngestAction<SyndicationOptions> action,
+        IOptions<SyndicationOptions> options)
+        : base(ingest, api, ches, chesOptions, action, options)
     {
     }
     #endregion

--- a/services/net/syndication/appsettings.Development.json
+++ b/services/net/syndication/appsettings.Development.json
@@ -15,5 +15,12 @@
     "OIDC": {
       "Token": "/realms/standard/protocol/openid-connect/token"
     }
+  },
+  "CHES": {
+    "AuthUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-dev.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
   }
 }

--- a/services/net/syndication/appsettings.Staging.json
+++ b/services/net/syndication/appsettings.Staging.json
@@ -15,5 +15,12 @@
     "OIDC": {
       "Token": "/realms/standard/protocol/openid-connect/token"
     }
+  },
+  "CHES": {
+    "AuthUrl": "https://test.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-test.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
   }
 }

--- a/services/net/syndication/appsettings.json
+++ b/services/net/syndication/appsettings.json
@@ -16,7 +16,15 @@
     "ApiUrl": "http://api:8080",
     "IngestTypes": "Syndication",
     "TimeZone": "Pacific Standard Time",
-    "InvalidEncodings": "�e(TM):_'__&#39;:_'"
+    "InvalidEncodings": "�e(TM):_'__&#39;:_'",
+    "SendEmailOnFailure": true
+  },
+  "CHES": {
+    "AuthUrl": "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
   },
   "Auth": {
     "Keycloak": {

--- a/services/net/transcription/appsettings.Development.json
+++ b/services/net/transcription/appsettings.Development.json
@@ -10,6 +10,13 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://host.docker.internal:40010/api"
   },
+  "CHES": {
+    "AuthUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-dev.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Kafka": {
     "Consumer": {
       "BootstrapServers": "host.docker.internal:40102"

--- a/services/net/transcription/appsettings.Staging.json
+++ b/services/net/transcription/appsettings.Staging.json
@@ -10,6 +10,13 @@
     "MaxFailLimit": 5,
     "ApiUrl": "http://api:8080"
   },
+  "CHES": {
+    "AuthUrl": "https://test.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches-test.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
+  },
   "Kafka": {
     "Consumer": {
       "BootstrapServers": "kafka-broker-0.kafka-headless:9092,kafka-broker-1.kafka-headless:9092,kafka-broker-2.kafka-headless:9092"

--- a/services/net/transcription/appsettings.json
+++ b/services/net/transcription/appsettings.json
@@ -19,7 +19,15 @@
     "VolumePath": "/data",
     "AzureRegion": "canadacentral",
     "AzureCognitiveServicesKey": "",
-    "ConvertToAudio": ["mp4", "mov", "m4a"]
+    "ConvertToAudio": ["mp4", "mov", "m4a"],
+    "SendEmailOnFailure": true
+  },
+  "CHES": {
+    "AuthUrl": "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token",
+    "HostUri": "https://ches.api.gov.bc.ca/api/v1",
+    "From": "Media Monitoring Insights <mmia@gov.bc.ca>",
+    "EmailEnabled": true,
+    "EmailAuthorized": false
   },
   "Auth": {
     "Keycloak": {

--- a/tools/scripts/gen-env-files.sh
+++ b/tools/scripts/gen-env-files.sh
@@ -489,6 +489,13 @@ Auth__OIDC__Token=/realms/tno/protocol/openid-connect/token
 
 Service__ApiUrl=http://host.docker.internal:$portApi/api
 
+CHES__AuthUrl=https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token
+CHES__HostUri=https://ches-dev.api.gov.bc.ca/api/v1
+CHES__Username={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__Password={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__EmailAuthorized=true
+# CHES__OverrideTo=
+
 Kafka__BootstrapServers=host.docker.internal:$portKafkaBrokerAdvertisedExternal" >> ./services/net/syndication/.env
     echo "./services/net/syndication/.env created"
 fi
@@ -508,6 +515,13 @@ Auth__OIDC__Token=/realms/tno/protocol/openid-connect/token
 
 Service__ApiUrl=http://host.docker.internal:$portApi/api
 # Service__VolumePath=../data
+
+CHES__AuthUrl=https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token
+CHES__HostUri=https://ches-dev.api.gov.bc.ca/api/v1
+CHES__Username={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__Password={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__EmailAuthorized=true
+# CHES__OverrideTo=
 
 Kafka__BootstrapServers=host.docker.internal:$portKafkaBrokerAdvertisedExternal" >> ./services/net/capture/.env
     echo "./services/net/capture/.env created"
@@ -529,6 +543,13 @@ Auth__OIDC__Token=/realms/tno/protocol/openid-connect/token
 Service__ApiUrl=http://host.docker.internal:$portApi/api
 # Service__VolumePath=../data
 
+CHES__AuthUrl=https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token
+CHES__HostUri=https://ches-dev.api.gov.bc.ca/api/v1
+CHES__Username={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__Password={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__EmailAuthorized=true
+# CHES__OverrideTo=
+
 Kafka__BootstrapServers=host.docker.internal:$portKafkaBrokerAdvertisedExternal" >> ./services/net/clip/.env
     echo "./services/net/clip/.env created"
 fi
@@ -549,6 +570,13 @@ Auth__OIDC__Token=/realms/tno/protocol/openid-connect/token
 Service__ApiUrl=http://host.docker.internal:$portApi/api
 # Service__VolumePath=../data
 
+CHES__AuthUrl=https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token
+CHES__HostUri=https://ches-dev.api.gov.bc.ca/api/v1
+CHES__Username={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__Password={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__EmailAuthorized=true
+# CHES__OverrideTo=
+
 Kafka__BootstrapServers=host.docker.internal:$portKafkaBrokerAdvertisedExternal" >> ./services/net/image/.env
     echo "./services/net/image/.env created"
 fi
@@ -568,6 +596,13 @@ Auth__OIDC__Token=/realms/tno/protocol/openid-connect/token
 
 Service__ApiUrl=http://host.docker.internal:$portApi/api
 # Service__VolumePath=../data
+
+CHES__AuthUrl=https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token
+CHES__HostUri=https://ches-dev.api.gov.bc.ca/api/v1
+CHES__Username={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__Password={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__EmailAuthorized=true
+# CHES__OverrideTo=
 
 Kafka__BootstrapServers=host.docker.internal:$portKafkaBrokerAdvertisedExternal" >> ./services/net/filemonitor/.env
     echo "./services/net/filemonitor/.env created"
@@ -591,7 +626,14 @@ Kafka__Producer__BootstrapServers=host.docker.internal:$portKafkaBrokerAdvertise
 Kafka__Consumer__BootstrapServers=host.docker.internal:$portKafkaBrokerAdvertisedExternal
 
 Service__ApiUrl=http://host.docker.internal:$portApi/api
-Service__TranscriptionTopic=transcription" >> ./services/net/content/.env
+Service__TranscriptionTopic=transcription
+
+CHES__AuthUrl=https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token
+CHES__HostUri=https://ches-dev.api.gov.bc.ca/api/v1
+CHES__Username={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__Password={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__EmailAuthorized=true
+# CHES__OverrideTo=" >> ./services/net/content/.env
     echo "./services/net/content/.env created"
 fi
 
@@ -612,7 +654,14 @@ Kafka__Admin__BootstrapServers=host.docker.internal:$portKafkaBrokerAdvertisedEx
 Kafka__Producer__BootstrapServers=host.docker.internal:$portKafkaBrokerAdvertisedExternal
 
 Service__ApiUrl=http://host.docker.internal:$portApi/api
-Service__TranscriptionTopic=transcription" >> ./services/net/contentmigration/.env
+Service__TranscriptionTopic=transcription
+
+CHES__AuthUrl=https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token
+CHES__HostUri=https://ches-dev.api.gov.bc.ca/api/v1
+CHES__Username={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__Password={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__EmailAuthorized=true
+# CHES__OverrideTo=" >> ./services/net/contentmigration/.env
     echo "./services/net/contentmigration/.env created"
 fi
 
@@ -631,6 +680,13 @@ Auth__OIDC__Token=/realms/tno/protocol/openid-connect/token
 
 Service__ApiUrl=http://host.docker.internal:$portApi/api
 Service__AzureCognitiveServicesKey={ENTER A VALID AZURE KEY}
+
+CHES__AuthUrl=https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token
+CHES__HostUri=https://ches-dev.api.gov.bc.ca/api/v1
+CHES__Username={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__Password={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__EmailAuthorized=true
+# CHES__OverrideTo=
 
 Kafka__BootstrapServers=host.docker.internal:$portKafkaBrokerAdvertisedExternal" >> ./services/net/transcription/.env
     echo "./services/net/transcription/.env created"
@@ -654,6 +710,13 @@ Service__ElasticsearchUri=http://host.docker.internal:$portElastic
 Service__ElasticsearchUsername=$elasticUser
 Service__ElasticsearchPassword=$password
 
+CHES__AuthUrl=https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token
+CHES__HostUri=https://ches-dev.api.gov.bc.ca/api/v1
+CHES__Username={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__Password={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__EmailAuthorized=true
+# CHES__OverrideTo=
+
 Kafka__BootstrapServers=host.docker.internal:$portKafkaBrokerAdvertisedExternal" >> ./services/net/indexing/.env
     echo "./services/net/indexing/.env created"
 fi
@@ -673,6 +736,13 @@ Auth__OIDC__Token=/realms/tno/protocol/openid-connect/token
 
 Service__ApiUrl=http://host.docker.internal:$portApi/api
 
+CHES__AuthUrl=https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token
+CHES__HostUri=https://ches-dev.api.gov.bc.ca/api/v1
+CHES__Username={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__Password={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__EmailAuthorized=true
+# CHES__OverrideTo=
+
 Kafka__BootstrapServers=host.docker.internal:$portKafkaBrokerAdvertisedExternal" >> ./services/net/nlp/.env
     echo "./services/net/nlp/.env created"
 fi
@@ -691,6 +761,13 @@ Auth__Keycloak__Secret={YOU WILL NEED TO GET THIS FROM KEYCLOAK}
 Auth__OIDC__Token=/realms/tno/protocol/openid-connect/token
 
 Service__ApiUrl=http://host.docker.internal:$portApi/api
+
+CHES__AuthUrl=https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token
+CHES__HostUri=https://ches-dev.api.gov.bc.ca/api/v1
+CHES__Username={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__Password={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__EmailAuthorized=true
+# CHES__OverrideTo=
 
 Kafka__BootstrapServers=host.docker.internal:$portKafkaBrokerAdvertisedExternal" >> ./services/net/filecopy/.env
     echo "./services/net/filecopy/.env created"
@@ -744,6 +821,31 @@ CHES__Username={YOU WILL NEED TO GET THIS FROM CHES}
 CHES__Password={YOU WILL NEED TO GET THIS FROM CHES}
 CHES__OverrideTo={CHANGE THIS TO YOUR EMAIL ADDRESS}" >> ./services/net/reporting/.env
     echo "./services/net/reporting/.env created"
+fi
+
+## Scheduler Service
+if test -f "./services/net/scheduler/.env"; then
+    echo "./services/net/scheduler/.env exists"
+else
+echo \
+"ASPNETCORE_ENVIRONMENT=Development
+ASPNETCORE_URLS=http://+:8081
+
+Auth__Keycloak__Authority=http://host.docker.internal:$portKeycloak/auth
+Auth__Keycloak__Audience=tno-service-account
+Auth__Keycloak__Secret={YOU WILL NEED TO GET THIS FROM KEYCLOAK}
+Auth__OIDC__Token=/realms/tno/protocol/openid-connect/token
+
+Service__ApiUrl=http://host.docker.internal:$portApi/api
+
+Kafka__BootstrapServers=host.docker.internal:$portKafkaBrokerAdvertisedExternal
+
+CHES__AuthUrl=https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token
+CHES__HostUri=https://ches-dev.api.gov.bc.ca/api/v1
+CHES__Username={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__Password={YOU WILL NEED TO GET THIS FROM CHES}
+CHES__OverrideTo={CHANGE THIS TO YOUR EMAIL ADDRESS}" >> ./services/net/scheduler/.env
+    echo "./services/net/scheduler/.env created"
 fi
 
 


### PR DESCRIPTION
Updated base services library which enables all services to send an email when they have failures.  Currently only the File Monitory Service, Syndication Service and the Content Migration Service have been configured to send an email when an Ingest configuration has reached its max failure limit.

## Summary

- Add email ability to all services on failure
- Updated Infrastructure as Code