### PR TITLE
TNO-2081: Remove search tags and height of selects

### DIFF
--- a/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
@@ -2,7 +2,7 @@ import { filterFormat } from 'features/search-page/utils';
 import React from 'react';
 import { BsCalendarEvent, BsSun } from 'react-icons/bs';
 import { FaPlay, FaRegSmile, FaSearch } from 'react-icons/fa';
-import { FaCloudArrowUp, FaIcons, FaNewspaper, FaTags, FaTv, FaUsers } from 'react-icons/fa6';
+import { FaCloudArrowUp, FaIcons, FaNewspaper, FaTv, FaUsers } from 'react-icons/fa6';
 import { IoIosCog, IoMdRefresh } from 'react-icons/io';
 import { useNavigate } from 'react-router';
 import { toast } from 'react-toastify';
@@ -21,7 +21,6 @@ import {
   SearchInGroup,
   SentimentSection,
   SeriesSection,
-  TagSection,
 } from './components';
 import { defaultAdvancedSearch } from './constants';
 import { defaultSubMediaGroupExpanded, ISubMediaGroupExpanded } from './interfaces';

--- a/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
@@ -199,12 +199,6 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({
                 <SeriesSection />
               </ExpandableRow>
             </Col>
-            {/* TAG SECTION */}
-            <Col>
-              <ExpandableRow icon={<FaTags />} title="Tags">
-                <TagSection />
-              </ExpandableRow>
-            </Col>
           </Col>
 
           <Row>

--- a/app/subscriber/src/components/sidebar/advanced-search/styled/AdvancedSearch.tsx
+++ b/app/subscriber/src/components/sidebar/advanced-search/styled/AdvancedSearch.tsx
@@ -263,14 +263,6 @@ export const AdvancedSearch = styled(Row)<{ expanded: boolean }>`
     margin-top: 0.5em;
   }
 
-  .content-types,
-  .contributors {
-    .rs__value-container {
-      max-height: 40px;
-      overflow-y: auto;
-    }
-  }
-
   .date-range-group,
   .media-group,
   .search-in-group,
@@ -292,11 +284,6 @@ export const AdvancedSearch = styled(Row)<{ expanded: boolean }>`
     padding: 0.1em;
     margin-left: 0.1em;
     border-bottom: 1px solid ${(props) => props.theme.css.bsGray500};
-
-    .rs__value-container {
-      max-height: 40px;
-      overflow-y: auto;
-    }
 
     .sub-options {
       font-size: 0.8em;


### PR DESCRIPTION
Small PR - needed to take a break from the rewiring of redux and rewiring everything to only use `IFilterContentSettings`.

Not removing Tags component incase needed back. Also removed the max height of the select dropdowns.

![image](https://github.com/bcgov/tno/assets/15724124/94012007-fe68-475b-80f9-2e886606d10f)
