### PR TITLE
TNO-2080, 2098, 2086: Little one pointers - styling, add source and series to search page, rename home -> featured stories

### DIFF
--- a/app/subscriber/src/components/layout/constants/SidebarMenuItems.tsx
+++ b/app/subscriber/src/components/layout/constants/SidebarMenuItems.tsx
@@ -28,7 +28,7 @@ export interface ISideBarMenuItems {
 /** The below manages the items that will appear in the left navigation bar in sequential order. */
 export const SidebarMenuItems: ISideBarMenuItems = {
   home: {
-    label: 'Home',
+    label: 'Featured Stories',
     path: 'landing/home',
     icon: <FaHome />,
   },

--- a/app/subscriber/src/components/sidebar/advanced-search/styled/AdvancedSearch.tsx
+++ b/app/subscriber/src/components/sidebar/advanced-search/styled/AdvancedSearch.tsx
@@ -149,6 +149,9 @@ export const AdvancedSearch = styled(Row)`
   }
 
   .date-range {
+    @media (max-width: 1300px) {
+      max-width: 15em;
+    }
     margin-left: auto;
     margin-right: auto;
   }
@@ -261,6 +264,10 @@ export const AdvancedSearch = styled(Row)`
     padding: 0.25em;
     .picker {
       margin-right: 0.5em;
+      @media (max-width: 1300px) {
+        margin-bottom: 0.5em;
+        margin-left: 0.5em;
+      }
     }
     p {
       margin: 0.35em 0.35em;

--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -161,6 +161,10 @@ export const SearchPage: React.FC = () => {
                                 <div className="date text-content">
                                   {new Date(item.publishedOn).toDateString()}
                                 </div>
+                                <span className="divider"> | </span>
+                                <div className="source text-content">{item.source?.name}</div>
+                                <span className="divider"> | </span>
+                                <div className="series text-content">{item.series?.name}</div>
                               </Row>
                             </Col>
                           </Row>

--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -163,8 +163,10 @@ export const SearchPage: React.FC = () => {
                                 </div>
                                 <span className="divider"> | </span>
                                 <div className="source text-content">{item.source?.name}</div>
-                                <span className="divider"> | </span>
-                                <div className="series text-content">{item.series?.name}</div>
+                                <Show visible={!!item.series?.name}>
+                                  <span className="divider"> | </span>
+                                  <div className="series text-content">{item.series?.name}</div>
+                                </Show>
                               </Row>
                             </Col>
                           </Row>

--- a/app/subscriber/src/features/search-page/styled/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/styled/SearchPage.tsx
@@ -1,6 +1,10 @@
 import styled from 'styled-components';
 
 export const SearchPage = styled.div`
+  .divider {
+    margin-left: 0.5em;
+    margin-right: 0.5em;
+  }
   max-height: 100vh;
   overflow: none;
 
@@ -142,9 +146,7 @@ export const SearchPage = styled.div`
 
   .tone-date {
     margin-left: auto;
-    .date {
-      color: #8f929d;
-    }
+    color: ${(props) => props.theme.css.fPrimaryColor};
     svg {
       margin-top: 0.15em;
       margin-right: 0.5em;


### PR DESCRIPTION
- date filter in advanced search will now center itself instead of piling on the right (short term fix discussed with Bobbi)
- add source and series if present to the search results 
- renamed home page to featured stories

![image](https://github.com/bcgov/tno/assets/15724124/57eddb42-2421-482c-a431-56928c9b7789)

![image](https://github.com/bcgov/tno/assets/15724124/f62e519d-2f37-4640-b501-db79d945a342)

![image](https://github.com/bcgov/tno/assets/15724124/9f73f6e9-c0ca-4a2d-8909-5c3d37b20d92)
