### PR TITLE
TNO-1889: Invalid start date on save (when left blank)

### DIFF
--- a/app/subscriber/src/features/search-page/utils/filterFormat.ts
+++ b/app/subscriber/src/features/search-page/utils/filterFormat.ts
@@ -8,7 +8,7 @@ import { IFilterSettingsModel } from 'tno-core';
 export const filterFormat = (filter: IContentListFilter & Partial<IContentListAdvancedFilter>) => {
   const settings: IFilterSettingsModel = {
     size: 0,
-    startDate: filter.startDate ?? undefined,
+    startDate: !!filter.startDate ? filter.startDate : undefined,
     endDate: filter.endDate
       ? filter.endDate
       : filter.startDate


### PR DESCRIPTION
The startDate empty string will no longer be passed through when saving a search.