### PR TITLE
Fix basic search

### DIFF
--- a/app/subscriber/src/components/basic-search/BasicSearch.tsx
+++ b/app/subscriber/src/components/basic-search/BasicSearch.tsx
@@ -1,14 +1,20 @@
 import { filterFormat } from 'features/search-page/utils';
-import { handleEnterPressed } from 'features/utils';
+import { handleEnterPressed, isNumber } from 'features/utils';
 import { FaPlay, FaSearch } from 'react-icons/fa';
 import { useNavigate } from 'react-router';
+import { useParams } from 'react-router-dom';
 import { useContent } from 'store/hooks';
-import { Button, Row, Text, toQueryString } from 'tno-core';
+import { Button, IFilterSettingsModel, Row, Text, toQueryString } from 'tno-core';
 
 import * as styled from './styled';
 
+export interface IBasicSearchProps {
+  onSearch?: (filter: IFilterSettingsModel) => void;
+}
+
 /** Basic search functionality (just search term), and an option to get to the advanced filter */
-export const BasicSearch: React.FC = () => {
+export const BasicSearch = ({ onSearch }: IBasicSearchProps) => {
+  const { id } = useParams();
   const [
     {
       search: { filter },
@@ -17,8 +23,11 @@ export const BasicSearch: React.FC = () => {
   ] = useContent();
   const navigate = useNavigate();
 
+  const filterId = id && isNumber(id) ? parseInt(id) : '';
+
   const handleSearch = async () => {
     navigate(`/search?${toQueryString(filterFormat(filter))}`);
+    onSearch?.(filter);
   };
 
   return (
@@ -30,6 +39,7 @@ export const BasicSearch: React.FC = () => {
           className="search-input"
           onKeyDown={(e) => handleEnterPressed(e, handleSearch)}
           name="search"
+          value={filter.search ?? ''}
           onChange={(e) => {
             storeSearchFilter({ ...filter, search: e.target.value });
           }}
@@ -38,6 +48,7 @@ export const BasicSearch: React.FC = () => {
       <Text
         className="search-mobile"
         name="search-mobile"
+        value={filter.search ?? ''}
         onChange={(e) => {
           storeSearchFilter({ ...filter, search: e.target.value });
         }}
@@ -52,7 +63,7 @@ export const BasicSearch: React.FC = () => {
         Search
         <FaPlay />
       </Button>
-      <p onClick={() => navigate('/search/advanced')}>GO ADVANCED</p>
+      <p onClick={() => navigate(`/search/advanced/${filterId}`)}>GO ADVANCED</p>
     </styled.BasicSearch>
   );
 };

--- a/app/subscriber/src/features/my-searches/MySearches.tsx
+++ b/app/subscriber/src/features/my-searches/MySearches.tsx
@@ -2,7 +2,7 @@ import { Action } from 'components/action';
 import { SubscriberTableContainer } from 'components/table';
 import React from 'react';
 import { FaCheck, FaSave } from 'react-icons/fa';
-import { FaBookmark, FaPen, FaTrash } from 'react-icons/fa6';
+import { FaBookmark, FaGear, FaPen, FaTrash } from 'react-icons/fa6';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useContent, useFilters } from 'store/hooks';
@@ -43,11 +43,11 @@ export const MySearches = () => {
   );
 
   const handleClick = React.useCallback(
-    (filter: IFilterModel) => {
+    (filter: IFilterModel, advanced: boolean = false) => {
       if (editing?.id !== filter.id) {
         storeFilter(filter);
         storeSearchFilter(filter.settings);
-        navigate(`/search/advanced/${filter.id}`);
+        navigate(`/search/${advanced ? `advanced/` : ''}${filter.id}`);
       }
     },
     [editing?.id, navigate, storeFilter, storeSearchFilter],
@@ -87,6 +87,7 @@ export const MySearches = () => {
                   }}
                 />
               )}
+              <FaGear onClick={() => handleClick(filter, true)} />
               <FaTrash
                 onClick={() => {
                   setActive(filter);

--- a/app/subscriber/src/features/router/AppRouter.tsx
+++ b/app/subscriber/src/features/router/AppRouter.tsx
@@ -57,6 +57,15 @@ export const AppRouter: React.FC<IAppRouter> = () => {
           }
         />
         <Route
+          path="/search/:id"
+          element={
+            <PrivateRoute
+              claims={Claim.subscriber}
+              element={<SearchPage showAdvanced={false} />}
+            ></PrivateRoute>
+          }
+        />
+        <Route
           path="/search/advanced"
           element={
             <PrivateRoute

--- a/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
@@ -19,7 +19,17 @@ import { useNavigate } from 'react-router';
 import { toast } from 'react-toastify';
 import { useApp, useContent, useFilters, useLookup } from 'store/hooks';
 import { useProfileStore } from 'store/slices';
-import { Button, Claim, Col, IFilterModel, Row, Show, Text, TextArea } from 'tno-core';
+import {
+  Button,
+  Claim,
+  Col,
+  IFilterModel,
+  IFilterSettingsModel,
+  Row,
+  Show,
+  Text,
+  TextArea,
+} from 'tno-core';
 
 import {
   ContentTypeSection,
@@ -42,7 +52,7 @@ import * as styled from './styled';
 
 export interface IAdvancedSearchProps {
   /** Event fires when search button is clicked. */
-  onSearch?: () => void;
+  onSearch?: (filter: IFilterSettingsModel) => void;
 }
 
 /***
@@ -147,7 +157,7 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ onSearch }) => 
               <TextArea
                 value={search?.search}
                 className="text-area"
-                onKeyDown={(e) => handleEnterPressed(e, () => onSearch?.(), true)}
+                onKeyDown={(e) => handleEnterPressed(e, () => onSearch?.(search), true)}
                 name="search"
                 onChange={(e) => storeSearchFilter({ ...search, search: e.target.value })}
               />
@@ -247,7 +257,7 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ onSearch }) => 
           </button>
           <Button
             onClick={() => {
-              onSearch?.();
+              onSearch?.(search);
             }}
             className="search-button"
           >

--- a/app/subscriber/src/features/search-page/utils/formatSearch.ts
+++ b/app/subscriber/src/features/search-page/utils/formatSearch.ts
@@ -1,0 +1,31 @@
+import parse from 'html-react-parser';
+import { IFilterSettingsModel } from 'tno-core';
+
+export const formatSearch = (text: string, filter: IFilterSettingsModel) => {
+  let tempText = text;
+  let parseText = () => {
+    if (filter.search) return filter.search;
+    else return '';
+  };
+  parseText()
+    .split(' e')
+    .forEach((word) => {
+      const regex = new RegExp(word ?? '', 'gi');
+      // remove duplicates found only want unique matches, this will be varying capitalization
+      const matches = text.match(regex)?.filter((v, i, a) => a.indexOf(v) === i) ?? [];
+      // text.match included in replace in order to keep the proper capitalization
+      // When there is more than one match, this indicates there will be varying capitalization. In this case we
+      // have to iterate through the matches and do a more specific replace in order to keep the words capitalization
+      if (matches.length > 1) {
+        matches.forEach((match, i) => {
+          let multiMatch = new RegExp(`${matches[i]}`);
+          tempText = tempText.replace(multiMatch, `<b>${match}</b>`);
+        });
+      } else {
+        // in this case there will only be one match, so we can just insert the first match
+        tempText = tempText.replace(regex, `<b>${matches[0]}</b>`);
+      }
+    });
+  if (!filter.boldKeywords) return parse(text);
+  return parse(tempText);
+};

--- a/app/subscriber/src/features/search-page/utils/index.ts
+++ b/app/subscriber/src/features/search-page/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './filterFormat';
+export * from './formatSearch';
 export * from './stripHtml';
 export * from './trimWords';

--- a/app/subscriber/src/features/utils/index.ts
+++ b/app/subscriber/src/features/utils/index.ts
@@ -2,4 +2,5 @@ export * from './castToSearchResult';
 export * from './createFilterSettings';
 export * from './determinePreview';
 export * from './handleEnterPressed';
+export * from './isNumber';
 export * from './showTranscription';

--- a/app/subscriber/src/features/utils/isNumber.ts
+++ b/app/subscriber/src/features/utils/isNumber.ts
@@ -1,0 +1,7 @@
+export function isNumber(str: string | undefined | null) {
+  if (typeof str != 'string') return false; // we only process strings!
+  return (
+    !isNaN(str as any) && // use type coercion to parse the _entirety_ of the string (`parseFloat` alone does not do this)...
+    !isNaN(parseFloat(str))
+  ); // ...and ensure strings of whitespace fail
+}

--- a/app/subscriber/src/store/slices/lookup/interfaces/ILookupState.ts
+++ b/app/subscriber/src/store/slices/lookup/interfaces/ILookupState.ts
@@ -43,4 +43,5 @@ export interface ILookupState {
   dataLocations: IDataLocationModel[];
   settings: ISettingModel[];
   rules: ITopicScoreRuleModel[];
+  frontPageImagesMediaTypeId?: number;
 }

--- a/app/subscriber/src/store/slices/lookup/lookupSlice.ts
+++ b/app/subscriber/src/store/slices/lookup/lookupSlice.ts
@@ -123,6 +123,9 @@ export const lookupSlice = createSlice({
     storeSettings(state: ILookupState, action: PayloadAction<ISettingModel[]>) {
       state.settings = action.payload;
     },
+    storeSettingsFrontPageImagesMediaTypeId(state: ILookupState, action: PayloadAction<number>) {
+      state.frontPageImagesMediaTypeId = action.payload;
+    },
     storeHolidays(state: ILookupState, action: PayloadAction<IHolidayModel[]>) {
       state.holidays = action.payload;
     },
@@ -152,4 +155,5 @@ export const {
   storeRoles,
   storeDataLocations,
   storeIngestTypes,
+  storeSettingsFrontPageImagesMediaTypeId,
 } = lookupSlice.actions;

--- a/app/subscriber/src/store/slices/lookup/useLookupStore.ts
+++ b/app/subscriber/src/store/slices/lookup/useLookupStore.ts
@@ -39,6 +39,7 @@ import {
   storeRules,
   storeSeries,
   storeSettings,
+  storeSettingsFrontPageImagesMediaTypeId,
   storeSourceActions,
   storeSources,
   storeTags,
@@ -72,6 +73,7 @@ export interface ILookupStore {
   storeUsers: (users: IUserModel[]) => void;
   storeDataLocations: (dataLocations: IDataLocationModel[]) => void;
   storeSettings: (settings: ISettingModel[]) => void;
+  storeSettingsFrontPageImagesMediaTypeId: (id: number) => void;
 }
 
 export const useLookupStore = (): [ILookupState, ILookupStore] => {
@@ -139,6 +141,9 @@ export const useLookupStore = (): [ILookupState, ILookupStore] => {
       },
       storeSettings: (settings: ISettingModel[]) => {
         dispatch(storeSettings(settings));
+      },
+      storeSettingsFrontPageImagesMediaTypeId: (id: number) => {
+        dispatch(storeSettingsFrontPageImagesMediaTypeId(id));
       },
       storeHolidays: (holidays: IHolidayModel[]) => {
         dispatch(storeHolidays(holidays));

--- a/libs/npm/core/src/utils/convertTo.ts
+++ b/libs/npm/core/src/utils/convertTo.ts
@@ -1,7 +1,7 @@
 /**
  * Convert the specified 'value' to the specified 'type', or return the specified 'defaultValue'.
  * @param value The value to convert.
- * @param type The type to conver to.
+ * @param type The type to convert to.
  * @param defaultValue The default value if there is no conversion map or value.
  * @returns The converter value or default value.
  */


### PR DESCRIPTION
Resolved regression bug introduced into the basic search.

My Saves Searches will now load the full page results instead of the Advanced Search.  Clicking the GO ADVANCED will load the component to edit the search.  I've added the gear icon back which will go directly to the advanced search.

![image](https://github.com/bcgov/tno/assets/3180256/58430582-a4e3-44f4-8769-9ef2786f1b03)
