### PR TITLE
TNO-1739 Fix file paths

### DIFF
--- a/api/net/Areas/Subscriber/Controllers/ContributorController.cs
+++ b/api/net/Areas/Subscriber/Controllers/ContributorController.cs
@@ -2,8 +2,8 @@ using System.Net;
 using System.Net.Mime;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
-using TNO.API.Filters;
 using TNO.API.Areas.Subscriber.Models.Contributor;
+using TNO.API.Filters;
 using TNO.API.Models;
 using TNO.DAL.Services;
 using TNO.Keycloak;
@@ -32,6 +32,7 @@ public class ContributorController : ControllerBase
     #region Constructors
     /// <summary>
     /// Creates a new instance of a ContributorController object, initializes with specified parameters.
+    /// </summary>
     /// <param name="service"></param>
     public ContributorController(IContributorService service)
     {

--- a/libs/net/dal/Models/ContentFileReference.cs
+++ b/libs/net/dal/Models/ContentFileReference.cs
@@ -213,7 +213,7 @@ public class ContentFileReference : IReadonlyFileReference
     /// <summary>
     /// Creates a new instance of a ContentFileReference, initializes with specified parameters.
     /// Use this to update an existing FileReference.
-    /// Only use this contructor when the 'content' already exists in the database.
+    /// Only use this constructor when the 'content' already exists in the database.
     /// </summary>
     /// <param name="fileReference"></param>
     /// <param name="file"></param>
@@ -258,7 +258,7 @@ public class ContentFileReference : IReadonlyFileReference
     public static string GenerateFilePath(Content content, IFormFile file)
     {
         var fileName = GenerateFileName(content, file);
-        return System.IO.Path.Combine(content.OtherSource, fileName);
+        return System.IO.Path.Combine(content.OtherSource.Replace(' ', '_'), fileName);
     }
 
     /// <summary>
@@ -270,7 +270,7 @@ public class ContentFileReference : IReadonlyFileReference
     public static string GenerateFileName(Content content, IFormFile file)
     {
         if (content.Id == 0) throw new ArgumentException("Parameter 'content.Id' must be greater than zero.", nameof(content));
-        if (String.IsNullOrWhiteSpace(content.OtherSource)) throw new ArgumentException("Parameter 'content.OtherSource' cannot be null, empty, or whitespace.", nameof(content));
+        if (String.IsNullOrWhiteSpace(content.OtherSource.Replace(' ', '_'))) throw new ArgumentException("Parameter 'content.OtherSource' cannot be null, empty, or whitespace.", nameof(content));
 
         return GenerateFileName(content, file.FileName);
     }
@@ -284,7 +284,7 @@ public class ContentFileReference : IReadonlyFileReference
     public static string GenerateFilePath(Content content, string file)
     {
         var fileName = GenerateFileName(content, file);
-        return System.IO.Path.Combine(content.OtherSource, fileName);
+        return System.IO.Path.Combine(content.OtherSource.Replace(' ', '_'), fileName);
     }
 
     /// <summary>
@@ -297,9 +297,9 @@ public class ContentFileReference : IReadonlyFileReference
     public static string GenerateFileName(Content content, string file)
     {
         if (content.Id == 0) throw new ArgumentException("Parameter 'content.Id' must be greater than zero.", nameof(content));
-        if (String.IsNullOrWhiteSpace(content.OtherSource)) throw new ArgumentException("Parameter 'content.OtherSource' cannot be null, empty, or whitespace.", nameof(content));
+        if (String.IsNullOrWhiteSpace(content.OtherSource.Replace(' ', '_'))) throw new ArgumentException("Parameter 'content.OtherSource' cannot be null, empty, or whitespace.", nameof(content));
 
-        return $"{content.OtherSource}-{content.Id}{System.IO.Path.GetExtension(file)}";
+        return $"{content.OtherSource.Replace(' ', '_')}-{content.Id}{System.IO.Path.GetExtension(file)}";
     }
 
     /// <summary>

--- a/services/net/capture/CaptureAction.cs
+++ b/services/net/capture/CaptureAction.cs
@@ -1,16 +1,16 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using TNO.API.Areas.Services.Models.ContentReference;
 using TNO.API.Areas.Services.Models.Ingest;
+using TNO.Core.Exceptions;
 using TNO.Core.Extensions;
 using TNO.Entities;
-using TNO.Models.Extensions;
 using TNO.Kafka.Models;
+using TNO.Models.Extensions;
+using TNO.Services.Actions;
 using TNO.Services.Capture.Config;
 using TNO.Services.Command;
-using System.Diagnostics;
-using TNO.Core.Exceptions;
-using TNO.Services.Actions;
 
 namespace TNO.Services.Capture;
 
@@ -168,7 +168,7 @@ public class CaptureAction : CommandAction<CaptureOptions>
         var process = new Process();
         process.StartInfo.Verb = $"Stream Type";
         process.StartInfo.FileName = "/bin/sh";
-        process.StartInfo.Arguments = $"-c \"ffmpeg -i {file} 2>&1 | grep Video | awk '{{print $0}}' | tr -d ,\"";
+        process.StartInfo.Arguments = $"-c \"ffmpeg -i '{file}' 2>&1 | grep Video | awk '{{print $0}}' | tr -d ,\"";
         process.StartInfo.UseShellExecute = false;
         process.StartInfo.CreateNoWindow = true;
         process.StartInfo.RedirectStandardOutput = true;

--- a/services/net/transcription/TranscriptionManager.cs
+++ b/services/net/transcription/TranscriptionManager.cs
@@ -416,7 +416,7 @@ public class TranscriptionManager : ServiceManager<TranscriptionOptions>
         var process = new System.Diagnostics.Process();
         process.StartInfo.Verb = $"Stream Type";
         process.StartInfo.FileName = "/bin/sh";
-        process.StartInfo.Arguments = $"-c \"ffmpeg -i {srcFile} -y {destFile} 2>&1 \"";
+        process.StartInfo.Arguments = $"-c \"ffmpeg -i '{srcFile}' -y '{destFile}' 2>&1 \"";
         process.StartInfo.UseShellExecute = false;
         process.StartInfo.RedirectStandardOutput = true;
         process.StartInfo.CreateNoWindow = true;


### PR DESCRIPTION
Currently files are uploaded to a directly that named by the `Source.Code`.  If the code has a space it causes issues.  Code has been updated to replace a space with an underscore.