### PR TITLE
TNO-1992: Fix expanding Story WYSIWYG editor to full size

### DIFF
--- a/app/editor/src/index.scss
+++ b/app/editor/src/index.scss
@@ -181,8 +181,8 @@ h4 {
       resize: both;
       // TODO: Figure out flexbox implementation.
       // I can't figure out how to make this expand.
-      width: calc(100vw - 10em);
-      height: calc(100vh - 15em);
+      width: calc(100vw - 7vw);
+      height: calc(100vh - 20em);
     }
   }
 }


### PR DESCRIPTION
Tested on various size screens:
<img width="1979" alt="Screenshot 2024-01-08 at 5 34 32 PM" src="https://github.com/bcgov/tno/assets/7937856/15f31147-6fc2-4541-9805-091d400ec674">

<img width="1240" alt="Screenshot 2024-01-08 at 5 35 39 PM" src="https://github.com/bcgov/tno/assets/7937856/460fab20-4eb9-44d9-bccc-cf191cf5b7d4">

<img width="1259" alt="Screenshot 2024-01-08 at 5 35 51 PM" src="https://github.com/bcgov/tno/assets/7937856/8582786f-6827-482f-8411-0e524a593d14">
