### PR TITLE
TNO-1866: Change search filters for Press Gallery 

### DIFF
--- a/app/subscriber/src/features/press-gallery/PressGallery.tsx
+++ b/app/subscriber/src/features/press-gallery/PressGallery.tsx
@@ -1,19 +1,22 @@
 import { MsearchMultisearchBody } from '@elastic/elasticsearch/lib/api/types';
-import { DateFilter } from 'components/date-filter';
 import { FolderSubMenu } from 'components/folder-sub-menu';
 import { determineColumns } from 'features/home/constants';
 import moment from 'moment';
 import React from 'react';
+import { FiRefreshCcw } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
 import { useContent } from 'store/hooks';
 import { useContributors } from 'store/hooks/subscriber/useContributors';
 import {
+  FieldSize,
   FlexboxTable,
   generateQuery,
   IContentModel,
   IFilterSettingsModel,
+  IOptionItem,
   ITableInternalRow,
   Row,
+  Select,
 } from 'tno-core';
 
 import * as styled from './styled';
@@ -24,36 +27,85 @@ export const PressGallery: React.FC = () => {
   const [{ filterAdvanced }, { findContentWithElasticsearch }] = useContent();
   const [, api] = useContributors();
   const [results, setResults] = React.useState<any>([]);
+  const [pressMembers, setPressMembers] = React.useState<any[]>([]);
   const [selected, setSelected] = React.useState<IContentModel[]>([]);
+  const [dateOptions, setDateOptions] = React.useState<any[]>([]);
+  const [aliases, setAliases] = React.useState<any[]>([]);
 
-  const [pressSettings, setPressSettings] = React.useState<IFilterSettingsModel>(
-    createFilterSettings(
-      `${moment(filterAdvanced.startDate)}`,
-      `${moment(filterAdvanced.startDate).endOf('day')}`,
-    ),
+  const [dateValue, setDateValue] = React.useState<IOptionItem | null>();
+  const [pressValue, setPressValue] = React.useState<IOptionItem | null>();
+
+  const [pressSettings] = React.useState<IFilterSettingsModel>(
+    createFilterSettings(`${moment().startOf('day')}`, `${moment().subtract('2', 'weeks')}`),
   );
-  const [pressQuery, setPressQuery] = React.useState<any>();
+  React.useEffect(() => {
+    // create for loop with a cap of 7 days
+    let dates: any[] = [];
+    for (let i = 0; i < 7; i++) {
+      dates.push({
+        label: `${moment().subtract(i, 'days').format('YYYY-MM-DD')}`,
+        value: `${moment().subtract(i, 'days')}`,
+      });
+    }
+    setDateOptions(dates);
+  }, []);
 
-  /**
-   * Update the settings and query values based on the new key=value.
-   */
-  const updateQuery = React.useCallback(
-    (key: string, value: any) => {
-      var settings = { ...pressSettings };
-      settings[key] = value;
-      if (key === 'dateOffset') {
-        settings = { ...settings, startDate: undefined, endDate: undefined };
-      } else if (key === 'startDate' || key === 'endDate') {
-        settings = { ...settings, dateOffset: undefined };
-      }
-      const query = generateQuery(settings, pressQuery);
-      setPressSettings(settings);
-      setPressQuery(query);
-    },
-    [pressQuery, pressSettings],
-  );
+  React.useEffect(() => {
+    api.findAllContributors().then((contributors) => {
+      setPressMembers(contributors.filter((contributor) => contributor.isPress));
+      const allAliases = contributors
+        .filter((c) => c.isPress)
+        .map((contributor) => {
+          if (!!contributor.aliases) {
+            return contributor.aliases;
+          } else {
+            return contributor.name;
+          }
+        });
+      setAliases(allAliases);
+    });
+  }, []);
 
-  React.useEffect(() => {}, [filterAdvanced.startDate]);
+  React.useEffect(() => {
+    fetchResults(
+      generateQuery({
+        ...pressSettings,
+        defaultSearchOperator: 'or',
+        search: aliases.toString().split(',').join(' '),
+        startDate: `${moment(filterAdvanced.startDate).subtract(2, 'weeks')}`,
+        endDate: `${moment()}`,
+      }),
+    );
+  }, [aliases.length]);
+
+  React.useEffect(() => {
+    pressMembers.forEach((contributor) => {
+      fetchResultHits(
+        generateQuery({
+          ...pressSettings,
+          search: contributor.aliases,
+          startDate: `${moment(filterAdvanced.startDate).subtract(2, 'weeks')}`,
+          endDate: `${moment()}`,
+        }),
+        contributor.name,
+      );
+    });
+  }, [pressMembers.length]);
+
+  React.useEffect(() => {
+    dateOptions.forEach((date) => {
+      fetchResultHits(
+        generateQuery({
+          ...pressSettings,
+          search: aliases.toString().split(',').join(' '),
+          startDate: `${moment(date.value).startOf('day')}`,
+          endDate: `${moment(date.value).endOf('day')}`,
+        }),
+        '',
+        date.value,
+      );
+    });
+  }, [dateOptions.length]);
 
   const fetchResults = React.useCallback(
     async (filter: MsearchMultisearchBody) => {
@@ -65,42 +117,23 @@ export const PressGallery: React.FC = () => {
     [findContentWithElasticsearch],
   );
 
-  /** Get all the contributors that are marked as press */
-  React.useEffect(() => {
-    getPressContributorAliases();
-
-    // Only want this to run when the date is updated or on initial load
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filterAdvanced.startDate]);
-
-  // async function to fetch the press enable contributors and update the search query with appropriate aliases
-  const getPressContributorAliases = React.useCallback(async () => {
-    // regex to match words separated by space or comma, and treat words surrounded by quotes as one value
-    const regex = /"[^"]+"|\w+/g;
-    const contributors = await api.findAllContributors();
-    const aliases = contributors
-      .filter((contributor) => contributor.isPress)
-      .map((contributor) => {
-        if (!!contributor.aliases) {
-          return contributor.aliases.match(regex);
-        } else {
-          return contributor.name;
-        }
-      });
-    updateQuery('search', aliases.toString().split(',').join(' '));
-    fetchResults(
-      generateQuery(
-        {
-          ...pressSettings,
-          startDate: `${moment(filterAdvanced.startDate)}`,
-          endDate: `${moment(filterAdvanced.startDate).endOf('day')}`,
-        },
-        pressQuery,
-      ),
-    );
-    // only want to trigger when date changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filterAdvanced.startDate]);
+  /** separate requests to find total hits for each press member */
+  const fetchResultHits = React.useCallback(
+    async (filter: MsearchMultisearchBody, name?: string, date?: string) => {
+      try {
+        const res: any = await findContentWithElasticsearch(filter, false);
+        if (!!name)
+          setPressMembers((pressMembers) =>
+            pressMembers.map((c) => (c.name === name ? { ...c, hits: res.hits.total.value } : c)),
+          );
+        if (!!date)
+          setDateOptions((dates) =>
+            dates.map((d) => (d.value === date ? { ...d, hits: res.hits.total.value } : d)),
+          );
+      } catch {}
+    },
+    [findContentWithElasticsearch],
+  );
 
   /** controls the checking and unchecking of rows in the list view */
   const handleSelectedRowsChanged = (row: ITableInternalRow<IContentModel>) => {
@@ -113,8 +146,86 @@ export const PressGallery: React.FC = () => {
 
   return (
     <styled.PressGallery>
-      <FolderSubMenu selectedContent={selected} />
-      <DateFilter />
+      <Row className="tool-bar">
+        <Select
+          width={FieldSize.Medium}
+          name="select-press-member"
+          placeholder={'Select a press member'}
+          isClearable={false}
+          clearValue={() => setPressValue(null)}
+          value={pressValue}
+          onChange={(e: any) => {
+            if (!!e.value) {
+              setPressValue(e);
+              // can only use one of the two filters
+              setDateValue(null);
+              fetchResults(
+                generateQuery({
+                  ...pressSettings,
+                  defaultSearchOperator: 'or',
+                  search: pressMembers.find((c) => c.name === e.value)?.aliases ?? '',
+                  startDate: `${moment().subtract(2, 'weeks')}`,
+                  endDate: `${moment()}`,
+                }),
+              );
+            }
+          }}
+          options={pressMembers.map((c) => {
+            return {
+              label: `${c.name} (${c.hits ?? 0})`,
+              value: c.alias ?? c.name,
+            };
+          })}
+        />
+        <p className="or">or</p>
+        <Select
+          value={dateValue}
+          isClearable={false}
+          options={dateOptions.map((d) => {
+            return {
+              label: `${d.label} (${d.hits ?? 0})`,
+              value: d.value,
+            };
+          })}
+          placeholder={'Select a date'}
+          clearValue={() => setDateValue(undefined)}
+          onChange={(e: any) => {
+            if (!!e.value) {
+              setDateValue(e);
+              // can only use one of the two filters
+              setPressValue(null);
+              fetchResults(
+                generateQuery({
+                  ...pressSettings,
+                  defaultSearchOperator: 'or',
+                  search: aliases.toString().split(',').join(' '),
+                  startDate: `${moment(e.value).startOf('day')}`,
+                  endDate: `${moment(e.value).endOf('day')}`,
+                }),
+              );
+            }
+          }}
+          name="date-select"
+          width={FieldSize.Medium}
+        />
+        <FiRefreshCcw
+          className="reset"
+          onClick={() => {
+            setDateValue(null);
+            setPressValue(null);
+            fetchResults(
+              generateQuery({
+                ...pressSettings,
+                defaultSearchOperator: 'or',
+                search: aliases.toString().split(',').join(' '),
+                startDate: `${moment(filterAdvanced.startDate).subtract(2, 'weeks')}`,
+                endDate: `${moment()}`,
+              }),
+            );
+          }}
+        />
+        <FolderSubMenu selectedContent={selected} />
+      </Row>
       <Row className="table-container">
         <FlexboxTable
           rowId="id"

--- a/app/subscriber/src/features/press-gallery/interfaces/IDateOptions.tsx
+++ b/app/subscriber/src/features/press-gallery/interfaces/IDateOptions.tsx
@@ -1,0 +1,5 @@
+import { IOptionItem } from 'tno-core';
+
+export interface IDateOptions extends IOptionItem {
+  hits?: number;
+}

--- a/app/subscriber/src/features/press-gallery/interfaces/IPressMember.tsx
+++ b/app/subscriber/src/features/press-gallery/interfaces/IPressMember.tsx
@@ -1,0 +1,5 @@
+import { IContributorModel } from 'tno-core';
+
+export interface IPressMember extends IContributorModel {
+  hits?: number;
+}

--- a/app/subscriber/src/features/press-gallery/interfaces/index.ts
+++ b/app/subscriber/src/features/press-gallery/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from './IDateOptions';
+export * from './IPressMember';

--- a/app/subscriber/src/features/press-gallery/styled/PressGallery.tsx
+++ b/app/subscriber/src/features/press-gallery/styled/PressGallery.tsx
@@ -1,6 +1,21 @@
 import styled from 'styled-components';
 
 export const PressGallery = styled.div`
+  .tool-bar {
+    .folder-sub-menu {
+      margin-left: auto;
+    }
+    .or {
+      margin-right: 0.5em;
+    }
+    .date-navigator {
+      margin-left: auto;
+      margin-right: auto;
+      input {
+        margin-top: 0.25em;
+      }
+    }
+  }
   .table {
     width: 100%;
     .group {

--- a/app/subscriber/src/features/press-gallery/styled/PressGallery.tsx
+++ b/app/subscriber/src/features/press-gallery/styled/PressGallery.tsx
@@ -2,6 +2,14 @@ import styled from 'styled-components';
 
 export const PressGallery = styled.div`
   .tool-bar {
+    .reset {
+      margin-top: 0.5em;
+      margin-left: 0.5em;
+      &:hover {
+        cursor: pointer;
+        transform: scale(1.1);
+      }
+    }
     .folder-sub-menu {
       margin-left: auto;
     }

--- a/app/subscriber/src/features/press-gallery/utils/generateDates.ts
+++ b/app/subscriber/src/features/press-gallery/utils/generateDates.ts
@@ -1,0 +1,13 @@
+import moment from 'moment';
+
+/** function that generates dates for the  last 7 days */
+export const generateDates = () => {
+  const dates: any = Array.from({ length: 7 }, (_, i) => {
+    const date = moment().subtract(i, 'days');
+    return {
+      label: date.format('YYYY-MM-DD'),
+      value: date.format(),
+    };
+  });
+  return dates;
+};

--- a/app/subscriber/src/features/press-gallery/utils/index.ts
+++ b/app/subscriber/src/features/press-gallery/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './createFilterSettings';
+export * from './generateDates';


### PR DESCRIPTION
Based off of Scott's comments - I need to look at this again in a little bit with fresh eyes

- user can filter by either press member OR date 
- user can see preview of how many pieces of content are associated with query by looking at the numeric value following the label
- one input will automatically clear when selecting the other 

I will be posting the comment below for clarity, I think that this may need to be broken up into more tickets as it is rather complex.

**Criteria:**
```
Please add a toggle option so clients can sort by Date or Member.

If sorted by Member all Press Gallery reporters should be listed in alphabetic order by their first name, followed by a number indicating the number or returned items for the last two weeks.

Keith Baldrey (8)

Mike Smyth (9)

Vaughn Palmer (10)

When a client clicks on reporter's name, all returned items should appear sorted by Type - print, news radio, talk radio, etc.

If no content is found for that type a list of the last seven days should appear indicating the number of content for that day:

20230-10-02 (Monday)
2023-10-01 (Sunday)
2023-09-30 (Saturday)
2023-09-29 (Friday)
2023-09-28 (Thursday)

IF the client selects Date, the days of the week should appear with the option to click on the specific date. The number preceding the date should be the number for returns.

10 - 20230-10-02 (Monday)
20 - 2023-10-01 (Sunday)
3 - 2023-09-30 (Saturday)
4 - 2023-09-29 (Friday)
10 - 2023-09-28 (Thursday)

If the client clicks on 20 - 2023-10-01, all twenty items should be returned divided by reporter and then medium.

The headlines for each item should by clickable and open up into that item in the normal content view.
```