### PR TITLE
Prevent new line from being added when hitting enter in Advanced Search

### DIFF
--- a/app/subscriber/src/components/basic-search/BasicSearch.tsx
+++ b/app/subscriber/src/components/basic-search/BasicSearch.tsx
@@ -1,4 +1,5 @@
 import { filterFormat } from 'features/search-page/utils';
+import { handleEnterPressed } from 'features/utils';
 import { FaPlay, FaSearch } from 'react-icons/fa';
 import { useNavigate } from 'react-router';
 import { useContent } from 'store/hooks';
@@ -20,12 +21,6 @@ export const BasicSearch: React.FC = () => {
     navigate(`/search?${toQueryString(filterFormat(filter))}`);
   };
 
-  const enterPressed = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      handleSearch();
-    }
-  };
-
   return (
     <styled.BasicSearch>
       <label>SEARCH FOR: </label>
@@ -33,7 +28,7 @@ export const BasicSearch: React.FC = () => {
         <FaSearch onClick={() => handleSearch()} className="search-icon" />
         <Text
           className="search-input"
-          onKeyDown={enterPressed}
+          onKeyDown={(e) => handleEnterPressed(e, handleSearch)}
           name="search"
           onChange={(e) => {
             storeSearchFilter({ ...filter, search: e.target.value });
@@ -42,7 +37,6 @@ export const BasicSearch: React.FC = () => {
       </Row>
       <Text
         className="search-mobile"
-        onKeyDown={enterPressed}
         name="search-mobile"
         onChange={(e) => {
           storeSearchFilter({ ...filter, search: e.target.value });

--- a/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/components/sidebar/advanced-search/AdvancedSearch.tsx
@@ -1,5 +1,6 @@
 import { PageSection } from 'components/section';
 import { filterFormat } from 'features/search-page/utils';
+import { handleEnterPressed } from 'features/utils';
 import React from 'react';
 import { BsCalendarEvent, BsSun } from 'react-icons/bs';
 import { FaPlay, FaRegSmile } from 'react-icons/fa';
@@ -102,13 +103,6 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ onSearchPage })
     );
   };
 
-  /** allow user to hit enter while searching */
-  const enterPressed = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      handleSearch();
-    }
-  };
-
   /** get viewed filter if in modify mode */
   React.useEffect(() => {
     if (filterId && !viewedFilter) {
@@ -156,7 +150,7 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ onSearchPage })
               <TextArea
                 value={filter?.search}
                 className="text-area"
-                onKeyDown={enterPressed}
+                onKeyDown={(e) => handleEnterPressed(e, handleSearch, true)}
                 name="search"
                 onChange={(e) => storeFilter({ ...filter, search: e.target.value })}
               />

--- a/app/subscriber/src/features/utils/handleEnterPressed.ts
+++ b/app/subscriber/src/features/utils/handleEnterPressed.ts
@@ -1,9 +1,11 @@
 import { KeyboardEvent } from 'react';
 
-export const handleEnterPressed = (
-  event: KeyboardEvent<HTMLInputElement>,
-  callback: () => void,
-) => {
+/**
+ * Handles enter key press on an element
+ * @param event generic keyboard event
+ * @param callback callback function to be called when enter is pressed on the element
+ */
+export const handleEnterPressed = <T>(event: KeyboardEvent<T>, callback: () => void) => {
   if (event.key === 'Enter') {
     callback();
   }

--- a/app/subscriber/src/features/utils/handleEnterPressed.ts
+++ b/app/subscriber/src/features/utils/handleEnterPressed.ts
@@ -4,9 +4,15 @@ import { KeyboardEvent } from 'react';
  * Handles enter key press on an element
  * @param event generic keyboard event
  * @param callback callback function to be called when enter is pressed on the element
+ * @param preventDefault if true, prevents default behaviour of the event
  */
-export const handleEnterPressed = <T>(event: KeyboardEvent<T>, callback: () => void) => {
+export const handleEnterPressed = <T>(
+  event: KeyboardEvent<T>,
+  callback: () => void,
+  preventDefault?: boolean,
+) => {
   if (event.key === 'Enter') {
+    preventDefault && event.preventDefault();
     callback();
   }
 };


### PR DESCRIPTION
Quick PR to disable default behaviour when hitting enter in the advanced search, this way only the search is fired as the user has intended.

Also made the `handleEnterPressed` function more generic incase we ever need to perform on a non input element (not sure if this will ever be the case....)