### PR TITLE
feat: #tno-1837 - updated reports sections display

### DIFF
--- a/app/editor/src/features/admin/reports/ReportFormSections.tsx
+++ b/app/editor/src/features/admin/reports/ReportFormSections.tsx
@@ -241,9 +241,9 @@ export const ReportFormSections = () => {
                     </Col>
                     <Col className="st-3">{row.description}</Col>
                     <Col className="st-4">
-                      {row.settings.sectionType == 'Content'
+                      {row.settings.sectionType === 'Content'
                         ? row.filter?.name
-                        : row.settings.sectionType == 'TableOfContents'
+                        : row.settings.sectionType === 'TableOfContents'
                         ? 'Table of Contents'
                         : 'Summary'}
                     </Col>

--- a/app/editor/src/features/admin/reports/ReportFormSections.tsx
+++ b/app/editor/src/features/admin/reports/ReportFormSections.tsx
@@ -223,7 +223,8 @@ export const ReportFormSections = () => {
                 <Col className="st-1"></Col>
                 <Col className="st-2">Heading</Col>
                 <Col className="st-3">Summary</Col>
-                <Col className="st-4"></Col>
+                <Col className="st-4">Content</Col>
+                <Col className="st-5"></Col>
               </Row>
               {values.sections.map((row, index) => (
                 <React.Fragment key={index}>
@@ -235,9 +236,18 @@ export const ReportFormSections = () => {
                     }}
                   >
                     <Col className="st-1">{row.sortOrder + 1}</Col>
-                    <Col className="st-2">{row.settings.label}</Col>
+                    <Col className="st-2">
+                      {row.settings.label.length > 0 ? row.settings.label : '[empty]'}
+                    </Col>
                     <Col className="st-3">{row.description}</Col>
                     <Col className="st-4">
+                      {row.settings.sectionType == 'Content'
+                        ? row.filter?.name
+                        : row.settings.sectionType == 'TableOfContents'
+                        ? 'Table of Contents'
+                        : 'Summary'}
+                    </Col>
+                    <Col className="st-5">
                       <Col>
                         <Button
                           variant={ButtonVariant.link}

--- a/app/editor/src/features/admin/reports/styled/ReportSections.tsx
+++ b/app/editor/src/features/admin/reports/styled/ReportSections.tsx
@@ -21,7 +21,7 @@ export const ReportSections = styled.div`
 
   .section-table {
     display: grid;
-    grid-template-columns: 1fr 2fr 5fr 1fr;
+    grid-template-columns: 0.25fr 2fr 4fr 2fr 0.25fr;
     row-gap: 0.25rem;
     width: 100%;
 
@@ -45,6 +45,13 @@ export const ReportSections = styled.div`
 
     .st-4 {
       grid-column-start: 4;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
+
+    .st-5 {
+      grid-column-start: 5;
       display: flex;
       flex-direction: row;
       justify-content: flex-end;


### PR DESCRIPTION
- added some more details to the sections grid header
- tweaked css
![image](https://github.com/bcgov/tno/assets/63015960/1de214de-c367-47cd-a058-f98b3b874cc1)
