### PR TITLE
Subscriber site double scrollbar fix

### DIFF
--- a/app/subscriber/src/components/sidebar/styled/CustomSidebar.tsx
+++ b/app/subscriber/src/components/sidebar/styled/CustomSidebar.tsx
@@ -30,7 +30,7 @@ export const CustomSidebar = styled(Sidebar)`
         return props.theme.css.testBackgroundColor;
       else return props.theme.css.productionBackgroundColor;
     }};
-    padding: 0.65rem;
+    padding: 0.5rem;
   }
 
   .ps-sidebar-root {
@@ -67,6 +67,10 @@ export const CustomSidebar = styled(Sidebar)`
       padding-left: 6px !important;
       padding-right: 6px !important;
     }
+    @media (max-height: 770px) {
+      /* important tag needed as we are fighting the library */
+      height: 40px !important;
+    }
     /* again need to override defaults */
     &:hover {
       background-color: ${(props) => props.theme.css.selectedMenuItemColor} !important;
@@ -74,7 +78,7 @@ export const CustomSidebar = styled(Sidebar)`
   }
   .ps-menuitem-root {
     color: white;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.25rem;
   }
 
   .ps-menuitem-root:not(.selected) {


### PR DESCRIPTION
Since our menu has been growing vertically it was causing some funky behaviour with scroll bars. The sidebar height is now more dynamic depending on the users device.

![sidebarheight](https://github.com/bcgov/tno/assets/15724124/8f56152f-eb52-4599-8bd6-46399f6cf158)
