### PR TITLE
Folder fixes and style enhancements 

### DIFF
--- a/app/subscriber/src/components/table/styled/SubscriberTableContainer.tsx
+++ b/app/subscriber/src/components/table/styled/SubscriberTableContainer.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { Col } from 'tno-core';
 
 export const SubscriberTableContainer = styled(Col)`
+  width: 100%;
   .table {
     width: 100%;
     overflow: hidden;

--- a/app/subscriber/src/features/my-folders/MyFolders.tsx
+++ b/app/subscriber/src/features/my-folders/MyFolders.tsx
@@ -1,8 +1,9 @@
+import { SubscriberTableContainer } from 'components/table';
+import { TooltipMenu } from 'components/tooltip-menu';
 import React from 'react';
 import { FaFolderPlus } from 'react-icons/fa6';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
-import { Tooltip } from 'react-tooltip';
 import { useFolders } from 'store/hooks/subscriber/useFolders';
 import { Col, FlexboxTable, IFolderModel, Modal, Row, Text, useModal } from 'tno-core';
 
@@ -81,15 +82,17 @@ export const MyFolders = () => {
         </button>
       </Row>
       <Row>
-        <FlexboxTable
-          pagingEnabled={false}
-          columns={columns(setActive, editable, handleSave, active)}
-          rowId={'id'}
-          onRowClick={(e) => navigate(`/folders/${e.original.id}`)}
-          data={myFolders}
-          showActive={false}
-        />
-        <Tooltip
+        <SubscriberTableContainer>
+          <FlexboxTable
+            pagingEnabled={false}
+            columns={columns(setActive, editable, handleSave, active)}
+            rowId={'id'}
+            onRowClick={(e) => navigate(`/folders/${e.original.id}`)}
+            data={myFolders}
+            showActive={false}
+          />
+        </SubscriberTableContainer>
+        <TooltipMenu
           clickable
           openOnClick
           place="right"
@@ -120,7 +123,7 @@ export const MyFolders = () => {
               Delete this folder
             </div>
           </Col>
-        </Tooltip>
+        </TooltipMenu>
       </Row>
       <Modal
         headerText="Confirm Removal"

--- a/app/subscriber/src/features/my-folders/constants/columns.tsx
+++ b/app/subscriber/src/features/my-folders/constants/columns.tsx
@@ -1,4 +1,5 @@
-import { FiMoreHorizontal, FiSave } from 'react-icons/fi';
+import { handleEnterPressed } from 'features/utils';
+import { FaCog, FaSave } from 'react-icons/fa';
 import { CellEllipsis, IFolderModel, ITableHookColumn, Text } from 'tno-core';
 
 export const columns = (
@@ -18,6 +19,9 @@ export const columns = (
             className="re-name"
             name="name"
             value={active.name}
+            onKeyDown={(e) => handleEnterPressed(e, handleSave)}
+            // stop the row click event from firing
+            onClick={(e) => e.stopPropagation()}
             onChange={(e) => setActive({ ...active, name: e.target.value })}
             key={active.id}
           />
@@ -40,16 +44,20 @@ export const columns = (
     cell: (cell) => (
       <>
         {editable === cell.original.name ? (
-          <FiSave onClick={() => handleSave()} className="elips" />
+          <FaSave
+            onClick={(e) => {
+              e.stopPropagation();
+              handleSave();
+            }}
+          />
         ) : (
-          <FiMoreHorizontal
+          <FaCog
             onClick={(e) => {
               // stop the row click event from firing
               e.stopPropagation();
               setActive(cell.original);
             }}
             data-tooltip-id="options"
-            className="elips"
           />
         )}
       </>

--- a/app/subscriber/src/features/my-folders/styled/MyFolders.tsx
+++ b/app/subscriber/src/features/my-folders/styled/MyFolders.tsx
@@ -3,20 +3,11 @@ import { Col } from 'tno-core';
 
 export const MyFolders = styled(Col)`
   max-height: calc(100vh - 6.5em);
-  .react-tooltip {
-    z-index: 999;
-  }
-  .options {
-    box-shadow: 0 0 0.5rem #c7c7c7;
-    opacity: 1;
-    padding-left: 1.5em;
-    padding-right: 1.5em;
-    .option {
-      &:hover {
-        text-decoration: underline;
-        color: ${(props) => props.theme.css.sidebarIconHoverColor};
-        cursor: pointer;
-      }
+  /* option in tooltip */
+  .option {
+    &:hover {
+      cursor: pointer;
+      text-decoration: underline;
     }
   }
   .folder-name {
@@ -30,42 +21,6 @@ export const MyFolders = styled(Col)`
     }
     margin-left: auto;
     margin-bottom: 0.5em;
-  }
-  /* table styling */
-  .table {
-    width: 100%;
-    overflow: hidden;
-    .re-name {
-      height: 1.5em;
-      padding: 0;
-      &:focus {
-        box-shadow: none;
-      }
-    }
-    .row {
-      &:hover {
-        cursor: pointer;
-      }
-    }
-    .header {
-      background-color: #f5f6fa;
-      font-family: 'Roboto', sans-serif;
-      font-size: 0.8em;
-      /* box shadow only on bottom */
-      box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
-      border: none;
-      color: #7c7e8a;
-
-      .column {
-        background-color: #f5f6fa;
-      }
-    }
-    .elips {
-      &:hover {
-        color: ${(props) => props.theme.css.sidebarIconHoverColor};
-        transform: scale(1.1);
-      }
-    }
   }
   .create-button {
     &:focus {
@@ -85,6 +40,18 @@ export const MyFolders = styled(Col)`
     &:hover {
       transform: scale(1.1);
       color: ${(props) => props.theme.css.sidebarIconHoverColor};
+    }
+  }
+
+  .re-name {
+    input {
+      outline: none;
+      border: none;
+      box-shadow: none;
+      border-bottom: 1px solid ${(props) => props.theme.css.btnPkPrimary};
+      border-radius: 0;
+      font-size: 1em;
+      padding: 0;
     }
   }
 `;

--- a/app/subscriber/src/features/utils/handleEnterPressed.ts
+++ b/app/subscriber/src/features/utils/handleEnterPressed.ts
@@ -1,0 +1,10 @@
+import { KeyboardEvent } from 'react';
+
+export const handleEnterPressed = (
+  event: KeyboardEvent<HTMLInputElement>,
+  callback: () => void,
+) => {
+  if (event.key === 'Enter') {
+    callback();
+  }
+};

--- a/app/subscriber/src/features/utils/index.ts
+++ b/app/subscriber/src/features/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './castToSearchResult';
 export * from './createFilterSettings';
 export * from './determinePreview';
+export * from './handleEnterPressed';
 export * from './showTranscription';


### PR DESCRIPTION
In this PR:

- strip repetitive css and use existing component made
- fix bug where you cannot rename folder
- apply common table theme to my folders
- allow user to hit enter when renaming a folder to confirm save
- change icons
- made a simple util for `handleEnterPress()` to be used with inputs throughout the app on their `onKeyDown` prop

![folder-bugs-enhance](https://github.com/bcgov/tno/assets/15724124/c1f5707d-aa80-417a-b327-a9e66796972c)
