### PR TITLE
Fix view report instance

### DIFF
--- a/api/net/Areas/Subscriber/Controllers/ReportInstanceController.cs
+++ b/api/net/Areas/Subscriber/Controllers/ReportInstanceController.cs
@@ -164,7 +164,7 @@ public class ReportInstanceController : ControllerBase
     /// </summary>
     /// <param name="id"></param>
     /// <returns></returns>
-    [HttpPost("{id}/preview")]
+    [HttpPost("{id}/view")]
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType(typeof(ReportResultModel), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]

--- a/libs/net/kafka/KafkaListener`.cs
+++ b/libs/net/kafka/KafkaListener`.cs
@@ -1,5 +1,5 @@
-using System.Text.Json;
 using System.Collections.Concurrent;
+using System.Text.Json;
 using Confluent.Kafka;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -168,7 +168,7 @@ public class KafkaListener<TKey, TValue> : IKafkaListener<TKey, TValue>, IDispos
             var consumeResult = this.Consumer!.Consume(cancellationToken);
             if (consumeResult != null)
             {
-                _logger.LogInformation("Message received from Kafka topic: '{topic}' key:'{key}'", consumeResult.Topic, consumeResult.Message.Key);
+                _logger.LogDebug("Message received from Kafka topic: '{topic}' key:'{key}'", consumeResult.Topic, consumeResult.Message.Key);
                 if (this.IsLongRunningJob)
                 {
                     var current = consumeResult;


### PR DESCRIPTION
Introduced a regression issue on the subscriber site when I changed the route for view a report instance from `preview` to `view`.