### PR TITLE
TNO-2212 Persist manual tags state "onLoad"

### DIFF
--- a/app/editor/src/features/content/form/components/tags/Tags.tsx
+++ b/app/editor/src/features/content/form/components/tags/Tags.tsx
@@ -20,6 +20,7 @@ export const Tags: React.FC<ITagsProps> = ({ selectedExternal }) => {
   const { values, setFieldValue } = useFormikContext<IContentForm>();
   const [{ tags }] = useLookup();
   const [showList, setShowList] = React.useState(false);
+  const [initialTagsLoad, setInitialTagsLoad] = React.useState(true);
   const [externalTags, setExternalTags] = React.useState<ITagModel[]>([]);
   const [manualTags, setManualTags] = React.useState<ITagModel[]>([]);
 
@@ -29,6 +30,15 @@ export const Tags: React.FC<ITagsProps> = ({ selectedExternal }) => {
       document.getElementById('tag-list')?.scrollIntoView({ behavior: 'smooth' });
     }
   }, [showList]);
+
+  React.useEffect(() => {
+    if (initialTagsLoad) {
+      if (values.tags.length > 0) {
+        setManualTags(values.tags);
+        setInitialTagsLoad(false);
+      }
+    }
+  }, [initialTagsLoad, values.tags]);
 
   React.useEffect(() => {
     const ext = tags.filter((tag) => selectedExternal?.some((t: string) => t === tag.code));


### PR DESCRIPTION
I needed to set the tags in the component as manual once it's loaded (because they are already persisted).
Once it's done, then the behavior will be the same, and persisted tags that are not in the text, will not be wiped.