### PR TITLE
TNO-2204 Fix reports drag+drop

### DIFF
--- a/app/subscriber/src/features/my-reports/view/components/ReportSectionContent.tsx
+++ b/app/subscriber/src/features/my-reports/view/components/ReportSectionContent.tsx
@@ -188,77 +188,77 @@ export const ReportSectionContent: React.FC<IReportSectionContentProps> = ({
       <Show visible={!section.filterId && !section.folderId && !sectionContent.length}>
         <p>Section is empty</p>
       </Show>
-      <Show visible={!!instance.content.length}>
-        <Droppable droppableId={section.name} isDropDisabled={disabled}>
-          {(droppableProvided) => (
-            <div {...droppableProvided.droppableProps} ref={droppableProvided.innerRef}>
-              {showAdd && !disabled && (
-                <Row className="add-story">
-                  <Action
-                    icon={<FaPlus />}
-                    label="Create a story"
-                    onClick={() => addStory(instance.id, section.name)}
-                  />
-                </Row>
-              )}
-              {showContent ? (
-                sectionContent.map((ic, contentInSectionIndex) => {
-                  // Only display content in this section.
-                  // The original index is needed to provide the ability to drag+drop content into other sections.
-                  if (ic.content == null) return null;
-                  const isActive =
-                    activeRow?.sectionName === section.name &&
-                    activeRow?.contentId === ic.contentId;
-                  const isSame = activeRow?.contentId === ic.contentId;
+      <Droppable droppableId={section.name} isDropDisabled={disabled}>
+        {(droppableProvided) => (
+          <div {...droppableProvided.droppableProps} ref={droppableProvided.innerRef}>
+            {showAdd && !disabled && (
+              <Row className="add-story">
+                <Action
+                  icon={<FaPlus />}
+                  label="Create a story"
+                  onClick={() => addStory(instance.id, section.name)}
+                />
+              </Row>
+            )}
+            <Show visible={!sectionContent.length}>
+              <Row justifyContent="center">Drop content here</Row>
+            </Show>
+            {showContent ? (
+              sectionContent.map((ic, contentInSectionIndex) => {
+                // Only display content in this section.
+                // The original index is needed to provide the ability to drag+drop content into other sections.
+                if (ic.content == null) return null;
+                const isActive =
+                  activeRow?.sectionName === section.name && activeRow?.contentId === ic.contentId;
+                const isSame = activeRow?.contentId === ic.contentId;
 
-                  return (
-                    <Draggable
-                      key={`${ic.sectionName}-${ic.contentId}-${ic.originalIndex}`}
-                      draggableId={`${ic.sectionName}__${ic.contentId}__${ic.originalIndex}`}
-                      index={contentInSectionIndex}
-                      isDragDisabled={disabled}
-                    >
-                      {(draggable) => {
-                        if (!ic.content) return <></>;
+                return (
+                  <Draggable
+                    key={`${ic.sectionName}-${ic.contentId}-${ic.originalIndex}`}
+                    draggableId={`${ic.sectionName}__${ic.contentId}__${ic.originalIndex}`}
+                    index={contentInSectionIndex}
+                    isDragDisabled={disabled}
+                  >
+                    {(draggable) => {
+                      if (!ic.content) return <></>;
 
-                        return (
-                          <div
-                            className={`${isSame ? 'active-content ' : ''}${
-                              isActive ? 'active-row' : ''
-                            }`}
-                            ref={draggable.innerRef}
-                            {...draggable.dragHandleProps}
-                            {...draggable.draggableProps}
-                          >
-                            <ReportContentSectionRow
-                              disabled={disabled}
-                              row={ic}
-                              contentIndex={contentInSectionIndex}
-                              show={!ic.contentId ? 'all' : 'none'}
-                              onRemove={(index) => handleRemoveContent(index)}
-                              showSelectSection
-                              sectionOptions={sectionOptions}
-                              onChangeSection={(sectionName, row) => {
-                                handleChangeSection(sectionName, row, instance);
-                              }}
-                              showSortOrder
-                              onBlurSortOrder={(row) => handleChangeSortOrder(row, instance)}
-                              onContentClick={onContentClick}
-                            />
-                          </div>
-                        );
-                      }}
-                    </Draggable>
-                  );
-                })
-              ) : (
-                <></>
-              )}
-              {droppableProvided.placeholder}
-            </div>
-          )}
-        </Droppable>
-      </Show>
+                      return (
+                        <div
+                          className={`${isSame ? 'active-content ' : ''}${
+                            isActive ? 'active-row' : ''
+                          }`}
+                          ref={draggable.innerRef}
+                          {...draggable.dragHandleProps}
+                          {...draggable.draggableProps}
+                        >
+                          <ReportContentSectionRow
+                            disabled={disabled}
+                            row={ic}
+                            contentIndex={contentInSectionIndex}
+                            show={!ic.contentId ? 'all' : 'none'}
+                            onRemove={(index) => handleRemoveContent(index)}
+                            showSelectSection
+                            sectionOptions={sectionOptions}
+                            onChangeSection={(sectionName, row) => {
+                              handleChangeSection(sectionName, row, instance);
+                            }}
+                            showSortOrder
+                            onBlurSortOrder={(row) => handleChangeSortOrder(row, instance)}
+                            onContentClick={onContentClick}
+                          />
+                        </div>
+                      );
+                    }}
+                  </Draggable>
+                );
+              })
+            ) : (
+              <></>
+            )}
+            {droppableProvided.placeholder}
+          </div>
+        )}
+      </Droppable>
     </Col>
   );
 };

