### PR TITLE
TNO-1839 Mask and state fix

### DIFF
--- a/app/editor/src/features/content/form/ContentStoryForm.tsx
+++ b/app/editor/src/features/content/form/ContentStoryForm.tsx
@@ -57,6 +57,15 @@ export const ContentStoryForm: React.FC<IContentStoryFormProps> = ({
   const source = sources.find((s) => s.id === values.sourceId);
   const program = series.find((s) => s.id === values.seriesId);
 
+  const setHours = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const date = new Date(values.publishedOn);
+    const hours = e.target.value?.split(':');
+    if (!!hours && !!e.target.value && !e.target.value.includes('_')) {
+      date.setHours(Number(hours[0]), Number(hours[1]), Number(hours[2]));
+      setFieldValue('publishedOn', moment(date.toISOString()).format('MMM D, yyyy HH:mm:ss'));
+    }
+  };
+
   React.useEffect(() => {
     setFieldValue(
       'publishedOnTime',
@@ -114,16 +123,14 @@ export const ContentStoryForm: React.FC<IContentStoryFormProps> = ({
                 width="7em"
                 value={!!values.publishedOn ? values.publishedOnTime : ''}
                 placeholder={!!values.publishedOn ? values.publishedOnTime : 'HH:MM:SS'}
-                onChange={(e) => {
-                  const date = new Date(values.publishedOn);
-                  const hours = e.target.value?.split(':');
-                  if (!!hours && !!e.target.value && !e.target.value.includes('_')) {
-                    date.setHours(Number(hours[0]), Number(hours[1]), Number(hours[2]));
-                    setFieldValue(
-                      'publishedOn',
-                      moment(date.toISOString()).format('MMM D, yyyy HH:mm:ss'),
-                    );
+                onBlur={(e) => {
+                  if (e.target.value.indexOf('_')) {
+                    e.target.value = e.target.value.replaceAll('_', '0');
+                    setHours(e);
                   }
+                }}
+                onChange={(e) => {
+                  setHours(e);
                 }}
               />
             </Show>


### PR DESCRIPTION
Problem source:
When the mask was not fully filled (still had the _) the validation would fail and the state was not set. So when there was a change anywhere else, the state would go back to the previous state.

Solution:
When leaving the field (onBlur) I checked for _ characters and replaced with zeros, so it would be ok to convert 12:00:__ to 12:00:00 or even 12:__:__ to 12:00:00, and then set the state with a valid field.