### PR TITLE
TNO-2123: Fix date picker colours and UI/UX

### DIFF
--- a/app/subscriber/src/components/date-filter/DateFilter.tsx
+++ b/app/subscriber/src/components/date-filter/DateFilter.tsx
@@ -62,6 +62,7 @@ export const DateFilter: React.FC<IDateFilterProps> = ({ filter, storeFilter }) 
         <FaCalendarDay className="calendar" onClick={() => setOpen(true)} />
         <ReactDatePicker
           open={open}
+          maxDate={new Date()}
           disabled
           dateFormat="dd-MMM-y"
           onChange={(e) => storeFilter({ ...filter, startDate: e?.toISOString() })}

--- a/app/subscriber/src/components/date-filter/styled/DateFilter.tsx
+++ b/app/subscriber/src/components/date-filter/styled/DateFilter.tsx
@@ -35,4 +35,23 @@ export const DateFilter = styled(Row)`
     }
     max-width: 6.5em;
   }
+
+  .react-datepicker__day--keyboard-selected,
+  .react-datepicker__day--in-selecting-range {
+    background-color: rgb(151, 29, 41, 0.5);
+  }
+
+  .react-datepicker__day--in-range,
+  .react-datepicker__day--selected {
+    background-color: rgb(151, 29, 41);
+  }
+
+  .react-datepicker__day--keyboard-selected,
+  .react-datepicker__month-text--keyboard-selected,
+  .react-datepicker__quarter-text--keyboard-selected,
+  .react-datepicker__year-text--keyboard-selected {
+    &:hover {
+      background-color: rgb(151, 29, 41);
+    }
+  }
 `;

--- a/app/subscriber/src/components/date-filter/styled/DateFilter.tsx
+++ b/app/subscriber/src/components/date-filter/styled/DateFilter.tsx
@@ -38,12 +38,12 @@ export const DateFilter = styled(Row)`
 
   .react-datepicker__day--keyboard-selected,
   .react-datepicker__day--in-selecting-range {
-    background-color: rgb(151, 29, 41, 0.5);
+    background-color: ${(props) => props.theme.css.btnLightRedColor};
   }
 
   .react-datepicker__day--in-range,
   .react-datepicker__day--selected {
-    background-color: rgb(151, 29, 41);
+    background-color: ${(props) => props.theme.css.btnRedColor};
   }
 
   .react-datepicker__day--keyboard-selected,
@@ -51,7 +51,7 @@ export const DateFilter = styled(Row)`
   .react-datepicker__quarter-text--keyboard-selected,
   .react-datepicker__year-text--keyboard-selected {
     &:hover {
-      background-color: rgb(151, 29, 41);
+      background-color: ${(props) => props.theme.css.btnRedColor};
     }
   }
 `;

--- a/app/subscriber/src/css/_variables.module.scss
+++ b/app/subscriber/src/css/_variables.module.scss
@@ -56,6 +56,7 @@
   btnPrimaryColor: $btn-primary-color;
   btnGrayColor: $btn-gray-color;
   btnRedColor: $btn-red-color;
+  btnLightRedColor: $btn-light-red-color;
   btnYellowColor: $btn-yellow-color;
   btnYellowBkColor: $btn-yellow-bk-color;
 

--- a/app/subscriber/src/css/_variables.scss
+++ b/app/subscriber/src/css/_variables.scss
@@ -61,6 +61,7 @@ $btn-bk-primary: #6750a4;
 $btn-primary-color: #fff;
 $btn-gray-color: #9f9196;
 $btn-red-color: #971d29;
+$btn-light-red-color: #971d2980;
 $btn-red-bk-color: #fef2f3;
 $btn-yellow-color: #876503;
 $btn-yellow-bk-color: #fff7e1;

--- a/app/subscriber/src/features/my-folders/Schedule.tsx
+++ b/app/subscriber/src/features/my-folders/Schedule.tsx
@@ -66,6 +66,10 @@ export const Schedule: React.FC<IScheduleProps> = ({ folderSchedule, onScheduleC
                 <Col>
                   <label>Start after:</label>
                   <ReactDatePicker
+                    minDate={new Date()}
+                    showMonthDropdown
+                    showYearDropdown
+                    showPreviousMonths
                     showTimeInput
                     selected={
                       folderSchedule && folderSchedule.runOn

--- a/app/subscriber/src/features/my-folders/styled/ConfigureFolder.tsx
+++ b/app/subscriber/src/features/my-folders/styled/ConfigureFolder.tsx
@@ -55,19 +55,19 @@ export const ConfigureFolder = styled(PageSection)`
   }
   .react-datepicker__time-list-item--selected,
   .react-datepicker__close-icon::after {
-    background-color: rgb(151, 29, 41) !important;
+    background-color: ${(props) => props.theme.css.btnRedColor}; !important;
   }
   .react-datepicker__close-icon::after {n
     background-color: ${(props) => props.theme.css.btnBkPrimary};
   }
   .react-datepicker__day--keyboard-selected,
   .react-datepicker__day--in-selecting-range {
-    background-color: rgb(151, 29, 41, 0.5);
+    background-color: ${(props) => props.theme.css.btnLightRedColor};;
   }
 
   .react-datepicker__day--in-range,
   .react-datepicker__day--selected {
-    background-color: rgb(151, 29, 41);
+    background-color: ${(props) => props.theme.css.btnRedColor};;
   }
 
   .react-datepicker__day--keyboard-selected,
