### PR TITLE
TNO-2210: Fix select all on Manage Folder and on Filter Media Type pages

### DIFF
--- a/app/subscriber/src/features/filter-media/FilterMedia.tsx
+++ b/app/subscriber/src/features/filter-media/FilterMedia.tsx
@@ -6,7 +6,7 @@ import { IContentSearchResult } from 'features/utils/interfaces';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useContent } from 'store/hooks';
-import { FlexboxTable, generateQuery, IContentModel, Show } from 'tno-core';
+import { FlexboxTable, generateQuery, IContentModel, ITableInternalRow, Show } from 'tno-core';
 
 import { PreviousResults } from './PreviousResults';
 import * as styled from './styled';
@@ -49,6 +49,19 @@ export const FilterMedia: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filter]);
 
+  const selectedIds = selected.map((i) => i.id.toString());
+  /** controls the checking and unchecking of rows in the list view */
+  const handleSelectedRowsChanged = React.useCallback(
+    (row: ITableInternalRow<IContentSearchResult>) => {
+      if (row.isSelected) {
+        setSelected(row.table.rows.filter((r) => r.isSelected).map((r) => r.original));
+      } else {
+        setSelected((selected) => selected.filter((r) => r.id !== row.original.id));
+      }
+    },
+    [],
+  );
+
   return (
     <styled.FilterMedia>
       <ContentListActionBar
@@ -57,6 +70,7 @@ export const FilterMedia: React.FC = () => {
       />
       <DateFilter filter={filter} storeFilter={storeFilter} />
       <FlexboxTable
+        isMulti
         rowId="id"
         columns={determineColumns('all')}
         groupBy={(item) => item.original.source?.name ?? ''}
@@ -66,6 +80,8 @@ export const FilterMedia: React.FC = () => {
         data={results}
         pageButtons={5}
         showPaging={false}
+        onSelectedChanged={handleSelectedRowsChanged}
+        selectedRowIds={selectedIds}
       />
       <Show visible={!results.length}>
         <PreviousResults results={results} setResults={setResults} />

--- a/app/subscriber/src/features/manage-folder/ManageFolder.tsx
+++ b/app/subscriber/src/features/manage-folder/ManageFolder.tsx
@@ -142,12 +142,13 @@ export const ManageFolder: React.FC = () => {
                             <Row>
                               <Col>
                                 <Checkbox
+                                  checked={selected.includes(item)}
                                   className="checkbox"
-                                  onClick={() => {
-                                    if (selected.includes(item)) {
-                                      setSelected(selected.filter((i) => i !== item));
+                                  onClick={(e) => {
+                                    if (!(e.target as HTMLInputElement).checked) {
+                                      setSelected((selected) => selected.filter((i) => i !== item));
                                     } else {
-                                      setSelected([...selected, item]);
+                                      setSelected((selected) => [...selected, item]);
                                     }
                                   }}
                                 />


### PR DESCRIPTION
Noticed this also wasn't working on Filter Media Type page, fixed on both pages:
<img width="897" alt="Screenshot 2024-01-31 at 6 36 34 PM" src="https://github.com/bcgov/tno/assets/7937856/dd923f5f-c3cd-4cef-b56d-94663e759427">
<img width="476" alt="Screenshot 2024-01-31 at 7 04 10 PM" src="https://github.com/bcgov/tno/assets/7937856/64f2604f-a9f9-4d78-8f26-79f2f5aff3f5">
