### PR TITLE
TNO-1946: Adjust AV summary/clip column widths, populate summary w/ h…

### DIFF
--- a/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
+++ b/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
@@ -145,6 +145,11 @@ export const OverviewGrid: React.FC<IOverviewGridProps> = ({ editable = true, in
       const selectedClip = content.searchResults?.items?.find((s) => s.id === newValue?.value);
       const publishedOn = moment(selectedClip?.publishedOn).format('HH:mm:ss');
       setFieldValue(`sections.${index}.items.${itemIndex}.time`, publishedOn);
+
+      // Populate summary with clip headline if no summary and headline exists
+      if (selectedClip?.headline && !summary) {
+        setFieldValue(`sections.${index}.items.${itemIndex}.summary`, selectedClip?.headline);
+      }
     }
   };
 
@@ -290,10 +295,9 @@ export const OverviewGrid: React.FC<IOverviewGridProps> = ({ editable = true, in
                                   disabled={!editable}
                                 />
                                 <Col
-                                  flex="1"
+                                  flex="1 1 50em"
                                   style={{
                                     position: 'relative',
-                                    width: '320px',
                                   }}
                                 >
                                   <div
@@ -366,18 +370,26 @@ export const OverviewGrid: React.FC<IOverviewGridProps> = ({ editable = true, in
                                       </styled.AutoCompleteContainer>
                                     )}
                                 </Col>
-                                <FormikSelect
-                                  name={`sections.${index}.items.${itemIndex}.contentId`}
-                                  value={clips?.find((c) => c.value === item.contentId)}
-                                  options={clips ?? []}
-                                  width={FieldSize.Medium}
-                                  isDisabled={!editable}
-                                  maxMenuHeight={120}
-                                  onChange={(newValue) =>
-                                    handleSelectionChanged(itemIndex, newValue as IOptionItem)
-                                  }
-                                />
+                                <Col
+                                  flex="1 0.2 17.5em"
+                                  style={{
+                                    position: 'relative',
+                                  }}
+                                >
+                                  <FormikSelect
+                                    name={`sections.${index}.items.${itemIndex}.contentId`}
+                                    value={clips?.find((c) => c.value === item.contentId)}
+                                    options={clips ?? []}
+                                    width={FieldSize.Medium}
+                                    isDisabled={!editable}
+                                    maxMenuHeight={120}
+                                    onChange={(newValue) =>
+                                      handleSelectionChanged(itemIndex, newValue as IOptionItem)
+                                    }
+                                  />
+                                </Col>
                                 <FaTrash
+                                  style={{ flexShrink: 0 }}
                                   className="clear-item"
                                   key={itemIndex + `trash`}
                                   onClick={() => handleDeleteItem(itemIndex)}

--- a/app/editor/src/features/reports/av-overview/styled/OverviewGrid.tsx
+++ b/app/editor/src/features/reports/av-overview/styled/OverviewGrid.tsx
@@ -42,9 +42,8 @@ export const OverviewGrid = styled.div`
     .placement-header {
       width: 11em;
     }
-
-    .summary-header {
-      max-width: 65em;
+    .content-header {
+      margin-left: auto;
     }
     .placement-header,
     .summary-header,


### PR DESCRIPTION
…eadline if empty & headline exists

Before:
<img width="1728" alt="Screenshot 2024-01-02 at 4 34 06 PM" src="https://github.com/bcgov/tno/assets/7937856/4566a3b8-cc49-495d-b042-41c70d8de312">

After:
<img width="1728" alt="Screenshot 2024-01-02 at 4 34 21 PM" src="https://github.com/bcgov/tno/assets/7937856/0dacff61-e69b-4827-bcc5-2d7ffa1fafc4">
