### PR TITLE
TNO-1749: View reports

### DIFF
--- a/app/subscriber/src/features/my-reports/MyReports.tsx
+++ b/app/subscriber/src/features/my-reports/MyReports.tsx
@@ -75,7 +75,7 @@ export const MyReport: React.FC = () => {
           rowId={'id'}
           data={myReports}
           showActive={false}
-          onRowClick={(report) => navigate(`/myreports/${report.original.id}`)}
+          onRowClick={(report) => navigate(`/myreports/view/${report.original.id}`)}
           isLoading={requests.some((r) => r.url.includes('find-my-reports'))}
         />
         <Col className="info">
@@ -90,7 +90,7 @@ export const MyReport: React.FC = () => {
           columns={reportProductColumns}
           rowId={'id'}
           data={allReports}
-          onRowClick={(report) => navigate(`/myreports/${report.original.id}`)}
+          onRowClick={(report) => navigate(`/myreports/view/${report.original.id}`)}
           showActive={false}
           isLoading={requests.some((r) => r.url.includes('get-public-reports'))}
         />

--- a/app/subscriber/src/features/my-reports/MyReports.tsx
+++ b/app/subscriber/src/features/my-reports/MyReports.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useReports } from 'store/hooks';
 import { useAppStore } from 'store/slices';
@@ -14,6 +14,7 @@ export const MyReport: React.FC = () => {
   const [{ getPublicReports, findMyReports, deleteReport, updateReport }] = useReports();
   const { toggle, isShowing } = useModal();
   const [{ requests }] = useAppStore();
+  const navigate = useNavigate();
 
   const [myReports, setMyReports] = React.useState<IReportModel[]>([]);
   const [allReports, setAllReports] = React.useState<IReportModel[]>([]);
@@ -74,6 +75,7 @@ export const MyReport: React.FC = () => {
           rowId={'id'}
           data={myReports}
           showActive={false}
+          onRowClick={(report) => navigate(`/myreports/${report.original.id}`)}
           isLoading={requests.some((r) => r.url.includes('find-my-reports'))}
         />
         <Col className="info">
@@ -88,6 +90,7 @@ export const MyReport: React.FC = () => {
           columns={reportProductColumns}
           rowId={'id'}
           data={allReports}
+          onRowClick={(report) => navigate(`/myreports/${report.original.id}`)}
           showActive={false}
           isLoading={requests.some((r) => r.url.includes('get-public-reports'))}
         />

--- a/app/subscriber/src/features/my-reports/hooks/useColumns.tsx
+++ b/app/subscriber/src/features/my-reports/hooks/useColumns.tsx
@@ -53,17 +53,26 @@ export const useColumns = (
         <Row gap="0.5rem">
           <FaGear
             className="btn-link"
-            onClick={() => navigate(`/reports/${cell.original.id}`)}
+            onClick={(e) => {
+              e.stopPropagation();
+              navigate(`/reports/${cell.original.id}`);
+            }}
             title="Configure"
           />
           <FaEdit
             className="btn-link"
-            onClick={() => navigate(`/reports/${cell.original.id}/edit`)}
+            onClick={(e) => {
+              e.stopPropagation();
+              navigate(`/reports/${cell.original.id}/edit`);
+            }}
             title="Edit"
           />
           <FaTrash
             className="btn-link error"
-            onClick={() => handleDelete(cell.original)}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleDelete(cell.original);
+            }}
             title="Delete"
           />
         </Row>

--- a/app/subscriber/src/features/my-reports/styled/MyReports.tsx
+++ b/app/subscriber/src/features/my-reports/styled/MyReports.tsx
@@ -60,6 +60,9 @@ export const MyReports = styled(Col)`
       svg:not(.error) {
         color: #6750a4;
       }
+      &:hover {
+        cursor: pointer;
+      }
     }
     .header {
       background-color: #f5f6fa;

--- a/app/subscriber/src/features/my-reports/view/ReportInstancePreview.tsx
+++ b/app/subscriber/src/features/my-reports/view/ReportInstancePreview.tsx
@@ -1,13 +1,13 @@
 import { SearchWithLogout } from 'components/search-with-logout';
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { useReportInstances } from 'store/hooks';
+import { useReports } from 'store/hooks';
 import { Col, IReportResultModel, Loading, Show } from 'tno-core';
 
 import * as styled from './styled';
 
 const ReportInstancePreview: React.FC = () => {
-  const [{ viewReportInstance }] = useReportInstances();
+  const [{ previewReport }] = useReports();
   const { id } = useParams();
   const reportId = parseInt(id ?? '');
 
@@ -18,14 +18,14 @@ const ReportInstancePreview: React.FC = () => {
     async (reportId: number) => {
       try {
         setIsLoading(true);
-        const response = await viewReportInstance(reportId);
+        const response = await previewReport(reportId);
         setPreview(response);
       } catch {
       } finally {
         setIsLoading(false);
       }
     },
-    [viewReportInstance, setPreview],
+    [previewReport, setPreview],
   );
 
   React.useEffect(() => {

--- a/app/subscriber/src/features/my-reports/view/ViewReportInstance.tsx
+++ b/app/subscriber/src/features/my-reports/view/ViewReportInstance.tsx
@@ -6,7 +6,7 @@ import { Col, IReportResultModel, Loading, Show } from 'tno-core';
 
 import * as styled from './styled';
 
-const ReportInstancePreview: React.FC = () => {
+export const ViewReportInstance: React.FC = () => {
   const [{ previewReport }] = useReports();
   const { id } = useParams();
   const reportId = parseInt(id ?? '');
@@ -53,5 +53,3 @@ const ReportInstancePreview: React.FC = () => {
     </styled.ReportPreview>
   );
 };
-
-export default ReportInstancePreview;

--- a/app/subscriber/src/features/my-reports/view/index.ts
+++ b/app/subscriber/src/features/my-reports/view/index.ts
@@ -1,1 +1,2 @@
 export * from './ReportSnapshot';
+export * from './ViewReportInstance';

--- a/app/subscriber/src/features/router/AppRouter.tsx
+++ b/app/subscriber/src/features/router/AppRouter.tsx
@@ -3,8 +3,7 @@ import { AccessRequest } from 'features/access-request';
 import { Landing } from 'features/landing';
 import { Login } from 'features/login';
 import { ManageFolder } from 'features/manage-folder';
-import { ReportAdmin, ReportSnapshot } from 'features/my-reports';
-import ReportInstancePreview from 'features/my-reports/view/ReportInstancePreview';
+import { ReportAdmin, ReportSnapshot, ViewReportInstance } from 'features/my-reports';
 import SearchForm from 'features/my-searches/SearchForm';
 import { SearchPage } from 'features/search-page/SearchPage';
 import React from 'react';
@@ -56,15 +55,6 @@ export const AppRouter: React.FC<IAppRouter> = () => {
           }
         />
         <Route
-          path="report/instances/:id/view"
-          element={
-            <PrivateRoute
-              claims={Claim.subscriber}
-              element={<ReportInstancePreview />}
-            ></PrivateRoute>
-          }
-        />
-        <Route
           path="/view/:id"
           element={<PrivateRoute claims={Claim.subscriber} element={<Landing />}></PrivateRoute>}
         />
@@ -79,12 +69,9 @@ export const AppRouter: React.FC<IAppRouter> = () => {
           }
         />
         <Route
-          path="/myreports/:id"
+          path="/myreports/view/:id"
           element={
-            <PrivateRoute
-              claims={Claim.subscriber}
-              element={<ReportInstancePreview />}
-            ></PrivateRoute>
+            <PrivateRoute claims={Claim.subscriber} element={<ViewReportInstance />}></PrivateRoute>
           }
         />
         <Route

--- a/app/subscriber/src/features/router/AppRouter.tsx
+++ b/app/subscriber/src/features/router/AppRouter.tsx
@@ -79,6 +79,15 @@ export const AppRouter: React.FC<IAppRouter> = () => {
           }
         />
         <Route
+          path="/myreports/:id"
+          element={
+            <PrivateRoute
+              claims={Claim.subscriber}
+              element={<ReportInstancePreview />}
+            ></PrivateRoute>
+          }
+        />
+        <Route
           path="/reports/:id/edit"
           element={
             <PrivateRoute claims={Claim.subscriber} element={<ReportSnapshot />}></PrivateRoute>


### PR DESCRIPTION
Backend was previously set up, just had to tweak the front end a little bit to make this work

Additionally:
- report rows now have pointer when hovering
- clicking icons in my reports still work as `stopPropegation` has been added to their onClicks

![preview-reports](https://github.com/bcgov/tno/assets/15724124/bfd0b807-226a-4c2f-be9d-d69f68f485e0)
