### PR TITLE
Tno 2139 filter content by transcription

### DIFF
--- a/app/editor/src/features/content/constants/ShowOnlyValues.ts
+++ b/app/editor/src/features/content/constants/ShowOnlyValues.ts
@@ -6,4 +6,5 @@ export enum ShowOnlyValues {
   OnTicker = 'On Ticker',
   Homepage = 'Homepage',
   Published = 'Published',
+  PendingTranscript = 'Pending Transcript',
 }

--- a/app/editor/src/features/content/constants/showOnlyOptions.ts
+++ b/app/editor/src/features/content/constants/showOnlyOptions.ts
@@ -8,4 +8,5 @@ export const showOnlyOptions = [
   new OptionItem(ShowOnlyValues.Commentary, ShowOnlyValues.Commentary),
   new OptionItem(ShowOnlyValues.TopStory, ShowOnlyValues.TopStory),
   new OptionItem(ShowOnlyValues.Published, ShowOnlyValues.Published),
+  new OptionItem(ShowOnlyValues.PendingTranscript, ShowOnlyValues.PendingTranscript),
 ];

--- a/app/editor/src/features/content/interfaces/IContentListFilter.ts
+++ b/app/editor/src/features/content/interfaces/IContentListFilter.ts
@@ -22,4 +22,5 @@ export interface IContentListFilter {
   topStory: boolean;
   homepage: boolean;
   sort: ISortBy[];
+  pendingTranscript?: boolean;
 }

--- a/app/editor/src/features/content/list-view/ContentListView.tsx
+++ b/app/editor/src/features/content/list-view/ContentListView.tsx
@@ -1,7 +1,7 @@
 import { NavigateOptions, useTab } from 'components/tab-control';
 import React, { lazy } from 'react';
 import { useParams } from 'react-router-dom';