@@ -75,7 +75,7 @@ export const ConfigureFolder = styled(PageSection)`
   .react-datepicker__quarter-text--keyboard-selected,
   .react-datepicker__year-text--keyboard-selected {
     &:hover {
-      background-color: rgb(151, 29, 41);
+      background-color: ${(props) => props.theme.css.btnRedColor};;
     }
   }
   .main-container {

--- a/app/subscriber/src/features/my-folders/styled/ConfigureFolder.tsx
+++ b/app/subscriber/src/features/my-folders/styled/ConfigureFolder.tsx
@@ -53,8 +53,30 @@ export const ConfigureFolder = styled(PageSection)`
       filter: grayscale(0.2);
     }
   }
+  .react-datepicker__time-list-item--selected,
   .react-datepicker__close-icon::after {
+    background-color: rgb(151, 29, 41) !important;
+  }
+  .react-datepicker__close-icon::after {n
     background-color: ${(props) => props.theme.css.btnBkPrimary};
+  }
+  .react-datepicker__day--keyboard-selected,
+  .react-datepicker__day--in-selecting-range {
+    background-color: rgb(151, 29, 41, 0.5);
+  }
+
+  .react-datepicker__day--in-range,
+  .react-datepicker__day--selected {
+    background-color: rgb(151, 29, 41);
+  }
+
+  .react-datepicker__day--keyboard-selected,
+  .react-datepicker__month-text--keyboard-selected,
+  .react-datepicker__quarter-text--keyboard-selected,
+  .react-datepicker__year-text--keyboard-selected {
+    &:hover {
+      background-color: rgb(151, 29, 41);
+    }
   }
   .main-container {
     padding: 1rem;

--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -126,17 +126,8 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
   }, [frontPageImagesMediaTypeId]);
 
   const handleSearch = React.useCallback(async () => {
-    console.log('***************filter*********************');
-    console.log(filter);
-    console.log('***************filter*********************');
     const settings = filterFormat(filter);
-    console.log('***************settings*********************');
-    console.log(settings);
-    console.log('***************settings*********************');
     const query = genQuery(settings);
-    console.log('***************query*********************');
-    console.log(query);
-    console.log('***************query*********************');
     fetchResults(query, filter.searchUnpublished);
   }, [fetchResults, filter, genQuery]);
 

--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -126,8 +126,17 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
   }, [frontPageImagesMediaTypeId]);
 
   const handleSearch = React.useCallback(async () => {
+    console.log('***************filter*********************');
+    console.log(filter);
+    console.log('***************filter*********************');
     const settings = filterFormat(filter);
+    console.log('***************settings*********************');
+    console.log(settings);
+    console.log('***************settings*********************');
     const query = genQuery(settings);
+    console.log('***************query*********************');
+    console.log(query);
+    console.log('***************query*********************');
     fetchResults(query, filter.searchUnpublished);
   }, [fetchResults, filter, genQuery]);
 

