### PR TITLE
TNO-1965 Fix File Monitor Service

### DIFF
--- a/app/editor/src/features/admin/ingests/configurations/Newspaper.tsx
+++ b/app/editor/src/features/admin/ingests/configurations/Newspaper.tsx
@@ -83,6 +83,7 @@ export const Newspaper: React.FC = (props) => {
         <Col flex="1 1 0">
           <FormikCheckbox label="Escape Content" name="configuration.escapeContent" />
           <FormikCheckbox label="Add Parent" name="configuration.addParent" />
+          <FormikCheckbox label="Fix Blacks Newsgroup XML" name="configuration.fixBlacksXml" />
         </Col>
         <Col flex="1 1 0"></Col>
       </Row>

--- a/services/net/filemonitor/models/Fields.cs
+++ b/services/net/filemonitor/models/Fields.cs
@@ -104,4 +104,9 @@ public static class Fields
     /// FMS story delimiter string.
     /// </summary>
     public const string FmsEntryEnd = "</story>";
+
+    /// <summary>
+    /// Whether to fix the Blacks XML issue.
+    /// </summary>
+    public const string FixBlacksXml = "fixBlacksXml";
 }


### PR DESCRIPTION
Fixing issue introduced when fixing the Blacks Newsgroup XML.  Resulted in breaking Globe & Mail XML.

Will now use a configuration option to turn it on or off.