### PR TITLE
TNO-1943 Update Papers filter

### DIFF
--- a/app/editor/src/features/content/papers/constants/defaultPaperFilter.ts
+++ b/app/editor/src/features/content/papers/constants/defaultPaperFilter.ts
@@ -13,7 +13,7 @@ export const defaultPaperFilter = (sources: ISourceModel[] = []): IContentListFi
   return {
     pageIndex: defaultPage.pageIndex,
     pageSize: defaultPage.pageSize,
-    contentTypes: [ContentTypeName.PrintContent, ContentTypeName.Image],
+    contentTypes: [ContentTypeName.PrintContent],
     hasTopic: false,
     isHidden: false,
     onlyPublished: false,


### PR DESCRIPTION
The Papers page will no longer include the front page images.

![image](https://github.com/bcgov/tno/assets/3180256/ff64920c-4967-4700-a0a6-58c66c46241b)
