### PR TITLE
TNO-1997/98: Ability to run filter on Folder, and schedule when to empty it 

### DIFF
--- a/app/subscriber/src/features/my-folders/ConfigureFolder.tsx
+++ b/app/subscriber/src/features/my-folders/ConfigureFolder.tsx
@@ -1,0 +1,155 @@
+import * as React from 'react';
+import { FaArrowLeft } from 'react-icons/fa6';
+import { useNavigate, useParams } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import { useContent, useFilters, useFolders } from 'store/hooks';
+import {
+  Button,
+  Col,
+  FieldSize,
+  getDistinct,
+  IContentModel,
+  IFilterModel,
+  IFolderContentModel,
+  IFolderModel,
+  IOptionItem,
+  Row,
+  Select,
+  Show,
+  sortObject,
+} from 'tno-core';
+
+import { getFilterOptions } from './constants';
+import { Schedule } from './Schedule';
+import * as styled from './styled';
+import { createSchedule } from './utils';
+
+export const ConfigureFolder: React.FC = () => {
+  const [{ myFilters }, { findMyFilters }] = useFilters();
+  const [, { findContentWithElasticsearch }] = useContent();
+  const [, { getFolder, updateFolder }] = useFolders();
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  const [active, setActive] = React.useState<IFilterModel>();
+  const [currentFolder, setCurrentFolder] = React.useState<IFolderModel>();
+  const [filterOptions, setFilterOptions] = React.useState<IOptionItem[]>(
+    getFilterOptions(myFilters, active?.id ?? 0),
+  );
+
+  React.useEffect(() => {
+    if (!myFilters.length) {
+      findMyFilters().then((data) => {
+        setFilterOptions(getFilterOptions(data, active?.id ?? 0));
+      });
+    }
+    // Only do this on init.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  React.useEffect(() => {
+    if (!currentFolder && id) {
+      getFolder(Number(id)).then((data) => {
+        setCurrentFolder(data);
+      });
+    }
+  }, [currentFolder, getFolder, id]);
+
+  const handleRun = React.useCallback(
+    async (filter: IFilterModel) => {
+      if (!currentFolder) return;
+      try {
+        const results: any = await findContentWithElasticsearch(
+          filter.query,
+          filter.settings.searchUnpublished,
+        );
+        if (results.hits.hits.length) {
+          const existing = [...currentFolder.content].sort(sortObject((c) => c.sortOrder));
+          const maxSortOrder = existing.length ? existing[existing.length - 1].sortOrder : 0;
+          const content: IFolderContentModel[] = getDistinct(
+            [
+              ...existing,
+              ...results.hits.hits.map((h: { _source: IContentModel }, index: number) => ({
+                contentId: h._source.id,
+                sortOrder: maxSortOrder + index,
+                content: h._source,
+                selected: false,
+              })),
+            ],
+            (item) => item.content.id,
+          ).map((item, index) => ({ ...item, sortOrder: index }));
+          updateFolder({ ...currentFolder, content });
+          toast.success(`Filter found and added ${results.hits.hits.length} content items.`);
+        } else {
+          toast.warning('No content found for this filter.');
+        }
+      } catch {}
+    },
+    [findContentWithElasticsearch, currentFolder, updateFolder],
+  );
+
+  return (
+    <styled.ConfigureFolder
+      ignoreLastChildGap
+      header={
+        <Row width={FieldSize.Stretch}>
+          <span className="back-to-folders" onClick={() => navigate(-1)}>
+            <FaArrowLeft /> Back to folders
+          </span>
+          <span className="name">Configuring folder: "{currentFolder?.name}"</span>
+        </Row>
+      }
+    >
+      <div className="main-container">
+        <div className="add-filter">
+          <div className="choose-text">Choose a filter to apply to this folder.</div>
+          <Row className="choose-filter">
+            <Select
+              options={filterOptions}
+              name="filters"
+              isClearable
+              className="filter-select"
+              value={filterOptions.find((option) => option.value === active?.id)}
+              onChange={(newValue) => {
+                const option = newValue as IOptionItem;
+                setActive(myFilters.find((f) => f.id === option.value));
+              }}
+            />
+            <Button className="run" onClick={() => !!active && handleRun(active)}>
+              Run
+            </Button>
+          </Row>
+        </div>
+        <Col className="add-schedule">
+          <Row>
+            <span className="schedule-text">
+              Configure when you would like to have content removed automatically.
+            </span>
+            <Button
+              className="add-schedule-btn"
+              onClick={() =>
+                currentFolder &&
+                setCurrentFolder({
+                  ...currentFolder,
+                  events: [createSchedule(currentFolder.name, currentFolder.description)],
+                })
+              }
+            >
+              Add Clearance Schedule
+            </Button>
+          </Row>
+          <Schedule setCurrentFolder={setCurrentFolder} folderEvents={currentFolder?.events} />
+          <Show visible={!!currentFolder?.events?.length}>
+            <Button
+              onClick={() => {
+                updateFolder(currentFolder as IFolderModel);
+              }}
+            >
+              Save
+            </Button>
+          </Show>
+        </Col>
+      </div>
+    </styled.ConfigureFolder>
+  );
+};

