### PR TITLE
TNO-2149: Move basic search to header

### DIFF
--- a/app/subscriber/src/components/basic-search/BasicSearch.tsx
+++ b/app/subscriber/src/components/basic-search/BasicSearch.tsx
@@ -41,7 +41,7 @@ export const BasicSearch = ({ onSearch, inHeader }: IBasicSearchProps) => {
   };
 
   return (
-    <styled.BasicSearch $inHeader={inHeader}>
+    <styled.BasicSearch inHeader={inHeader}>
       <label>SEARCH FOR: </label>
       <Row className="icon-search">
         <FaSearch onClick={() => handleSearch()} className="search-icon" />

--- a/app/subscriber/src/components/basic-search/BasicSearch.tsx
+++ b/app/subscriber/src/components/basic-search/BasicSearch.tsx
@@ -10,10 +10,12 @@ import * as styled from './styled';
 
 export interface IBasicSearchProps {
   onSearch?: (filter: IFilterSettingsModel) => void;
+  /** whether to display the header variant of the search */
+  inHeader?: boolean;
 }
 
 /** Basic search functionality (just search term), and an option to get to the advanced filter */
-export const BasicSearch = ({ onSearch }: IBasicSearchProps) => {
+export const BasicSearch = ({ onSearch, inHeader }: IBasicSearchProps) => {
   const { id } = useParams();
   const [
     {
@@ -39,7 +41,7 @@ export const BasicSearch = ({ onSearch }: IBasicSearchProps) => {
   };
 
   return (
-    <styled.BasicSearch>
+    <styled.BasicSearch $inHeader={inHeader}>
       <label>SEARCH FOR: </label>
       <Row className="icon-search">
         <FaSearch onClick={() => handleSearch()} className="search-icon" />

--- a/app/subscriber/src/components/basic-search/styled/BasicSearch.tsx
+++ b/app/subscriber/src/components/basic-search/styled/BasicSearch.tsx
@@ -1,14 +1,14 @@
 import styled from 'styled-components';
 import { Row } from 'tno-core';
 
-export const BasicSearch = styled(Row)<{ $inHeader?: boolean }>`
+export const BasicSearch = styled(Row)<{ inHeader?: boolean }>`
   ${(props) =>
-    props.$inHeader &&
+    props.inHeader &&
     `
       width: 60%;
     `}
   ${(props) =>
-    !props.$inHeader &&
+    !props.inHeader &&
     `
       width: 100%;
       background: ${props.theme.css.bkSecondary};
@@ -26,7 +26,7 @@ export const BasicSearch = styled(Row)<{ $inHeader?: boolean }>`
     font-size: 0.8em;
     margin-right: 0.5em;
     align-self: center;
-    margin-left: ${(props) => props.$inHeader && '5%'};
+    margin-left: ${(props) => props.inHeader && '5%'};
   }
 
   /** GROUP CONTAINING ICON AND SEARCH INPUT  */
@@ -66,14 +66,14 @@ export const BasicSearch = styled(Row)<{ $inHeader?: boolean }>`
   .search-mobile {
     display: flex;
     max-width: 13em;
-    margin-top: ${(props) => !props.$inHeader && 'auto'};
+    margin-top: ${(props) => !props.inHeader && 'auto'};
     padding: 0;
   }
   /** SEARCH BUTTON */
   .search-button {
     display: flex;
     margin-left: 0.5em;
-    margin-bottom: ${(props) => props.$inHeader && '0.5em'};
+    margin-bottom: ${(props) => props.inHeader && '0.5em'};
     align-self: center;
     font-weight: 400;
     font-size: 0.8em;
@@ -108,7 +108,7 @@ export const BasicSearch = styled(Row)<{ $inHeader?: boolean }>`
   /* GO ADVANCED TEXT */
   p {
     font-size: 0.8em;
-    margin-left: ${(props) => (props.$inHeader ? '3em' : 'auto')};
+    margin-left: ${(props) => (props.inHeader ? '3em' : 'auto')};
     align-self: center;
     margin-right: 0.5em;
     color: ${(props) => props.theme.css.fRedColor};

--- a/app/subscriber/src/components/basic-search/styled/BasicSearch.tsx
+++ b/app/subscriber/src/components/basic-search/styled/BasicSearch.tsx
@@ -1,28 +1,39 @@
 import styled from 'styled-components';
 import { Row } from 'tno-core';
 
-export const BasicSearch = styled(Row)`
-  width: 100%;
-  margin: 0.25em;
-  border-color: ${(props) => props.theme.css.inputGrey};
-  border-style: solid;
-  border-width: 1px;
-  border-radius: 1em;
-  background: ${(props) => props.theme.css.bkSecondary};
-  box-shadow: ${(props) => props.theme.css.boxShadow};
-  padding: 0.5em;
+export const BasicSearch = styled(Row)<{ $inHeader?: boolean }>`
+  ${(props) =>
+    props.$inHeader &&
+    `
+      width: 60%;
+    `}
+  ${(props) =>
+    !props.$inHeader &&
+    `
+      width: 100%;
+      background: ${props.theme.css.bkSecondary};
+      margin: 0.25em;
+      border-color: ${props.theme.css.inputGrey};
+      border-style: solid;
+      border-width: 1px;
+      border-radius: 1em;
+      box-shadow: ${props.theme.css.boxShadow};
+      padding: 0.5em;
+  `}
 
   /** SEARCH FOR TEXT */
   label {
     font-size: 0.8em;
     margin-right: 0.5em;
     align-self: center;
+    margin-left: ${(props) => props.$inHeader && '5%'};
   }
 
   /** GROUP CONTAINING ICON AND SEARCH INPUT  */
   .icon-search {
     border: 0.5px solid ${(props) => props.theme.css.linePrimaryColor};
     border-radius: 1.5em;
+    background-color: ${(props) => props.theme.css.bkWhite};
     width: 30%;
     height: 2.5em;
   }
@@ -55,13 +66,14 @@ export const BasicSearch = styled(Row)`
   .search-mobile {
     display: flex;
     max-width: 13em;
-    margin-top: auto;
+    margin-top: ${(props) => !props.$inHeader && 'auto'};
     padding: 0;
   }
   /** SEARCH BUTTON */
   .search-button {
     display: flex;
     margin-left: 0.5em;
+    margin-bottom: ${(props) => props.$inHeader && '0.5em'};
     align-self: center;
     font-weight: 400;
     font-size: 0.8em;
@@ -73,8 +85,8 @@ export const BasicSearch = styled(Row)`
       outline: none !important;
       box-shadow: none;
     }
-    /* HIDE SVG IF SCREEN LESS THAN 750px */
-    @media only screen and (max-width: 750px) {
+    /* HIDE SVG IF SCREEN LESS THAN 900px */
+    @media only screen and (max-width: 900px) {
       svg {
         display: none;
       }
@@ -85,8 +97,8 @@ export const BasicSearch = styled(Row)`
     }
   }
 
-  /* BUTTON APPEAR ON RIGHT SIDE OF SEARCH IF SCREEN IS LESS THAN 750px */
-  @media only screen and (max-width: 750px) {
+  /* BUTTON APPEAR ON RIGHT SIDE OF SEARCH IF SCREEN IS LESS THAN 900px */
+  @media only screen and (max-width: 900px) {
     .search-button {
       margin-left: auto;
       margin-right: 0.5em;
@@ -96,7 +108,7 @@ export const BasicSearch = styled(Row)`
   /* GO ADVANCED TEXT */
   p {
     font-size: 0.8em;
-    margin-left: auto;
+    margin-left: ${(props) => (props.$inHeader ? '3em' : 'auto')};
     align-self: center;
     margin-right: 0.5em;
     color: ${(props) => props.theme.css.fRedColor};
@@ -109,27 +121,27 @@ export const BasicSearch = styled(Row)`
   /* CONDITIONALS TO HIDE THINGS FOR MOBILE/DESKTOP */
 
   /** HIDE SEARCH GROUP DISPLAY BASIC */
-  @media only screen and (min-width: 750px) {
+  @media only screen and (min-width: 900px) {
     .search-mobile {
       display: none;
     }
   }
 
-  @media only screen and (max-width: 750px) {
+  @media only screen and (max-width: 900px) {
     .icon-search {
       display: none;
     }
   }
 
   /* HIDE ADVANCED TEXT IF WIDTH GREATER THAN 750 */
-  @media only screen and (max-width: 750px) {
+  @media only screen and (max-width: 900px) {
     p {
       display: none;
     }
   }
 
-  /* NO LABEL IF SCREEN SIZE LESS THAN 750px */
-  @media only screen and (max-width: 750px) {
+  /* NO LABEL IF SCREEN SIZE LESS THAN 900px */
+  @media only screen and (max-width: 900px) {
     label {
       display: none;
     }

--- a/app/subscriber/src/components/header/Header.tsx
+++ b/app/subscriber/src/components/header/Header.tsx
@@ -1,6 +1,7 @@
+import { BasicSearch } from 'components/basic-search';
 import { UserProfile } from 'components/user-profile';
 import React from 'react';
-import { Row } from 'tno-core';
+import { Row, Show } from 'tno-core';
 
 import * as styled from './styled';
 
@@ -25,7 +26,7 @@ export const Header: React.FC<IHeaderProps> = ({
 }) => {
   return (
     <styled.Header className="header">
-      <Row flex="1">
+      <Row>
         {showLogo && (
           <div className="logo-container">
             <img
@@ -37,7 +38,9 @@ export const Header: React.FC<IHeaderProps> = ({
         )}
         {children}
       </Row>
-
+      <Show visible={!window.location.pathname.includes('search')}>
+        <BasicSearch inHeader />
+      </Show>
       {showProfile && <UserProfile />}
     </styled.Header>
   );

--- a/app/subscriber/src/components/layout/styled/Layout.tsx
+++ b/app/subscriber/src/components/layout/styled/Layout.tsx
@@ -16,6 +16,7 @@ export const Layout = styled.div<ILayoutProps>`
   }
 
   .grid-container {
+    height: 100dvh;
     display: grid;
     transition: 300ms;
     background-color: ${(props) => props.theme.css.bkMain};

--- a/app/subscriber/src/features/landing/Landing.tsx
+++ b/app/subscriber/src/features/landing/Landing.tsx
@@ -1,4 +1,3 @@
-import { BasicSearch } from 'components/basic-search';
 import { NavbarOptions, navbarOptions } from 'components/navbar/NavbarItems';
 import { PageSection } from 'components/section';
 import { Commentary } from 'features/commentary';

--- a/app/subscriber/src/features/landing/Landing.tsx
+++ b/app/subscriber/src/features/landing/Landing.tsx
@@ -40,9 +40,6 @@ export const Landing: React.FC = () => {
 
   return (
     <styled.Landing className="main-container">
-      <Row>
-        <BasicSearch />
-      </Row>
       <Row className="contents-container">
         <PageSection
           ignoreMinWidth

--- a/app/subscriber/src/index.scss
+++ b/app/subscriber/src/index.scss
@@ -33,6 +33,7 @@ body {
 
 main {
   overflow: clip;
+  height: calc(100dvh - 78px);
 }
 
 body,
@@ -149,10 +150,6 @@ h4 {
       font-weight: normal;
     }
   }
-}
-
-main {
-  height: 100%;
 }
 
 .error {

--- a/app/subscriber/src/index.scss
+++ b/app/subscriber/src/index.scss
@@ -33,7 +33,6 @@ body {
 
 main {
   overflow: clip;
-  height: calc(100dvh - 78px);
 }
 
 body,


### PR DESCRIPTION
**In this PR:**
- basic search will appear in the header when not viewing a search page
- small styling changes to accommodate this

**Things to consider:**
- need to talk to Bobbi on how this will work on mobile, as the horizontal screen real estate is not the same in the header. spent a good chunk of time trying to figure out a "nice" solution but was not happy with it
- may need some new designs to accompany this and or use the old search bar on mobile (will reach out to her) and create another ticket

![image](https://github.com/bcgov/tno/assets/15724124/c5ce2fce-bcc2-46a1-8290-186a787b72f3)




