### PR TITLE
TNO-2096 Fix to allow check box selection

### DIFF
--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -181,9 +181,12 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
                       >
                         <Col className="cols">
                           <Row>
-                            <Col className="checkBoxColumn" alignItems="center">
+                            <Col
+                              className="checkBoxColumn"
+                              alignItems="center"
+                              onClick={(e) => e.stopPropagation()}
+                            >
                               <Checkbox
-                                onClick={(e) => e.stopPropagation()}
                                 onChange={(e) => {
                                   if (e.target.checked) {
                                     setSelected([...selected, item]);

--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -183,6 +183,7 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
                           <Row>
                             <Col className="checkBoxColumn" alignItems="center">
                               <Checkbox
+                                onClick={(e) => e.stopPropagation()}
                                 onChange={(e) => {
                                   if (e.target.checked) {
                                     setSelected([...selected, item]);


### PR DESCRIPTION
Still keeping the behavior on clicking the whole line to navigate to content, but allowing the click on the check box.

![image](https://github.com/bcgov/tno/assets/26801490/390442bf-e305-4426-ae3a-3bb7f3443829)
