### PR TITLE
fix alignment

### DIFF
--- a/app/subscriber/src/components/share-menu/ShareMenu.tsx
+++ b/app/subscriber/src/components/share-menu/ShareMenu.tsx
@@ -58,7 +58,7 @@ export const ShareMenu: React.FC<IShareSubMenuProps> = ({ content }) => {
   return (
     <styled.ShareMenu className="share-sub-menu">
       <Row justifyContent="end" className="action">
-        <div data-tooltip-id="share">
+        <div className="action" data-tooltip-id="share">
           <FaEnvelope /> SHARE
         </div>
       </Row>


### PR DESCRIPTION
something changed the alignment of the content action bar recently, just lining it up again

CURRENTLY:
![image](https://github.com/bcgov/tno/assets/15724124/e27f079c-3405-479e-8e9e-01912795a429)


AFTER:
![image](https://github.com/bcgov/tno/assets/15724124/c102c27a-0806-4790-87a3-60ffde114e4b)