-import { useApiHub, useApp, useContent } from 'store/hooks';
+import { useApiHub, useApp, useContent, useWorkOrders } from 'store/hooks';
 import { IContentSearchResult, useContentStore } from 'store/slices';
 import { castContentToSearchResult } from 'store/slices/content/utils';
 import {
@@ -55,6 +55,8 @@ const ContentListView: React.FC = () => {
   const [contentType, setContentType] = React.useState(formType ?? ContentTypeName.AudioVideo);
   const [isLoading, setIsLoading] = React.useState(false);
 
+  const [{ transcriptFilter: woFilter }, { findWorkOrders }] = useWorkOrders();
+
   React.useEffect(() => {
     // Extract query string values and place them into redux store.
     if (!!window.location.search) {
@@ -82,6 +84,8 @@ const ContentListView: React.FC = () => {
 
   const onWorkOrder = React.useCallback(
     (workOrder: IWorkOrderMessageModel) => {
+      // eslint-disable-next-line no-console
+      console.log('tes ACVDDF');
       if (
         [WorkOrderTypeName.Transcription, WorkOrderTypeName.NaturalLanguageProcess].includes(
           workOrder.workType,
@@ -142,10 +146,20 @@ const ContentListView: React.FC = () => {
         if (!isLoading) {
           setIsLoading(true);
           const result = await findContentWithElasticsearch(toFilter(filter), true);
-          const items = result.hits?.hits?.map((h) =>
-            castContentToSearchResult(h._source as IContentModel),
-          );
+          const items = result.hits?.hits
+            ?.map((h) => castContentToSearchResult(h._source as IContentModel))
+            .map((m) => {
+              let v = { ...m };
+              v.headline = '123';
+              return v;
+            });
+          // const response = await findWorkOrders(woFilter);
+          // response.data.items.forEach((i) => {
+          //   items[0].transcriptStatus = i.status;
+          // });
           const page = new Page(1, filter.pageSize, items, result.hits?.total as number);
+          // eslint-disable-next-line no-console
+          console.log('WORDERS', items, page);
           return page;
         }
       } catch {

--- a/app/editor/src/features/content/list-view/ContentListView.tsx
+++ b/app/editor/src/features/content/list-view/ContentListView.tsx
@@ -13,13 +13,16 @@ import {
   ITableInternalRow,
   ITablePage,
   ITableSort,
+  IWorkOrderFilter,
   IWorkOrderMessageModel,
+  IWorkOrderModel,
   MessageTargetName,
   Page,
   replaceQueryParams,
   Row,
   Show,
   useCombinedView,
+  WorkOrderStatusName,
   WorkOrderTypeName,
 } from 'tno-core';
 
@@ -52,10 +55,11 @@ const ContentListView: React.FC = () => {
   const toFilter = useElasticsearch();
 
   const [contentId, setContentId] = React.useState(id);
+  const [workOrders, setWorkOrders] = React.useState<IWorkOrderModel[]>([]);
   const [contentType, setContentType] = React.useState(formType ?? ContentTypeName.AudioVideo);
   const [isLoading, setIsLoading] = React.useState(false);
 
-  const [{ transcriptFilter: woFilter }, { findWorkOrders }] = useWorkOrders();
+  const [, { findWorkOrders }] = useWorkOrders();
 
   React.useEffect(() => {
     // Extract query string values and place them into redux store.
@@ -67,25 +71,26 @@ const ContentListView: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const page = React.useMemo(
-    () =>
-      !!searchResults
-        ? new Page(
-            searchResults.page - 1,
-            filter.pageSize,
-            searchResults?.items,
-            searchResults.total,
-          )
-        : defaultPage,
-    [filter.pageSize, searchResults],
-  );
+  const page = React.useMemo(() => {
+    let items: IContentSearchResult[] | undefined = searchResults?.items.map((m) => {
+      let v = { ...m };
+      v.transcriptStatus = workOrders.find((w) => w.contentId === m.id)?.status;
+      return v;
+    });
+    if (filter.pendingTranscript && items) {
+      items = items.filter((x) => x.transcriptStatus === WorkOrderStatusName.InProgress);
+    }
+    if (searchResults && items) {
+      return new Page(searchResults.page - 1, filter.pageSize, items, searchResults.total);
+    } else {
+      return defaultPage;
+    }
+  }, [filter.pageSize, filter.pendingTranscript, searchResults, workOrders]);
   const userId = userInfo?.id ?? '';
   const isReady = !!userId && filter.userId !== '';
 
   const onWorkOrder = React.useCallback(
     (workOrder: IWorkOrderMessageModel) => {
-      // eslint-disable-next-line no-console
-      console.log('tes ACVDDF');
       if (
         [WorkOrderTypeName.Transcription, WorkOrderTypeName.NaturalLanguageProcess].includes(
           workOrder.workType,
@@ -146,25 +151,26 @@ const ContentListView: React.FC = () => {
         if (!isLoading) {
           setIsLoading(true);
           const result = await findContentWithElasticsearch(toFilter(filter), true);
-          const items = result.hits?.hits
-            ?.map((h) => castContentToSearchResult(h._source as IContentModel))
-            .map((m) => {
-              let v = { ...m };
-              v.headline = '123';
-              return v;
-            });
-          // const response = await findWorkOrders(woFilter);
-          // response.data.items.forEach((i) => {
-          //   items[0].transcriptStatus = i.status;
-          // });
+          const items = result.hits?.hits?.map((h) =>
+            castContentToSearchResult(h._source as IContentModel),
+          );
           const page = new Page(1, filter.pageSize, items, result.hits?.total as number);
-          // eslint-disable-next-line no-console
-          console.log('WORDERS', items, page);
           return page;
         }
       } catch {
       } finally {
         setIsLoading(false);
+        const endDate = new Date();
+        const startDate = new Date();
+        startDate.setDate(endDate.getDate() - 3);
+        const woFilter: IWorkOrderFilter = {
+          createdStartOn: startDate.toLocaleDateString('en-US'),
+          createdEndOn: endDate.toLocaleDateString('en-US'),
+        };
+        const response = await findWorkOrders(woFilter);
+        if (response) {
+          setWorkOrders(response.data.items);
+        }
       }
     },
     // 'isLoading' will result in an infinite loop for some reason.

--- a/app/editor/src/features/content/list-view/components/tool-bar/filter/ShowOnlySection.tsx
+++ b/app/editor/src/features/content/list-view/components/tool-bar/filter/ShowOnlySection.tsx
@@ -61,6 +61,8 @@ export const ShowOnlySection: React.FC<IShowOnlySectionProps> = () => {
       if (filter.hasTopic) selectedOptions.push(showOnlyOptions[1]);
       if (filter.commentary) selectedOptions.push(showOnlyOptions[2]);
       if (filter.topStory) selectedOptions.push(showOnlyOptions[3]);
+      if (filter.onlyPublished) selectedOptions.push(showOnlyOptions[4]);
+      if (filter.pendingTranscript) selectedOptions.push(showOnlyOptions[5]);
       return selectedOptions;
     };
 
@@ -111,6 +113,9 @@ export const ShowOnlySection: React.FC<IShowOnlySectionProps> = () => {
                     commentary: values.some((o) => o.value === ShowOnlyValues.Commentary),
                     topStory: values.some((o) => o.value === ShowOnlyValues.TopStory),
                     onlyPublished: values.some((o) => o.value === ShowOnlyValues.Published),
+                    pendingTranscript: values.some(
+                      (o) => o.value === ShowOnlyValues.PendingTranscript,
+                    ),
                   };
                 });
               }}
@@ -186,6 +191,20 @@ export const ShowOnlySection: React.FC<IShowOnlySectionProps> = () => {
                     ...filter,
                     pageIndex: 0,
                     onlyPublished: e.target.checked,
+                  });
+                }}
+              />
+              <Checkbox
+                className="spaced"
+                name="pendingTranscript"
+                label="Pending Transcript"
+                tooltip="Pending Transcript"
+                checked={filter.pendingTranscript}
+                onChange={(e) => {
+                  onChange({
+                    ...filter,
+                    pageIndex: 0,
+                    pendingTranscript: e.target.checked,
                   });
                 }}
               />

--- a/app/editor/src/features/content/list-view/hooks/useColumns.tsx
+++ b/app/editor/src/features/content/list-view/hooks/useColumns.tsx
@@ -2,7 +2,8 @@ import { Status } from 'components/status';
 import { TabControl } from 'components/tab-control';
 import { AdvancedSearchKeys } from 'features/content/constants';
 import { IContentListAdvancedFilter, IContentListFilter } from 'features/content/interfaces';
-import { FaFeather } from 'react-icons/fa';
+import { FaBug, FaCheckCircle, FaClock, FaFeather } from 'react-icons/fa';
+import { FaCirclePause, FaRegCircleRight } from 'react-icons/fa6';
 import { useContent } from 'store/hooks';
 import { IContentSearchResult } from 'store/slices';
 import {
@@ -15,6 +16,8 @@ import {
   Page,
   Row,
   Show,
+  Spinner,
+  WorkOrderStatusName,
 } from 'tno-core';
 
 export interface IColumnProps {
@@ -123,7 +126,27 @@ export const useColumns = ({ fetch }: IColumnProps): ITableHookColumn<IContentSe
       label: 'Transcript',
       hAlign: 'center',
       width: '155px',
-      cell: (cell) => <div>{cell.original.transcriptStatus}</div>,
+      cell: (cell) => {
+        if (cell.original.transcriptStatus === WorkOrderStatusName.InProgress)
+          return <Spinner size="8px" title="Transcribing" />;
+        if (
+          cell.original.transcriptStatus === WorkOrderStatusName.Completed &&
+          !cell.original.isApproved
+        )
+          return <FaRegCircleRight className="completed" title="Ready to review" />;
+        if (
+          cell.original.transcriptStatus === WorkOrderStatusName.Completed &&
+          cell.original.isApproved
+        )
+          return <FaCheckCircle className="completed" title="Completed" />;
+        if (cell.original.transcriptStatus === WorkOrderStatusName.Submitted)
+          return <FaClock className="submitted" title="Submitted" />;
+        if (cell.original.transcriptStatus === WorkOrderStatusName.Failed)
+          return <FaBug className="failed" title="Failed" />;
+        if (cell.original.transcriptStatus === WorkOrderStatusName.Cancelled)
+          return <FaCirclePause className="cancelled" title="Cancelled" />;
+        return cell.original.transcriptStatus;
+      },
     },
   ];
 };

--- a/app/editor/src/features/content/list-view/hooks/useColumns.tsx
+++ b/app/editor/src/features/content/list-view/hooks/useColumns.tsx
@@ -118,5 +118,12 @@ export const useColumns = ({ fetch }: IColumnProps): ITableHookColumn<IContentSe
       width: '55px',
       cell: (cell) => <Status value={cell.original.status} />,
     },
+    {
+      accessor: 'transcript',
+      label: 'Transcript',
+      hAlign: 'center',
+      width: '155px',
+      cell: (cell) => <div>{cell.original.transcriptStatus}</div>,
+    },
   ];
 };

--- a/app/editor/src/store/slices/content/interfaces/IContentSearchResult.ts
+++ b/app/editor/src/store/slices/content/interfaces/IContentSearchResult.ts
@@ -24,4 +24,5 @@ export interface IContentSearchResult {
   // React-Table Properties
   // TODO: Should not be part of the API interface.
   isSelected?: boolean;
+  transcriptStatus?: string;
 }


### PR DESCRIPTION
- When the list is already rendered, a call is made to retrieve the work orders on the last two days.
- New Column added to display transcript status
- If there are work orders, the new column is filled
- Added option at Show Only to display the pending transcripts
- When the Option is checked, a frontend "filter" function is called to display that status.