### PR TITLE
TNO-1835: Fix evening overview clip options

### DIFF
--- a/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
+++ b/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
@@ -43,7 +43,7 @@ export const OverviewGrid: React.FC<IOverviewGridProps> = ({ editable = true, in
    */
   const shouldFetch = React.useMemo(() => {
     return !values.sections[index].startTime.includes('_') && !!values.sections[index].startTime;
-  }, [values.sections[index].startTime]);
+  }, [index, values.sections]);
 
   /** fetch pieces of content that are related to the series to display as options for associated clips, search for clips published after the start time if it is specified - otherwise filter based on that day.*/
   React.useEffect(() => {

--- a/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
+++ b/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
@@ -38,28 +38,36 @@ export const OverviewGrid: React.FC<IOverviewGridProps> = ({ editable = true, in
   const items = values.sections[index].items;
   const startTime = values.sections[index]?.startTime?.split(':');
 
+  /** flag to keep track of when new complete start time is entered and trigger another search
+   * for relevant clips
+   */
+  const shouldFetch = React.useMemo(() => {
+    return !values.sections[index].startTime.includes('_') && !!values.sections[index].startTime;
+  }, [values.sections[index].startTime]);
+
   /** fetch pieces of content that are related to the series to display as options for associated clips, search for clips published after the start time if it is specified - otherwise filter based on that day.*/
   React.useEffect(() => {
-    findContent({
-      seriesId: values.sections[index].seriesId,
-      publishedStartOn: !!values.sections[index].startTime
-        ? moment()
-            .utcOffset(0)
-            .set({
-              hour: Number(startTime[0]),
-              minute: Number(startTime[1]),
-              second: Number(startTime[2]),
-              millisecond: 0,
-            })
-            .toISOString()
-        : moment().startOf('day').toISOString(),
-      contentTypes: [],
-    }).then((data) =>
-      setClips(data.items.map((c) => new OptionItem(c.headline, c.id)) as IOptionItem[]),
-    );
-    // only want to fire once
+    if (shouldFetch) {
+      findContent({
+        seriesId: values.sections[index].seriesId,
+        publishedStartOn: !!values.sections[index].startTime
+          ? moment()
+              .set({
+                hour: Number(startTime[0]),
+                minute: Number(startTime[1]),
+                second: Number(startTime[2]),
+                millisecond: 0,
+              })
+              .toISOString()
+          : moment().startOf('day').toISOString(),
+        contentTypes: [],
+      }).then((data) =>
+        setClips(data.items.map((c) => new OptionItem(c.headline, c.id)) as IOptionItem[]),
+      );
+    }
+    // only want to fire on init, and when start time is changed
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [shouldFetch]);
 
   /** function that runs after a user drops an item in the list */
   const handleDrop = (droppedItem: any) => {


### PR DESCRIPTION
Not sure exactly what time it did this; however, the timezone was wrong so it would jump forward a day on the content filter resulting in no options when doing the evening report. If you tested it before 5ish it would work but not otherwise.

![image](https://github.com/bcgov/tno/assets/15724124/09805aa7-9f6c-413a-a406-57d3d16eb850)
