### PR TITLE
[Now Review Ready ✅] TNO-1904: Add events filter

### DIFF
--- a/app/subscriber/src/components/date-filter/DateFilter.tsx
+++ b/app/subscriber/src/components/date-filter/DateFilter.tsx
@@ -11,7 +11,9 @@ export interface IDateFilterProps {}
 export const DateFilter: React.FC<IDateFilterProps> = () => {
   const [{ filterAdvanced }, { storeFilterAdvanced }] = useContent();
   /** default to today's date or the filters previously saved date if present */
-  const [date, setDate] = React.useState<Date>(new Date(filterAdvanced.startDate ?? ''));
+  const [date, setDate] = React.useState<Date>(
+    !!filterAdvanced.startDate ? new Date(filterAdvanced.startDate) : new Date(),
+  );
   /** control state of open calendar from outside components. i.e custom calendar button */
   const [open, setOpen] = React.useState(false);
 

--- a/app/subscriber/src/components/date-filter/DateFilter.tsx
+++ b/app/subscriber/src/components/date-filter/DateFilter.tsx
@@ -9,11 +9,11 @@ export interface IDateFilterProps {}
 
 /** Custom date filter for the subscriber home page. Control the calendar state with custom button, custom styling also applied. Also allows user to navigate a day at a time via arrow buttons. */
 export const DateFilter: React.FC<IDateFilterProps> = () => {
-  /** default to today's date */
-  const [date, setDate] = React.useState<Date>(new Date());
+  const [{ filterAdvanced }, { storeFilterAdvanced }] = useContent();
+  /** default to today's date or the filters previously saved date if present */
+  const [date, setDate] = React.useState<Date>(new Date(filterAdvanced.startDate ?? ''));
   /** control state of open calendar from outside components. i.e custom calendar button */
   const [open, setOpen] = React.useState(false);
-  const [{ filterAdvanced }, { storeFilterAdvanced }] = useContent();
 
   /** close calendar after a date has been selected, and fetch related content */
   React.useEffect(() => {

--- a/app/subscriber/src/features/home/Home.tsx
+++ b/app/subscriber/src/features/home/Home.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { FaEllipsisVertical } from 'react-icons/fa6';
 import { useNavigate } from 'react-router-dom';
 import { Tooltip } from 'react-tooltip';
-import { useContent, useLookup } from 'store/hooks';
+import { useContent } from 'store/hooks';
 import {
   Checkbox,
   Col,
@@ -29,7 +29,7 @@ import * as styled from './styled';
  * Home component that will be rendered when the user is logged in.
  */
 export const Home: React.FC = () => {
-  const [{ filter, filterAdvanced }, { findContent, findContentWithElasticsearch }] = useContent();
+  const [{ filter, filterAdvanced }, { findContentWithElasticsearch }] = useContent();
   const [homeItems, setHomeItems] = React.useState<IContentModel[]>([]);
   const [selected, setSelected] = React.useState<IContentModel[]>([]);
   const [disabledCols, setDisabledCols] = React.useState<string[]>([]);
@@ -43,8 +43,6 @@ export const Home: React.FC = () => {
     ),
   );
 
-  const [, setLoading] = React.useState(false);
-
   const fetchResults = React.useCallback(
     async (filter: MsearchMultisearchBody) => {
       try {
@@ -56,7 +54,6 @@ export const Home: React.FC = () => {
   );
 
   React.useEffect(() => {
-    // only fetch once the aliases are ready
     fetchResults(
       generateQuery({
         ...settings,

--- a/app/subscriber/src/features/home/constants/HomeFilterType.ts
+++ b/app/subscriber/src/features/home/constants/HomeFilterType.ts
@@ -4,4 +4,5 @@ export enum HomeFilterType {
   Internet = 'internet',
   CPNews = 'cpNews',
   All = 'all',
+  Events = 'events',
 }

--- a/app/subscriber/src/features/home/home-filters/HomeFilters.tsx
+++ b/app/subscriber/src/features/home/home-filters/HomeFilters.tsx
@@ -76,7 +76,6 @@ export const HomeFilters: React.FC<IHomeFilterProps> = () => {
             setActive(HomeFilterType.Internet);
             break;
           }
-          break;
         default:
           setActive(!!filter.productIds?.length ? HomeFilterType.Events : HomeFilterType.All);
       }


### PR DESCRIPTION
In this PR:

- persist date so when the user views a piece of content and navigates back, the date filter is on the appropriate date
- add events filter to the home screen to show contents tagged with the events product id
- rework home page to use elastic queries like the rest of the application

![tno-1904](https://github.com/bcgov/tno/assets/15724124/fc9d8a4c-6ed3-4f20-a2ea-6e4a834cc35e)
