### PR TITLE
TNO-1531 Fix invalid fitler date settings

### DIFF
--- a/app/editor/src/features/admin/filters/FilterForm.tsx
+++ b/app/editor/src/features/admin/filters/FilterForm.tsx
@@ -48,9 +48,11 @@ export const FilterForm: React.FC<IFilterFormProps> = () => {
   React.useEffect(() => {
     if (!!filterId && filter?.id !== filterId) {
       setFilter({ ...defaultFilter, id: filterId }); // Do this to stop double fetch.
-      getFilter(filterId).then((data) => {
-        setFilter(data);
-      });
+      getFilter(filterId)
+        .then((data) => {
+          setFilter(data);
+        })
+        .catch(() => {});
     }
   }, [getFilter, filter?.id, filterId]);
 

--- a/app/editor/src/features/admin/filters/FilterFormImportExport.tsx
+++ b/app/editor/src/features/admin/filters/FilterFormImportExport.tsx
@@ -7,6 +7,7 @@ import { useFormikContext } from 'formik';
 import { highlight, languages } from 'prismjs';
 import React from 'react';
 import Editor from 'react-simple-code-editor';
+import { toast } from 'react-toastify';
 import { useLookupOptions } from 'store/hooks';
 import {
   Button,
@@ -32,19 +33,27 @@ export const FilterFormImportExport: React.FC = () => {
   const [rawFilter, setRawFilter] = React.useState('{}');
 
   const parseImport = React.useCallback(
-    (rawExportedFilter: any) => {
-      var importedFilter = parseExportedFilter(
-        rawExportedFilter,
-        actions,
-        contributors,
-        series,
-        sources,
-        products,
-      );
-      setValues({ ...importedFilter });
+    (data: string) => {
+      try {
+        const rawExportedFilter = JSON.parse(data);
 
-      const query = generateQuery(importedFilter.settings as IFilterSettingsModel, null);
-      setFieldValue('query', query);
+        var importedFilter = parseExportedFilter(
+          rawExportedFilter,
+          actions,
+          contributors,
+          series,
+          sources,
+          products,
+        );
+        setValues({ ...importedFilter });
+
+        const query = generateQuery(importedFilter.settings as IFilterSettingsModel, null);
+        setFieldValue('query', query);
+      } catch (ex) {
+        const error = ex as Error;
+        console.error(ex);
+        toast.error(error.message);
+      }
     },
     [setValues, setFieldValue, actions, contributors, series, sources, products],
   );
@@ -60,7 +69,7 @@ export const FilterFormImportExport: React.FC = () => {
           <Button
             variant={ButtonVariant.secondary}
             onClick={() => {
-              parseImport(JSON.parse(rawFilter));
+              parseImport(rawFilter);
             }}
           >
             Import Filter

--- a/app/editor/src/features/admin/filters/FilterFormQuery.tsx
+++ b/app/editor/src/features/admin/filters/FilterFormQuery.tsx
@@ -4,6 +4,7 @@ import 'prismjs/components/prism-cshtml';
 import 'prismjs/components/prism-json';
 
 import { useFormikContext } from 'formik';
+import moment from 'moment';
 import { highlight, languages } from 'prismjs';
 import React from 'react';
 import Editor from 'react-simple-code-editor';
@@ -40,6 +41,13 @@ export const FilterFormQuery: React.FC = () => {
   const [filter, setFilter] = React.useState(JSON.stringify(values.query, null, 2));
   const [actionOptions, setActionOptions] = React.useState(getActionOptions(actions));
   const [tagOptions, setTagOptions] = React.useState(getTagOptions(tags));
+
+  const startDate = values.settings.startDate
+    ? moment(values.settings.startDate).format('YYYY/MM/DD')
+    : '';
+  const endDate = values.settings.endDate
+    ? moment(values.settings.endDate).format('YYYY/MM/DD')
+    : '';
 
   React.useEffect(() => {
     setActionOptions(getActionOptions(actions));
@@ -175,24 +183,28 @@ export const FilterFormQuery: React.FC = () => {
             <FormikDatePicker
               name="settings.startDate"
               label="Start Date"
-              value={values.settings.startDate ?? ''}
-              width="13ch"
+              value={startDate}
+              selectedDate={startDate}
+              width="15ch"
               onChange={(value) => {
                 updateQuery('startDate', value);
               }}
               disabled={!!values.settings.dateOffset}
+              isClearable={true}
             />
           </Col>
           <Col>
             <FormikDatePicker
               name="settings.endDate"
               label="End Date"
-              value={values.settings.endDate ?? ''}
-              width="13ch"
+              value={endDate}
+              selectedDate={endDate}
+              width="15ch"
               onChange={(value) => {
                 updateQuery('endDate', value);
               }}
               disabled={!!values.settings.dateOffset}
+              isClearable={true}
             />
           </Col>
           <Row nowrap>

--- a/app/subscriber/src/features/content/list-view/interfaces/IContentListFilter.ts
+++ b/app/subscriber/src/features/content/list-view/interfaces/IContentListFilter.ts
@@ -23,7 +23,7 @@ export interface IContentListFilter {
   searchTerm?: string;
   topStory?: boolean;
   userId?: number | '';
-  useUnpublished?: boolean;
+  useUnpublished?: boolean; // TODO: Rename 'searchUnpublished' to be consistent with filter settings.
   inHeadline?: boolean;
   inByline?: boolean;
   inStory?: boolean;

--- a/app/subscriber/src/features/my-searches/FilterFormDetails.tsx
+++ b/app/subscriber/src/features/my-searches/FilterFormDetails.tsx
@@ -1,4 +1,5 @@
 import { useFormikContext } from 'formik';
+import moment from 'moment';
 import React from 'react';
 import { useLookupOptions } from 'store/hooks';
 import { getActionOptions } from 'store/hooks/subscriber/getActionOptions';
@@ -34,6 +35,13 @@ export const FilterFormDetails: React.FC = () => {
   const [, setFilter] = React.useState(JSON.stringify(values.query, null, 2));
   const [actionOptions, setActionOptions] = React.useState(getActionOptions(actions));
   const [tagOptions, setTagOptions] = React.useState(getTagOptions(tags));
+
+  const startDate = values.settings.startDate
+    ? moment(values.settings.startDate).format('YYYY/MM/DD')
+    : '';
+  const endDate = values.settings.endDate
+    ? moment(values.settings.endDate).format('YYYY/MM/DD')
+    : '';
 
   React.useEffect(() => {
     setActionOptions(getActionOptions(actions));
@@ -124,22 +132,26 @@ export const FilterFormDetails: React.FC = () => {
           <FormikDatePicker
             name="settings.startDate"
             label="Start Date"
-            value={values.settings.startDate ?? ''}
-            width="13ch"
+            value={startDate}
+            selectedDate={startDate}
+            width="15ch"
             onChange={(value) => {
               updateQuery('startDate', value);
             }}
+            isClearable={true}
           />
         </Col>
         <Col>
           <FormikDatePicker
             name="settings.endDate"
             label="End Date"
-            value={values.settings.endDate ?? ''}
-            width="13ch"
+            value={endDate}
+            selectedDate={endDate}
+            width="15ch"
             onChange={(value) => {
               updateQuery('endDate', value);
             }}
+            isClearable={true}
           />
         </Col>
       </Row>

--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -58,26 +58,26 @@ export const SearchPage: React.FC = () => {
   const advancedSubscriberFilter: IContentListFilter & Partial<IContentListAdvancedFilter> =
     React.useMemo(() => {
       return {
-        actions: search.actions?.map((v: any) => convertTo(v, 'string', undefined)),
-        contentTypes: [],
-        endDate: urlParams.get('publishedEndOn') ?? '',
-        hasFile: urlParams.get('hasFile') === 'true' ?? false,
-        headline: urlParams.get('headline') ?? '',
+        useUnpublished: urlParams.get('useUnpublished') === 'true' ?? false,
+        keyword: urlParams.get('keyword') ?? '',
+        searchTerm: urlParams.get('searchTerm') ?? '',
         inByline: urlParams.get('inByline') === 'true' ?? false,
         inHeadline: urlParams.get('inHeadline') === 'true' ?? false,
         inStory: urlParams.get('inStory') === 'true' ?? false,
-        keyword: urlParams.get('keyword') ?? '',
+        contentTypes: [],
+        actions: search.actions?.map((v: any) => convertTo(v, 'string', undefined)),
+        hasFile: urlParams.get('hasFile') === 'true' ?? false,
+        headline: urlParams.get('headline') ?? '',
         pageIndex: convertTo(urlParams.get('pageIndex'), 'number', 0),
         pageSize: convertTo(urlParams.get('pageSize'), 'number', 100),
-        sort: [],
         sourceIds: search.sourceIds?.map((v: any) => convertTo(v, 'number', undefined)),
         productIds: search.productIds?.map((v: any) => convertTo(v, 'number', undefined)),
         sentiment: search.sentiment?.map((v: any) => convertTo(v, 'number', undefined)),
-        searchTerm: urlParams.get('searchTerm') ?? '',
         startDate: urlParams.get('publishedStartOn') ?? '',
+        endDate: urlParams.get('publishedEndOn') ?? '',
         storyText: urlParams.get('storyText') ?? '',
         boldKeywords: urlParams.get('boldKeywords') === 'true' ?? '',
-        useUnpublished: urlParams.get('useUnpublished') === 'true' ?? false,
+        sort: [],
       };
       // only want this to update when the query changes
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/subscriber/src/features/search-page/utils/filterFormat.ts
+++ b/app/subscriber/src/features/search-page/utils/filterFormat.ts
@@ -7,8 +7,13 @@ import { IFilterSettingsModel } from 'tno-core';
 
 export const filterFormat = (filter: IContentListFilter & Partial<IContentListAdvancedFilter>) => {
   const settings: IFilterSettingsModel = {
+    size: 0,
     startDate: filter.startDate ?? undefined,
-    endDate: !filter.endDate ? `${moment(filter.startDate).endOf('day')}` : filter.endDate,
+    endDate: filter.endDate
+      ? filter.endDate
+      : filter.startDate
+      ? `${moment(filter.startDate).endOf('day')}`
+      : undefined,
     searchUnpublished: filter.useUnpublished ?? false,
     inHeadline: filter.inHeadline ?? false,
     inByline: filter.inByline ?? false,
@@ -17,11 +22,10 @@ export const filterFormat = (filter: IContentListFilter & Partial<IContentListAd
     sourceIds: filter.sourceIds ?? [],
     productIds: filter.productIds ?? [],
     search: filter.searchTerm,
-    size: 0,
     seriesIds: [],
     contributorIds: [],
     actions: [],
-    contentTypes: [],
+    contentTypes: filter.contentTypes,
     tags: [],
   };
 

--- a/openshift/kustomize/tekton/base/tasks/deploy-all.yaml
+++ b/openshift/kustomize/tekton/base/tasks/deploy-all.yaml
@@ -56,11 +56,26 @@ spec:
         fi
 
         # An array of all the objects for the solution.
+
         INGEST=("filemonitor" "image" "syndication" "capture" "contentmigration")
-        PROCESSING=("content" "filecopy" "indexing" "nlp" "notification" "reporting" "transcription" "clip" "scheduler")
+        PROCESSING=("content" "filecopy" "indexing" "nlp" "notification" "reporting" "transcription" "clip" "scheduler" "folder-collection")
         APPS=("api" "editor" "subscriber" "charts-api")
         SERVICES=(${INGEST[@]} ${PROCESSING[@]})
         COMPONENTS=(${INGEST[@]} ${PROCESSING[@]} {APPS[@]})
+
+        declare -A COMPONENT0=(
+          [name]="filemonitor"
+          [image]="filemonitor-service"
+          [type]="dc"
+          [replicas]="1"
+          [action]="stop"
+        )
+
+        declare -n component;
+        for component in ${!COMPONENT@}; do
+
+        done
+
         declare -A IMAGES=(["api"]="api" ["editor"]="editor" ["subscriber"]="subscriber" ["charts-api"]="charts-api" ["content"]="content-service" ["filecopy"]="filecopy-service" ["filemonitor"]="filemonitor-service" ["image"]="image-service" ["indexing"]="indexing-service" ["nlp"]="nlp-service" ["notification"]="notification-service" ["reporting"]="reporting-service" ["syndication"]="syndication-service" ["transcription"]="transcription-service" ["capture"]="capture-service" ["clip"]="clip-service" ["scheduler"]="scheduler-service" ["contentmigration"]= "contentmigration-service")
         declare -A OBJECTS=(["api"]="sts" ["editor"]="dc" ["subscriber"]="dc" ["charts-api"]="dc" ["content"]="dc" ["filecopy"]="dc" ["filemonitor"]="dc" ["image"]="dc" ["indexing"]="dc" ["nlp"]="dc" ["notification"]="dc" ["reporting"]="dc" ["syndication"]="dc" ["transcription"]="dc" ["capture"]="dc" ["clip"]="dc" ["scheduler"]="dc" ["contentmigration"]="dc")
         declare -A REPLICAS=(["content"]="2" ["filecopy"]="1" ["filemonitor"]="1" ["image"]="1" ["indexing"]="2" ["nlp"]="1" ["notification"]="1" ["reporting"]="1" ["syndication"]="1" ["transcription"]="2" ["capture"]="0" ["clip"]="0" ["scheduler"]=1 ["contentmigration"]=1)


### PR DESCRIPTION
The dates saved by the Subscriber app searches were invalid when they were empty strings.  This "used" to work because we were using the `any` type and ignoring bad data.  Now we have strong types to reduce this type of issue.

I've also fixed the DatePicker component implementation for the Filter forms.  We can now clear the value and it properly formats.