### PR TITLE
TNO-2138: Display all enabled sources for images

### DIFF
--- a/app/editor/src/features/content/form/ImageSection.tsx
+++ b/app/editor/src/features/content/form/ImageSection.tsx
@@ -15,9 +15,6 @@ import {
 
 import { IContentForm } from './interfaces';
 
-// TODO: This is horrible to hardcode these sources, the image form is for any type of image and shouldn't be limited to a few sources.
-const validSources = ['TC', 'PROVINCE', 'GLOBE', 'POST', 'SUN'];
-
 interface IImageSectionProps {}
 
 /** Contains form field in a layout specific to the image snippet. */
@@ -28,9 +25,7 @@ export const ImageSection: React.FunctionComponent<IImageSectionProps> = (props)
   const [sourceOptions, setSourceOptions] = React.useState<IOptionItem[]>([]);
 
   React.useEffect(() => {
-    setSourceOptions(
-      getSourceOptions(sources.filter((s) => validSources.some((v) => v === s.code))),
-    );
+    setSourceOptions(getSourceOptions(sources));
   }, [sources]);
 
   return (


### PR DESCRIPTION
Image content can now select from all enabled sources

<img width="561" alt="Screenshot 2024-01-08 at 5 55 10 PM" src="https://github.com/bcgov/tno/assets/7937856/c1db22fd-7e2f-411d-b092-d27b5afc0338">