--- a/app/subscriber/src/features/my-folders/ConfigureFolder.tsx
+++ b/app/subscriber/src/features/my-folders/ConfigureFolder.tsx
@@ -125,24 +125,28 @@ export const ConfigureFolder: React.FC = () => {
             <span className="schedule-text">
               Configure when you would like to have content removed automatically.
             </span>
-            <Button
-              className="add-schedule-btn"
-              onClick={() =>
-                currentFolder &&
-                setCurrentFolder({
-                  ...currentFolder,
-                  events: [createSchedule(currentFolder.name, currentFolder.description)],
-                })
-              }
-            >
-              Add Clearance Schedule
-            </Button>
+            <Show visible={!currentFolder?.events?.length}>
+              <Button
+                className="add-schedule-btn"
+                onClick={() =>
+                  currentFolder &&
+                  setCurrentFolder({
+                    ...currentFolder,
+                    events: [createSchedule(currentFolder.name, currentFolder.description)],
+                  })
+                }
+              >
+                Add Clearance Schedule
+              </Button>
+            </Show>
           </Row>
           <Schedule setCurrentFolder={setCurrentFolder} folderEvents={currentFolder?.events} />
           <Show visible={!!currentFolder?.events?.length}>
             <Button
               onClick={() => {
-                updateFolder(currentFolder as IFolderModel);
+                updateFolder(currentFolder as IFolderModel)
+                  .then(() => toast.success('Folder schedule saved.'))
+                  .catch(() => toast.error('Failed to save folder schedule.'));
               }}
             >
               Save

--- a/app/subscriber/src/features/my-folders/MyFolders.tsx
+++ b/app/subscriber/src/features/my-folders/MyFolders.tsx
@@ -104,6 +104,9 @@ export const MyFolders = () => {
             <div className="option" onClick={() => setEditable(active?.name ?? '')}>
               Edit folder name
             </div>
+            <div className="option" onClick={() => navigate(`/folders/configure/${active?.id}`)}>
+              Configure folder
+            </div>
             <div
               className="option"
               onClick={() => {

--- a/app/subscriber/src/features/my-folders/Schedule.tsx
+++ b/app/subscriber/src/features/my-folders/Schedule.tsx
@@ -1,0 +1,182 @@
+import moment from 'moment';
+import * as React from 'react';
+import ReactDatePicker from 'react-datepicker';
+import { FaInfoCircle } from 'react-icons/fa';
+import { FaTrash } from 'react-icons/fa6';
+import { Tooltip } from 'react-tooltip';
+import {
+  Button,
+  Checkbox,
+  Col,
+  FieldSize,
+  IFolderModel,
+  IFolderScheduleModel,
+  Row,
+  Show,
+  Text,
+  TimeInput,
+} from 'tno-core';
+
+import { daysOfWeek } from './constants/daysOfWeek';
+
+export interface IScheduleProps {
+  setCurrentFolder: React.Dispatch<React.SetStateAction<IFolderModel | undefined>>;
+  folderEvents?: IFolderScheduleModel[];
+}
+/*
+ * This component will display the schedule options for clearing a folder in the ConfigureFolder component.
+ */
+export const Schedule: React.FC<IScheduleProps> = ({ folderEvents, setCurrentFolder }) => {
+  const [days, setDays] = React.useState<string[]>([]);
+
+  // init days
+  React.useEffect(() => {
+    if (folderEvents?.length && folderEvents[0].runOnWeekDays) {
+      setDays(folderEvents[0].runOnWeekDays.split(','));
+    }
+    // only run to sync up with db
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [folderEvents?.length]);
+
+  // easy way to convert checked days to a comma separated string
+  React.useEffect(() => {
+    if (!!days.length) {
+      setCurrentFolder((prev) => {
+        if (prev) {
+          return { ...prev, events: [{ ...prev.events[0], runOnWeekDays: days.join(',') }] };
+        }
+      });
+    }
+    // only run when days change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [days]);
+
+  return (
+    <Show visible={!!folderEvents?.length}>
+      <Row alignSelf="center" className="schedule-content">
+        <Col>
+          <Checkbox
+            label="Schedule is enabled"
+            checked={!!folderEvents && !!folderEvents[0]?.isEnabled}
+            onChange={(e) => {
+              setCurrentFolder((prev) => {
+                if (prev) {
+                  prev.events[0].isEnabled = e.target.checked;
+                }
+                return prev;
+              });
+            }}
+          />
+          <TimeInput
+            label="Run schedle at:"
+            placeholder='e.g. "13:00:00"'
+            value={folderEvents && folderEvents[0]?.startAt}
+            width={FieldSize.Small}
+            onChange={(e) => {
+              setCurrentFolder((prev) => {
+                if (prev) {
+                  prev.events[0].startAt = e.target.value;
+                }
+                return prev;
+              });
+            }}
+          />
+          <label>Start after:</label>
+          <ReactDatePicker
+            showTimeInput
+            selected={
+              folderEvents?.length && folderEvents[0].runOn
+                ? new Date(folderEvents[0].runOn)
+                : undefined
+            }
+            isClearable
+            showTimeSelect
+            dateFormat="MM/dd/yyyy HH:mm:ss"
+            value={
+              folderEvents?.length && folderEvents[0].runOn
+                ? moment(folderEvents[0].runOn).format('MM/DD/yyyy HH:mm:ss')
+                : undefined
+            }
+            onChange={(date) => {
+              setCurrentFolder((prev) => {
+                if (prev) {
+                  return {
+                    ...prev,
+                    events: [{ ...prev.events[0], runOn: moment(date).toISOString() }],
+                  };
+                }
+              });
+            }}
+          />
+        </Col>
+        <Col className="checkboxes">
+          {daysOfWeek.map((day) => (
+            <Checkbox
+              key={day.value}
+              label={day.label}
+              checked={
+                !!folderEvents && !!folderEvents[0]?.runOnWeekDays?.includes(day.value as string)
+              }
+              onChange={(e) => {
+                if (e.target.checked) {
+                  setDays([...days, e.target.value]);
+                } else {
+                  setDays(days.filter((day) => day !== e.target.value));
+                }
+              }}
+              value={day.value}
+            />
+          ))}
+        </Col>
+        <Col className="set-days">
+          <Row>
+            <Tooltip id="keep-age" variant="light">
+              Remove content older than specified amount of days. Use '0' if you would like to
+              remove all content.
+            </Tooltip>
+            <label>
+              Keep age limit (days)
+              <FaInfoCircle data-tooltip-id="keep-age" />
+            </label>
+            <Text width={FieldSize.Small} name="days" type="number" min="0" max="365" />
+          </Row>
+        </Col>
+        <Col>
+          <Text
+            name="request-date"
+            value={
+              folderEvents?.length && folderEvents[0].requestSentOn
+                ? folderEvents[0]?.requestSentOn
+                : ''
+            }
+            label="Last Request Sent On"
+            disabled
+          >
+            <Button
+              tooltip="Clear last request sent on"
+              className="btn-clear"
+              onClick={() => {
+                setCurrentFolder((prev) => {
+                  if (prev) {
+                    prev.events[0].requestSentOn = undefined;
+                  }
+                  return prev;
+                });
+              }}
+            >
+              <FaTrash />
+            </Button>
+          </Text>
+          <Text
+            name={`lastRanOn`}
+            value={
+              !!folderEvents?.length && folderEvents[0].lastRanOn ? folderEvents[0]?.lastRanOn : ''
+            }
+            label="Last Ran On"
+            disabled
+          />
+        </Col>
+      </Row>
+    </Show>
+  );
+};

--- a/app/subscriber/src/features/my-folders/constants/daysOfWeek.ts
+++ b/app/subscriber/src/features/my-folders/constants/daysOfWeek.ts
@@ -1,0 +1,15 @@
+import { IOptionItem, OptionItem } from 'tno-core';
+
+enum DaysOfWeek {
+  Monday = 'Monday',
+  Tuesday = 'Tuesday',
+  Wednesday = 'Wednesday',
+  Thursday = 'Thursday',
+  Friday = 'Friday',
+  Saturday = 'Saturday',
+  Sunday = 'Sunday',
+}
+
+export const daysOfWeek: IOptionItem[] = Object.keys(DaysOfWeek).map(
+  (key) => new OptionItem(key, DaysOfWeek[key as keyof typeof DaysOfWeek]),
+);

--- a/app/subscriber/src/features/my-folders/constants/defaultSchedule.ts
+++ b/app/subscriber/src/features/my-folders/constants/defaultSchedule.ts
@@ -1,0 +1,16 @@
+import { IFolderScheduleModel, ScheduleMonthName, ScheduleWeekDayName } from 'tno-core';
+
+export const defaultSchedule: IFolderScheduleModel = {
+  id: 0,
+  scheduleId: 0,
+  name: '',
+  description: '',
+  isEnabled: true,
+  delayMS: 3000000,
+  runOnlyOnce: false,
+  repeat: false,
+  runOnWeekDays: ScheduleWeekDayName.NA,
+  runOnMonths: ScheduleMonthName.NA,
+  dayOfMonth: 0,
+  settings: {},
+};

--- a/app/subscriber/src/features/my-folders/constants/filterOptions.ts
+++ b/app/subscriber/src/features/my-folders/constants/filterOptions.ts
@@ -1,0 +1,15 @@
+import { getSortableOptions, IFilterModel, OptionItem } from 'tno-core';
+
+export const getFilterOptions = (filters: IFilterModel[], currentFilterId: number) => {
+  return getSortableOptions(
+    filters,
+    currentFilterId,
+    undefined,
+    (item) =>
+      new OptionItem(
+        `${item.name}${item.owner?.username ? ` [${item.owner.username}]` : ''}`,
+        item.id,
+        item.isEnabled,
+      ),
+  );
+};

--- a/app/subscriber/src/features/my-folders/constants/index.ts
+++ b/app/subscriber/src/features/my-folders/constants/index.ts
@@ -1,0 +1,2 @@
+export * from './defaultSchedule';
+export * from './filterOptions';

--- a/app/subscriber/src/features/my-folders/index.ts
+++ b/app/subscriber/src/features/my-folders/index.ts
@@ -1,1 +1,2 @@
+export * from './ConfigureFolder';
 export * from './MyFolders';

--- a/app/subscriber/src/features/my-folders/styled/ConfigureFolder.tsx
+++ b/app/subscriber/src/features/my-folders/styled/ConfigureFolder.tsx
@@ -1,0 +1,90 @@
+import { PageSection } from 'components/section';
+import styled from 'styled-components';
+
+export const ConfigureFolder = styled(PageSection)`
+  .react-datepicker-ignore-onclickoutside {
+    border-radius: 0.5rem;
+  }
+  input[type='checkbox'] {
+    accent-color: ${(props) => props.theme.css.btnBkPrimary};
+  }
+  .back-to-folders {
+    cursor: pointer;
+    color: ${(props) => props.theme.css.btnBkPrimary};
+    font-size: 1rem;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+  .name {
+    margin-left: auto;
+  }
+  button:not(.react-datepicker__close-icon) {
+    background-color: ${(props) => props.theme.css.btnBkPrimary};
+    border: none;
+    border-radius: 1rem;
+    max-width: fit-content;
+  }
+  .react-datepicker__close-icon::after {
+    background-color: ${(props) => props.theme.css.btnBkPrimary};
+  }
+  .main-container {
+    margin-left: 1rem;
+    margin-right: 1rem;
+    .frm-in {
+      width: 95%;
+    }
+    .add-filter {
+      border: 1px solid;
+      margin-bottom: 1rem;
+      border-color: ${(props) => props.theme.css.bkQuaternary};
+      background-color: ${(props) => props.theme.css.bkQuaternary};
+      border-radius: 1rem;
+      padding: 1rem;
+      .choose-filter {
+        margin-left: auto;
+        margin-right: auto;
+      }
+    }
+    .add-schedule-btn {
+      background-color: transparent;
+      color: ${(props) => props.theme.css.btnBkPrimary};
+      border: solid 2px;
+    }
+    .add-schedule {
+      label {
+        font-weight: bold;
+      }
+      .btn-clear {
+        background-color: transparent;
+        color: ${(props) => props.theme.css.btnBkPrimary};
+        border: solid 2px;
+        border-color: ${(props) => props.theme.css.btnBkPrimary};
+      }
+      display: flex;
+      border: 1px solid;
+      margin-bottom: 1rem;
+      border-color: ${(props) => props.theme.css.bkQuaternary};
+      background-color: ${(props) => props.theme.css.bkQuaternary};
+      border-radius: 1rem;
+      padding: 1rem;
+      button {
+        margin-left: auto;
+      }
+      .checkboxes {
+        margin-left: 2rem;
+        min-width: 10rem;
+      }
+      .schedule-content {
+        .btn-clear {
+          margin-left: 1rem;
+        }
+        margin-top: 2rem;
+        .set-days {
+          max-width: 10rem;
+          margin-right: 3rem;
+        }
+      }
+    }
+  }
+`;

--- a/app/subscriber/src/features/my-folders/styled/index.ts
+++ b/app/subscriber/src/features/my-folders/styled/index.ts
@@ -1,1 +1,2 @@
+export * from './ConfigureFolder';
 export * from './MyFolders';

--- a/app/subscriber/src/features/my-folders/utils/createSchedule.ts
+++ b/app/subscriber/src/features/my-folders/utils/createSchedule.ts
@@ -1,0 +1,5 @@
+import { defaultSchedule } from '../constants';
+
+export const createSchedule = (name: string, description: string) => {
+  return { ...defaultSchedule, name, description };
+};

--- a/app/subscriber/src/features/my-folders/utils/index.ts
+++ b/app/subscriber/src/features/my-folders/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './createSchedule';

--- a/app/subscriber/src/features/router/AppRouter.tsx
+++ b/app/subscriber/src/features/router/AppRouter.tsx
@@ -5,6 +5,7 @@ import { Login } from 'features/login';
 import { ManageFolder } from 'features/manage-folder';
 import { MyColleagues } from 'features/my-colleagues';
 import { ColleagueEdit } from 'features/my-colleagues/ColleagueEdit';
+import { ConfigureFolder } from 'features/my-folders/ConfigureFolder';
 import { MyProducts } from 'features/my-products';
 import { MyReports, ReportAdmin, ReportEdit, ReportView } from 'features/my-reports';
 import { SearchPage } from 'features/search-page/SearchPage';
@@ -56,6 +57,13 @@ export const AppRouter: React.FC<IAppRouter> = () => {
             <PrivateRoute claims={Claim.subscriber} element={<ManageFolder />}></PrivateRoute>
           }
         />
+        <Route
+          path="/folders/configure/:id"
+          element={
+            <PrivateRoute claims={Claim.subscriber} element={<ConfigureFolder />}></PrivateRoute>
+          }
+        />
+
         <Route
           path="/colleagues"
           element={


### PR DESCRIPTION
In this PR:

- the ability to run a filter against a folder to populate is now available
- you may also set up the schedule to determine when to empty the folder

I also have a bug fix that I will add for the editor side when picking the `runOn` date.

_Note that this ticket has not had UX yet_

![image](https://github.com/bcgov/tno/assets/15724124/f7a551ed-555d-447c-9258-6cc1abc7d75a)

![image](https://github.com/bcgov/tno/assets/15724124/d3802903-4ef1-43fc-8f82-b799565e9241)


