### PR TITLE
TNO-1794 Suppress transcript warning messages

### DIFF
--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -62,11 +62,7 @@ export const ViewContent: React.FC = () => {
         setWorkOrders([response.data, ...workOrders]);
 
         if (response.status === 200) toast.success('A transcript has been requested');
-        else if (response.status === 208) {
-          if (response.data.status === WorkOrderStatusName.Completed)
-            toast.warn('Content has already been transcribed');
-          else toast.warn(`An active request for transcription already exists`);
-        }
+        // In case of failure no message will be displayed to the Subscriber application user.
       }
     } catch {
       // Ignore this failure it is handled by our global ajax requests.


### PR DESCRIPTION
Suppress transcript warning messages on subscriber app.
Other status errors were hardcoded to ensure that the app would "eat" the warning messages. 