--- a/app/subscriber/src/features/search-page/components/advanced-search/components/sections/DateSection.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/components/sections/DateSection.tsx
@@ -42,6 +42,8 @@ export const DateSection: React.FC = () => {
       <Row className="picker">
         <ReactDatePicker
           className="date-picker"
+          // startDate must not be allowed to be AFTER the end date or AFTER today's date
+          maxDate={filter?.endDate ? new Date(filter.endDate) : new Date()}
           startDate={filter?.startDate ? new Date(filter.startDate) : null}
           selected={filter?.startDate ? new Date(filter.startDate) : null}
           selectsStart
@@ -57,6 +59,10 @@ export const DateSection: React.FC = () => {
         <p>to</p>
         <ReactDatePicker
           className="date-picker"
+          // endDate must not be allowed to be AFTER today's date
+          maxDate={new Date()}
+          // endDate must not be allowed to be BEFORE the startDate
+          minDate={!!filter.startDate ? new Date(filter.startDate) : undefined}
           startDate={filter?.startDate ? new Date(filter.startDate) : null}
           selected={filter?.endDate ? new Date(filter.endDate) : null}
           selectsEnd

--- a/app/subscriber/src/features/search-page/components/advanced-search/styled/AdvancedSearch.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/styled/AdvancedSearch.tsx
@@ -358,12 +358,12 @@ export const AdvancedSearch = styled(Row)`
 
   .react-datepicker__day--keyboard-selected,
   .react-datepicker__day--in-selecting-range {
-    background-color: rgb(151, 29, 41, 0.5);
+    background-color: ${(props) => props.theme.css.btnLightRedColor};
   }
 
   .react-datepicker__day--in-range,
   .react-datepicker__day--selected {
-    background-color: rgb(151, 29, 41);
+    background-color: ${(props) => props.theme.css.btnRedColor};
   }
 
   .react-datepicker__day--keyboard-selected,
@@ -371,7 +371,7 @@ export const AdvancedSearch = styled(Row)`
   .react-datepicker__quarter-text--keyboard-selected,
   .react-datepicker__year-text--keyboard-selected {
     &:hover {
-      background-color: rgb(151, 29, 41);
+      background-color: ${(props) => props.theme.css.btnRedColor};
     }
   }
 

--- a/app/subscriber/src/features/search-page/components/advanced-search/styled/AdvancedSearch.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/styled/AdvancedSearch.tsx
@@ -356,6 +356,25 @@ export const AdvancedSearch = styled(Row)`
     }
   }
 
+  .react-datepicker__day--keyboard-selected,
+  .react-datepicker__day--in-selecting-range {
+    background-color: rgb(151, 29, 41, 0.5);
+  }
+
+  .react-datepicker__day--in-range,
+  .react-datepicker__day--selected {
+    background-color: rgb(151, 29, 41);
+  }
+
+  .react-datepicker__day--keyboard-selected,
+  .react-datepicker__month-text--keyboard-selected,
+  .react-datepicker__quarter-text--keyboard-selected,
+  .react-datepicker__year-text--keyboard-selected {
+    &:hover {
+      background-color: rgb(151, 29, 41);
+    }
+  }
+
   .sub-group-title {
     max-height: 100%;
     min-width: 15em;

--- a/app/subscriber/src/features/search-page/utils/filterFormat.ts
+++ b/app/subscriber/src/features/search-page/utils/filterFormat.ts
@@ -10,11 +10,6 @@ export const filterFormat = (filter: IFilterSettingsModel) => {
     dateOffset: filter.dateOffset,
     defaultSearchOperator: filter.defaultSearchOperator ?? 'and',
     edition: filter.edition ?? '',
-    endDate: filter.endDate
-      ? filter.endDate
-      : filter.startDate
-      ? `${moment(filter.startDate).endOf('day').toISOString()}`
-      : undefined,
     from: 0,
     inByline: filter.inByline ?? false,
     inHeadline: filter.inHeadline ?? false,
@@ -29,6 +24,7 @@ export const filterFormat = (filter: IFilterSettingsModel) => {
     size: filter.size,
     sourceIds: filter.sourceIds ?? [],
     startDate: !!filter.startDate ? filter.startDate : undefined,
+    endDate: !!filter.endDate ? filter.endDate : undefined,
     tags: filter.tags ?? [],
   };
   return settings;

--- a/app/subscriber/src/features/search-page/utils/filterFormat.ts
+++ b/app/subscriber/src/features/search-page/utils/filterFormat.ts
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import { IFilterSettingsModel } from 'tno-core';
 
 export const filterFormat = (filter: IFilterSettingsModel) => {


### PR DESCRIPTION
- Fix buggy behaviour with start dates before end date and end dates after start date
- CSS, colour updates from Bobbi
- Fix query filter for start but no end date, and end but no start date
- Fixed folder schedule date picker, no months or year nav before
- Only allow scheduling dates from today on
- Only allow filtering for dates on or before today's date

Folder date picker:
Before:
<img width="467" alt="Screenshot 2024-02-02 at 1 17 14 PM" src="https://github.com/bcgov/tno/assets/7937856/f1dd8aa8-f27c-46c9-8171-d0d77a066b1b">

After:
<img width="361" alt="Screenshot 2024-02-02 at 2 43 45 PM" src="https://github.com/bcgov/tno/assets/7937856/f09efc36-1941-4232-8280-f8bcfd64d227">

Bugs with advanced search date picker:
Before:
<img width="329" alt="Screenshot 2024-02-02 at 12 57 45 PM" src="https://github.com/bcgov/tno/assets/7937856/74e1f40d-f932-4216-9081-aa32c96774cd">

After:
<img width="245" alt="Screenshot 2024-02-02 at 1 01 07 PM" src="https://github.com/bcgov/tno/assets/7937856/20216a8a-690a-4407-b85e-b92106917c6e">
