### PR TITLE
fix scroll issues on search page

### DIFF
--- a/app/subscriber/src/components/content-list/ContentList.tsx
+++ b/app/subscriber/src/components/content-list/ContentList.tsx
@@ -23,6 +23,8 @@ export interface IContentListProps {
   showDate?: boolean;
   /** used to determine if the content list is draggable and what to do for handling drop */
   handleDrop?: any;
+  /** whether or not the content list is scrollable from within the content list container*/
+  scrollWithin?: boolean;
 }
 
 export const ContentList: React.FC<IContentListProps> = ({
@@ -32,6 +34,7 @@ export const ContentList: React.FC<IContentListProps> = ({
   styleOnSettings = false,
   showDate = false,
   handleDrop,
+  scrollWithin = false,
 }) => {
   const navigate = useNavigate();
   const { groupBy, setActiveStream, activeFileReference } = React.useContext(ContentListContext);
@@ -63,7 +66,7 @@ export const ContentList: React.FC<IContentListProps> = ({
   }, [settings]);
 
   return (
-    <styled.ContentList>
+    <styled.ContentList scrollWithin={scrollWithin}>
       <Show visible={!handleDrop}>
         {Object.keys(grouped).map((group) => (
           <div key={group}>

--- a/app/subscriber/src/components/content-list/styled/ContentList.tsx
+++ b/app/subscriber/src/components/content-list/styled/ContentList.tsx
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 
-export const ContentList = styled.div`
+export const ContentList = styled.div<{ scrollWithin: boolean }>`
   .group-title {
     border-bottom: 1px solid ${(props) => props.theme.css.border};
   }
+  ${(props) => (props.scrollWithin ? 'overflow-y: auto;' : '')}
 `;

--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -139,6 +139,7 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
               selected={selected}
               showDate
               styleOnSettings
+              scrollWithin
             />
             {isLoading && <Loading />}
           </PageSection>


### PR DESCRIPTION
add prop that allows user to control whether `ContentList` should be a scroll container on the y-axis. Fixes current bug on search page