--- a/app/subscriber/src/features/my-reports/view/components/ReportSectionGallery.tsx
+++ b/app/subscriber/src/features/my-reports/view/components/ReportSectionGallery.tsx
@@ -10,6 +10,7 @@ import {
   IReportInstanceModel,
   OptionItem,
   ReportSectionTypeName,
+  Row,
   Show,
 } from 'tno-core';
 
@@ -123,55 +124,56 @@ export const ReportSectionGallery: React.FC<IReportSectionGalleryProps> = ({
       <Show visible={!section.filterId && !section.folderId && !sectionContent.length}>
         <p>Section is empty</p>
       </Show>
-      <Show visible={!!instance.content.length}>
-        <Droppable droppableId={section.name} isDropDisabled={disabled}>
-          {(droppableProvided) => (
-            <div {...droppableProvided.droppableProps} ref={droppableProvided.innerRef}>
-              {sectionContent.map((ic, contentInSectionIndex) => {
-                // Only display content in this section.
-                // The original index is needed to provide the ability to drag+drop content into other sections.
-                if (ic.content == null) return null;
-                return (
-                  <Draggable
-                    key={`${ic.sectionName}-${ic.contentId}-${ic.originalIndex}`}
-                    draggableId={`${ic.sectionName}__${ic.contentId}__${ic.originalIndex}`}
-                    index={contentInSectionIndex}
-                    isDragDisabled={disabled}
-                  >
-                    {(draggable) => {
-                      if (!ic.content) return <></>;
+      <Droppable droppableId={section.name} isDropDisabled={disabled}>
+        {(droppableProvided) => (
+          <div {...droppableProvided.droppableProps} ref={droppableProvided.innerRef}>
+            <Show visible={!sectionContent.length}>
+              <Row justifyContent="center">Drop content here</Row>
+            </Show>
+            {sectionContent.map((ic, contentInSectionIndex) => {
+              // Only display content in this section.
+              // The original index is needed to provide the ability to drag+drop content into other sections.
+              if (ic.content == null) return null;
+              return (
+                <Draggable
+                  key={`${ic.sectionName}-${ic.contentId}-${ic.originalIndex}`}
+                  draggableId={`${ic.sectionName}__${ic.contentId}__${ic.originalIndex}`}
+                  index={contentInSectionIndex}
+                  isDragDisabled={disabled}
+                >
+                  {(draggable) => {
+                    if (!ic.content) return <></>;
 
-                      return (
-                        <div
-                          ref={draggable.innerRef}
-                          {...draggable.dragHandleProps}
-                          {...draggable.draggableProps}
-                        >
-                          <ReportContentSectionRow
-                            disabled={disabled}
-                            row={ic}
-                            contentIndex={contentInSectionIndex}
-                            show={!ic.contentId ? 'all' : 'none'}
-                            onRemove={(index) => handleRemoveContent(index)}
-                            showSelectSection
-                            sectionOptions={sectionOptions}
-                            onChangeSection={(sectionName, row) => {
-                              handleChangeSection(sectionName, row, instance);
-                            }}
-                            showSortOrder
-                            onBlurSortOrder={(row) => handleChangeSortOrder(row, instance)}
-                          />
-                        </div>
-                      );
-                    }}
-                  </Draggable>
-                );
-              })}
-              {droppableProvided.placeholder}
-            </div>
-          )}
-        </Droppable>
-      </Show>
+                    return (
+                      <div
+                        ref={draggable.innerRef}
+                        {...draggable.dragHandleProps}
+                        {...draggable.draggableProps}
+                      >
+                        <ReportContentSectionRow
+                          disabled={disabled}
+                          row={ic}
+                          contentIndex={contentInSectionIndex}
+                          show={!ic.contentId ? 'all' : 'none'}
+                          onRemove={(index) => handleRemoveContent(index)}
+                          showSelectSection
+                          sectionOptions={sectionOptions}
+                          onChangeSection={(sectionName, row) => {
+                            handleChangeSection(sectionName, row, instance);
+                          }}
+                          showSortOrder
+                          onBlurSortOrder={(row) => handleChangeSortOrder(row, instance)}
+                        />
+                      </div>
+                    );
+                  }}
+                </Draggable>
+              );
+            })}
+            {droppableProvided.placeholder}
+          </div>
+        )}
+      </Droppable>
     </Col>
   );
 };

--- a/app/subscriber/src/features/my-reports/view/components/ReportSections.tsx
+++ b/app/subscriber/src/features/my-reports/view/components/ReportSections.tsx
@@ -45,7 +45,7 @@ export const ReportSections: React.FC<IReportSectionsProps> = ({
     (result: DropResult, provided: ResponderProvided) => {
       if (instance) {
         const newItems = moveContent(result, instance.content);
-        setFieldValue(`instances.0.content`, newItems);
+        if (newItems) setFieldValue(`instances.0.content`, newItems);
       }
     },
     [instance, setFieldValue],
@@ -83,6 +83,7 @@ export const ReportSections: React.FC<IReportSectionsProps> = ({
       </Row>
       <DragDropContext onDragEnd={handleDrop}>
         {values.sections.map((section, index) => {
+          // Only display content and gallery sections if it's the stories tab.
           if (
             form === 'stories' &&
             ![ReportSectionTypeName.Content, ReportSectionTypeName.Gallery].includes(


### PR DESCRIPTION
We can now drag+drop to an empty section, and to a gallery.

![image](https://github.com/bcgov/tno/assets/3180256/38bbe9b9-4a99-45c0-908d-b424ce3da3b3)
