### PR TITLE
TNO 2106 - My Minister screen

### DIFF
--- a/app/subscriber/src/css/_variables.module.scss
+++ b/app/subscriber/src/css/_variables.module.scss
@@ -60,6 +60,7 @@
   // Code blocks
   codeBlockColor: $code-block-color;
   teaserBackgroundColor: $teaser-background-color;
+  tagBackgroundColor: $tag-background-color;
 
   // Navbar
   navItemBackgroundColor: $nav-item-background-color;

--- a/app/subscriber/src/css/_variables.scss
+++ b/app/subscriber/src/css/_variables.scss
@@ -66,6 +66,7 @@ $line-quaternary-color: #f8f7f8;
 // Code blocks
 $code-block-color: #f0eeee;
 $teaser-background-color: #f5f6f9;
+$tag-background-color: #e1fff3;
 
 // Navigation
 $nav-item-background-color: #605f73;

--- a/app/subscriber/src/features/my-minister/MyMinister.tsx
+++ b/app/subscriber/src/features/my-minister/MyMinister.tsx
@@ -190,6 +190,7 @@ export const MyMinister: React.FC = () => {
         {userMinisters.map((m) => {
           return (
             <Checkbox
+              key={m.id}
               label={`${m.name} (${m.contentCount})`}
               className="option"
               checked={!m.hide}

--- a/app/subscriber/src/features/my-minister/constants/columns.tsx
+++ b/app/subscriber/src/features/my-minister/constants/columns.tsx
@@ -1,0 +1,75 @@
+import { Sentiment } from 'components/sentiment';
+import { IContentSearchResult } from 'features/utils/interfaces';
+import { ContentTypeName, ITableHookColumn, Show } from 'tno-core';
+
+export const determineColumns = (
+  contentType: ContentTypeName | 'all',
+  windowWidth?: number,
+  hide?: string[],
+  media?: Function,
+) => {
+  const formatDate = (date: string) => {
+    const d = new Date(date);
+    const day = d.toLocaleDateString('en-us', { day: '2-digit' });
+    const month = d.toLocaleDateString('en-us', { month: 'short' }).toUpperCase();
+    const year = d.toLocaleDateString('en-us', { year: 'numeric' });
+    return `${day}-${month}-${year}`;
+  };
+
+  // columns common to all content
+  const baseCols: ITableHookColumn<IContentSearchResult>[] = [
+    {
+      accessor: 'tone',
+      label: '',
+      isVisible: !hide?.includes('tone'),
+      cell: (cell) => (
+        <Sentiment value={cell.original.tonePools ? cell.original.tonePools[0]?.value : 0} />
+      ),
+    },
+    {
+      accessor: 'headline',
+      label: '',
+      cell: (cell) => (
+        <table className="tableHeadline">
+          <tbody>
+            <tr>
+              <td className="dateColumn td-date">
+                <div className="date">{formatDate(cell.original.publishedOn)}</div>
+              </td>
+              <td className="headlineColumn">
+                <div className="headline">{cell.original.headline}</div>
+              </td>
+              <td className="mentionsColumn">
+                <div className="mentions">
+                  {cell.original.ministerMentions?.map((m) => {
+                    return <div className="mentionTag">{m}</div>;
+                  })}
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      ),
+    },
+  ];
+  // columns specific to print content
+  const printCols: ITableHookColumn<IContentSearchResult>[] = [
+    {
+      accessor: 'sectionPage',
+      label: '',
+      isVisible: !hide?.includes('sectionPage'),
+      cell: (cell) => (
+        <>
+          <Show visible={cell.original.contentType !== ContentTypeName.AudioVideo}>
+            <div className="section">{`${cell.original.section}: ${cell?.original.page}`}</div>
+          </Show>
+        </>
+      ),
+    },
+  ];
+  if (contentType === ContentTypeName.PrintContent || contentType === 'all') {
+    return [...baseCols, ...printCols];
+  } else {
+    return baseCols;
+  }
+};

--- a/app/subscriber/src/features/my-minister/constants/columns.tsx
+++ b/app/subscriber/src/features/my-minister/constants/columns.tsx
@@ -39,13 +39,6 @@ export const determineColumns = (
               <td className="headlineColumn">
                 <div className="headline">{cell.original.headline}</div>
               </td>
-              <td className="mentionsColumn">
-                <div className="mentions">
-                  {cell.original.ministerMentions?.map((m) => {
-                    return <div className="mentionTag">{m}</div>;
-                  })}
-                </div>
-              </td>
             </tr>
           </tbody>
         </table>
@@ -67,8 +60,27 @@ export const determineColumns = (
       ),
     },
   ];
+
+  // columns specific to my minister mentions
+  const mentionCols: ITableHookColumn<IContentSearchResult>[] = [
+    {
+      accessor: 'sectionPage',
+      label: '',
+      isVisible: !hide?.includes('sectionPage'),
+      cell: (cell) => (
+        <div className="mentionsColumn">
+          <div className="mentions">
+            {cell.original.ministerMentions?.map((m) => {
+              return <div className="mentionTag">{m}</div>;
+            })}
+          </div>
+        </div>
+      ),
+    },
+  ];
+
   if (contentType === ContentTypeName.PrintContent || contentType === 'all') {
-    return [...baseCols, ...printCols];
+    return [...baseCols, ...printCols, ...mentionCols];
   } else {
     return baseCols;
   }

--- a/app/subscriber/src/features/my-minister/constants/columns.tsx
+++ b/app/subscriber/src/features/my-minister/constants/columns.tsx
@@ -2,12 +2,7 @@ import { Sentiment } from 'components/sentiment';
 import { IContentSearchResult } from 'features/utils/interfaces';
 import { ContentTypeName, ITableHookColumn, Show } from 'tno-core';
 
-export const determineColumns = (
-  contentType: ContentTypeName | 'all',
-  windowWidth?: number,
-  hide?: string[],
-  media?: Function,
-) => {
+export const determineColumns = (contentType: ContentTypeName | 'all', hide?: string[]) => {
   const formatDate = (date: string) => {
     const d = new Date(date);
     const day = d.toLocaleDateString('en-us', { day: '2-digit' });
@@ -64,14 +59,18 @@ export const determineColumns = (
   // columns specific to my minister mentions
   const mentionCols: ITableHookColumn<IContentSearchResult>[] = [
     {
-      accessor: 'sectionPage',
+      accessor: 'mentions',
       label: '',
-      isVisible: !hide?.includes('sectionPage'),
+      isVisible: !hide?.includes('mentions'),
       cell: (cell) => (
         <div className="mentionsColumn">
           <div className="mentions">
             {cell.original.ministerMentions?.map((m) => {
-              return <div className="mentionTag">{m}</div>;
+              return (
+                <div key={`${cell.original.id}-${m}`} className="mentionTag">
+                  {m}
+                </div>
+              );
             })}
           </div>
         </div>

--- a/app/subscriber/src/features/my-minister/constants/index.ts
+++ b/app/subscriber/src/features/my-minister/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './columns';

--- a/app/subscriber/src/features/my-minister/styled/MyMinister.tsx
+++ b/app/subscriber/src/features/my-minister/styled/MyMinister.tsx
@@ -21,8 +21,73 @@ export const MyMinister = styled.div`
       cursor: pointer;
     }
   }
+  // tone column
+  .column.col-1 {
+    width: 2.5rem;
+    flex: unset;
+    div {
+      width: 100%;
+      justify-content: center;
+      svg.tone-icon {
+        margin-left: unset;
+      }
+    }
+  }
+
   .headline {
     /* link color */
     color: #3847aa;
+  }
+  .tableHeadline {
+    width: 100%;
+    table-layout: fixed;
+  }
+
+  .dateColumn {
+    width: 20%;
+  }
+
+  .headlineColumn {
+    width: 60%;
+  }
+
+  .mentionsColumn {
+    width: 20%;
+  }
+
+  .td-date {
+    white-space: nowrap;
+  }
+
+  .ministerCheckboxes {
+    display: flex;
+  }
+
+  .option {
+    margin: 5px;
+    font-weight: bold;
+  }
+
+  .mentions {
+    display: flex;
+  }
+
+  .mentionTag {
+    display: flex;
+    border-radius: 4px;
+    background: ${(props) => props.theme.css.tagBackgroundColor};
+    padding: 4px 4px;
+    justify-content: center;
+    align-items: center;
+    gap: 2px;
+    color: #000;
+    text-align: center;
+    font-family: ${(props) => props.theme.css.fPrimary};
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 600;
+    line-height: 12px; /* 100% */
+    text-transform: uppercase;
+    margin-right: 6px;
   }
 `;

--- a/app/subscriber/src/features/my-minister/styled/MyMinister.tsx
+++ b/app/subscriber/src/features/my-minister/styled/MyMinister.tsx
@@ -34,6 +34,19 @@ export const MyMinister = styled.div`
     }
   }
 
+  // headline column
+  .column.col-2 {
+    width: 35rem;
+    flex: unset;
+    div {
+      width: 100%;
+      justify-content: center;
+      svg.tone-icon {
+        margin-left: unset;
+      }
+    }
+  }
+
   .headline {
     /* link color */
     color: #3847aa;
@@ -44,15 +57,11 @@ export const MyMinister = styled.div`
   }
 
   .dateColumn {
-    width: 20%;
+    width: 30%;
   }
 
   .headlineColumn {
-    width: 60%;
-  }
-
-  .mentionsColumn {
-    width: 20%;
+    width: 70%;
   }
 
   .td-date {

--- a/app/subscriber/src/features/utils/interfaces/IContentSearchResult.ts
+++ b/app/subscriber/src/features/utils/interfaces/IContentSearchResult.ts
@@ -5,4 +5,5 @@ export interface IContentSearchResult extends IContentModel {
   mediaUrl?: string | undefined;
   displayMedia?: boolean;
   ministerName?: string;
+  ministerMentions?: string[];
 }

--- a/app/subscriber/src/features/utils/interfaces/IContentSearchResult.ts
+++ b/app/subscriber/src/features/utils/interfaces/IContentSearchResult.ts
@@ -4,4 +4,5 @@ export interface IContentSearchResult extends IContentModel {
   hasTranscript: boolean;
   mediaUrl?: string | undefined;
   displayMedia?: boolean;
+  ministerName?: string;
 }

--- a/app/subscriber/src/store/hooks/subscriber/interfaces/IMinisterModel.ts
+++ b/app/subscriber/src/store/hooks/subscriber/interfaces/IMinisterModel.ts
@@ -5,4 +5,6 @@ export interface IMinisterModel extends ISortableModel<number> {
   organizationId?: number;
   organization?: IOrganizationModel;
   position: string;
+  hide?: boolean;
+  contentCount?: number;
 }


### PR DESCRIPTION
Overall functionality:

- Filter the Ministers base on user setting
- Iterates this list and make a call for each Minister using the Minister name, Minister aliases and date as parameters
- Get the results and check mentions to each other Minister and populate the Object, also add a count to that minister content.

![image](https://github.com/bcgov/tno/assets/26801490/c65a72d7-e0bf-4ee1-88b4-47e5f3d7f878)

UI Functionalities:

- Checkboxes are displayed with the minister name and content count
- It can be clicked to hide/show a certain Minister content
- A tag to is displayed to show the mentions to other ministers on that content
