### PR TITLE
fix: #tno-2151 - fixed reset settings

### DIFF
--- a/app/subscriber/src/components/tool-bar/styled/ContentActionBar.tsx
+++ b/app/subscriber/src/components/tool-bar/styled/ContentActionBar.tsx
@@ -26,7 +26,6 @@ export const ContentActionBar = styled(Row)`
 
   .right-side-items {
     margin-left: auto;
-    margin-right: 0.5em;
     color: ${(props) => props.theme.css.btnBkPrimary};
     @media (max-width: 768px) {
       span {
@@ -49,12 +48,8 @@ export const ContentActionBar = styled(Row)`
   &.list-view {
     background-color: ${(props) => props.theme.css.lineQuaternaryColor};
     margin-bottom: 1em;
-    width: calc(100% + 1.2em);
-    /* negative margin is to bypass the padding of the parent (PageSection) to match UI designs */
-    margin-left: -1.2em;
-    margin-right: -1.2em;
     border: 1px solid ${(props) => props.theme.css.lineTertiaryColor};
-    padding: 0.5em;
+    padding: 0em;
     .select-all {
       .check-area {
         @media (max-width: 768px) {
@@ -62,12 +57,9 @@ export const ContentActionBar = styled(Row)`
         }
         display: flex;
         flex-direction: row;
-        padding: 0.5em;
+        padding: 0.5em 0.5em 0.5em 0em;
       }
       height: 2.5em;
-      margin-top: -1.5em;
-      margin-bottom: -1.5em;
-      margin-left: -0.5em;
       background-color: ${(props) => props.theme.css.bkQuaternary};
     }
     .arrow {

--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -12,7 +12,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useContent, useFilters, useLookup } from 'store/hooks';
 import { useProfileStore } from 'store/slices';
-import { Checkbox, Col, IContentModel, Loading, Row, Show, toQueryString } from 'tno-core';
+import { Checkbox, Col, IContentModel, Loading, Row, Show } from 'tno-core';
 
 import { AdvancedSearch } from './components';
 import { Player } from './player/Player';
@@ -84,7 +84,6 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
     // Need to wait until front page images are in redux store before making a request.
     if (frontPageImagesMediaTypeId) {
       const settings = filterFormat(filter, actions);
-      navigate(`?${toQueryString(settings)}`);
       const query = genQuery(settings);
       fetchResults(query, filter.searchUnpublished);
     }
@@ -94,10 +93,9 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
 
   const handleSearch = React.useCallback(async () => {
     const settings = filterFormat(filter, actions);
-    navigate(`?${toQueryString(settings)}`);
     const query = genQuery(settings);
     fetchResults(query, filter.searchUnpublished);
-  }, [actions, fetchResults, filter, genQuery, navigate]);
+  }, [actions, fetchResults, filter, genQuery]);
 
   return (
     <styled.SearchPage>

--- a/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
@@ -138,7 +138,11 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ onSearch }) => 
                       ...defaultAdvancedSearch,
                       ...originalFilterSettings,
                     } as IFilterSettingsModel)
-                  : { ...search, ...defaultAdvancedSearch };
+                  : {
+                      ...search,
+                      ...defaultAdvancedSearch,
+                      search: search.search,
+                    };
                 storeSearchFilter(resetFilter);
               }}
             />

--- a/app/subscriber/src/features/search-page/components/advanced-search/components/ExpandableRow.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/components/ExpandableRow.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { IoIosArrowDropdownCircle, IoIosArrowDroprightCircle } from 'react-icons/io';
-import { Row } from 'tno-core';
+import { MdOutlineFilterList } from 'react-icons/md';
+import { Tooltip } from 'react-tooltip';
+import { Col, Row } from 'tno-core';
 
 export interface IExpandableRowProps {
   /** icon to be displayed on the row */
@@ -9,21 +11,57 @@ export interface IExpandableRowProps {
   title: string;
   /** children to be displayed when the row is expanded */
   children: React.ReactNode;
+  /** show icon to indicate values are set inside collapsible row */
+  hasValues: boolean;
 }
 
 /** contains the logic and skeleton for an expandable row in the advanced search section. helps to eliminate redundant code. */
-export const ExpandableRow: React.FC<IExpandableRowProps> = ({ children, icon, title }) => {
+export const ExpandableRow: React.FC<IExpandableRowProps> = ({
+  children,
+  icon,
+  title,
+  hasValues = true,
+}) => {
   const [expanded, setExpanded] = React.useState(false);
+  const [uniqueId] = React.useState(new Date().getTime().toString(36));
   return (
     <>
       <Row className="option-row" onClick={() => setExpanded(!expanded)}>
+        <Tooltip
+          style={{ zIndex: '999' }}
+          variant="info"
+          id={`btn-tip-${uniqueId}`}
+          place="top"
+          float
+        />
         {icon}
         {title}
-        {!expanded ? (
-          <IoIosArrowDroprightCircle onClick={() => setExpanded(true)} className="drop-icon" />
-        ) : (
-          <IoIosArrowDropdownCircle onClick={() => setExpanded(false)} className="drop-icon" />
-        )}
+        <Col className="action-icons">
+          {hasValues ? (
+            <MdOutlineFilterList
+              data-tooltip-id={`btn-tip-${uniqueId}`}
+              data-tooltip-content="Expand to see current filter settings"
+            />
+          ) : (
+            <></>
+            // <MdOutlineFilterListOff />
+          )}
+          {!expanded ? (
+            <IoIosArrowDroprightCircle
+              onClick={() => setExpanded(true)}
+              className="drop-icon"
+              data-tooltip-id={`btn-tip-${uniqueId}`}
+              data-tooltip-content="Expand"
+            />
+          ) : (
+            <IoIosArrowDropdownCircle
+              onClick={() => setExpanded(false)}
+              className="drop-icon"
+              data-tooltip-id={`btn-tip-${uniqueId}`}
+              data-tooltip-content="Collapse"
+            />
+          )}
+        </Col>
       </Row>
       {expanded && <div className="option-children">{children}</div>}
     </>

--- a/app/subscriber/src/features/search-page/components/advanced-search/components/sections/SearchInGroup.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/components/sections/SearchInGroup.tsx
@@ -14,22 +14,25 @@ export const SearchInGroup: React.FC = () => {
     <Row className="options expanded space-top">
       <label className="search-in-label">SEARCH IN: </label>
       <Checkbox
+        id="chkInHeadline"
+        label="Headline"
         checked={filter.inHeadline}
         onChange={(e) => {
           storeFilter({ ...filter, inHeadline: e.target.checked });
         }}
       />
-      <label>Headline</label>
       <Checkbox
+        id="chkInByline"
+        label="Byline"
         checked={filter.inByline}
         onChange={(e) => storeFilter({ ...filter, inByline: e.target.checked })}
       />
-      <label>Byline</label>
       <Checkbox
+        id="chkInStory"
+        label="Story text"
         checked={filter.inStory}
         onChange={(e) => storeFilter({ ...filter, inStory: e.target.checked })}
       />
-      <label>Story text</label>
     </Row>
   );
 };

--- a/app/subscriber/src/features/search-page/components/advanced-search/constants/DefaultAdvancedSearch.ts
+++ b/app/subscriber/src/features/search-page/components/advanced-search/constants/DefaultAdvancedSearch.ts
@@ -13,7 +13,7 @@ export const defaultAdvancedSearch = {
   page: '',
   publishedEndOn: '',
   publishedStartOn: '',
-  // search: '', // don't reset this...
+  search: '',
   section: '',
   sentiment: [],
   seriesIds: [],

--- a/app/subscriber/src/features/search-page/components/advanced-search/constants/DefaultAdvancedSearch.ts
+++ b/app/subscriber/src/features/search-page/components/advanced-search/constants/DefaultAdvancedSearch.ts
@@ -13,8 +13,9 @@ export const defaultAdvancedSearch = {
   page: '',
   publishedEndOn: '',
   publishedStartOn: '',
-  search: '',
+  // search: '', // don't reset this...
   section: '',
+  sentiment: [],
   seriesIds: [],
   sourceIds: [],
   tags: [],

--- a/app/subscriber/src/features/search-page/components/advanced-search/styled/AdvancedSearch.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/styled/AdvancedSearch.tsx
@@ -23,8 +23,6 @@ export const AdvancedSearch = styled(Row)`
     width: 100%;
     padding: 0.5em;
     align-items: center;
-    border-bottom-left-radius: 0.75em;
-    border-bottom-right-radius: 0.75em;
     .save-cloud {
       margin-right: 0.5em;
       max-height: 30px;
@@ -51,7 +49,11 @@ export const AdvancedSearch = styled(Row)`
     }
   }
   .main-search-body {
-    padding-left: 0.5em;
+    padding: 0em 1em;
+    .viewed-name {
+      margin: 0 -1em;
+      padding-left: 1em;
+    }
   }
   /* HEADER OF THE ADVANCED SEARCH COMPONENT */
   .top-bar {
@@ -112,6 +114,10 @@ export const AdvancedSearch = styled(Row)`
   /* TEXT AREA IN SEARCH IN GROUP */
   .text-area-container {
     width: 100%;
+    .frm-in {
+      padding-right: 0;
+      padding-bottom: 0;
+    }
     .text-area {
       resize: vertical;
     }
@@ -180,6 +186,10 @@ export const AdvancedSearch = styled(Row)`
     &:hover {
       cursor: pointer;
     }
+    .drop-icon {
+      margin-left: auto;
+      cursor: pointer;
+    }
   }
 
   .paper-attributes-container {
@@ -232,9 +242,12 @@ export const AdvancedSearch = styled(Row)`
 
   .section {
     width: 100%;
-    .drop-icon {
+    .action-icons {
       margin-left: auto;
-      cursor: pointer;
+      flex-direction: row;
+      .drop-icon {
+        cursor: pointer;
+      }
     }
     svg {
       margin-right: 0.5em;
@@ -264,7 +277,7 @@ export const AdvancedSearch = styled(Row)`
   }
 
   .date-range {
-    padding: 0.25em;
+    padding-bottom: 0.5em;
     .picker {
       margin-right: 0.5em;
       @media (max-width: 1300px) {

--- a/app/subscriber/src/features/search-page/styled/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/styled/SearchPage.tsx
@@ -19,8 +19,8 @@ export const SearchPage = styled.div`
     background-color: ${(props) => props.theme.css.bkWhite};
     padding-bottom: 0.5em;
     padding-top: 0.5em;
-    margin-left: 0.5em;
-    margin-right: 0.5em;
+    // margin-left: 0.5em;
+    // margin-right: 0.5em;
     svg {
       color: ${(props) => props.theme.css.iconPrimaryColor};
     }
@@ -68,6 +68,15 @@ export const SearchPage = styled.div`
   .page-section {
     max-height: calc(100vh - 10em);
     overflow: hidden;
+  }
+  .adv-search-container > div {
+    margin: 0em 1em;
+    .page-section {
+      margin: 0rem;
+    }
+  }
+  .result-container > .page-section {
+    margin: 0em 1em 0em 0em;
   }
 
   /** END HEADER */


### PR DESCRIPTION
- added visual hint for advanced search settings when section is collapsed
- added tooltips to icons in collapsible section
- fixed check box labels to be clickable for "search in"
- altered layout for advanced search to remove excess margins
- removed a bunch of uneccesary css
- In the screen grab below, Sentiment and Media Types both have search criteria set, as hinted at by the indicator (which has a tooltip)
![image](https://github.com/bcgov/tno/assets/63015960/bc192d37-bfbc-4010-9ef8-652765010158)
