### PR TITLE
TNO-2245 Change report summary

### DIFF
--- a/app/subscriber/src/features/my-reports/view/components/ContentForm.tsx
+++ b/app/subscriber/src/features/my-reports/view/components/ContentForm.tsx
@@ -55,7 +55,7 @@ export const ContentForm: React.FC<IContentFormProps> = ({
         <Wysiwyg
           name={`instances.0.content.${index}.versions.${userId}.summary`}
           label="Summary"
-          value={content.versions?.[userId]?.summary ?? content.summary}
+          value={content.versions?.[userId]?.summary ?? ''}
           onChange={(text) =>
             setFieldValue(`instances.0.content.${index}.content.versions`, {
               ...content.versions,
@@ -71,7 +71,7 @@ export const ContentForm: React.FC<IContentFormProps> = ({
         <Wysiwyg
           name={`instances.0.content.${index}.versions.${userId}.body`}
           label="Body"
-          value={content.versions?.[userId]?.body ?? content.body ?? ''}
+          value={content.versions?.[userId]?.body ?? content.isApproved ? content.body ?? '' : ''}
           onChange={(text) => {
             setFieldValue(`instances.0.content.${index}.content.versions`, {
               ...content.versions,

--- a/libs/net/template/ReportEngine.cs
+++ b/libs/net/template/ReportEngine.cs
@@ -198,6 +198,7 @@ public class ReportEngine : IReportEngine
             instance.Content = model.Content;
             instance.Sections = model.Sections;
             instance.ViewOnWebOnly = viewOnWebOnly;
+            instance.OwnerId = model.OwnerId;
 
             instance.SubscriberAppUrl = this.TemplateOptions.SubscriberAppUrl;
             instance.ViewContentUrl = this.TemplateOptions.ViewContentUrl;
@@ -239,6 +240,7 @@ public class ReportEngine : IReportEngine
             instance.Content = model.Content;
             instance.Sections = model.Sections;
             instance.ViewOnWebOnly = viewOnWebOnly;
+            instance.OwnerId = model.OwnerId;
 
             instance.SubscriberAppUrl = this.TemplateOptions.SubscriberAppUrl;
             instance.ViewContentUrl = this.TemplateOptions.ViewContentUrl;


### PR DESCRIPTION
Reports will no longer show the Editor Summary but instead will show the Subscriber Summary (if they enter one).

The Subscriber Summary will be included in the report template output.