### PR TITLE
TNO-2130: Clips being cut off of Evening Overview

### DIFF
--- a/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
+++ b/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
@@ -164,7 +164,8 @@ export const OverviewGrid: React.FC<IOverviewGridProps> = ({ editable = true, in
             )
               acc.push({ index, text: current.summary });
             return acc;
-          }, []),
+          },
+          []),
         );
       });
     }

--- a/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
+++ b/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
@@ -164,8 +164,7 @@ export const OverviewGrid: React.FC<IOverviewGridProps> = ({ editable = true, in
             )
               acc.push({ index, text: current.summary });
             return acc;
-          },
-          []),
+          }, []),
         );
       });
     }
@@ -372,6 +371,7 @@ export const OverviewGrid: React.FC<IOverviewGridProps> = ({ editable = true, in
                                   options={clips ?? []}
                                   width={FieldSize.Medium}
                                   isDisabled={!editable}
+                                  maxMenuHeight={120}
                                   onChange={(newValue) =>
                                     handleSelectionChanged(itemIndex, newValue as IOptionItem)
                                   }


### PR DESCRIPTION
When clips have too many options, and appear at the bottom of the screen it would cause a layout issue with options being cut off. This will restrict the menu size to 120px maximum.