### PR TITLE
Bug Fixes - Only show Homepage items & Top Stories fix

### DIFF
--- a/app/subscriber/src/components/section/styled/PageSection.tsx
+++ b/app/subscriber/src/components/section/styled/PageSection.tsx
@@ -24,10 +24,10 @@ export const PageSection = styled.div<{ $ignoreMinWidth?: boolean; $ignoreLastCh
   }
 
   .page-icon {
-    height: 1.5em;
-    width: 1.5em;
-    margin: 0.1em 0;
+    margin: 0.1em 0.25em 0 0;
     color: ${(props) => props.theme.css.iconPurpleColor};
+    // size of font and icons
+    max-height: 26px;
   }
 
   ${(props) =>

--- a/app/subscriber/src/features/home/Home.tsx
+++ b/app/subscriber/src/features/home/Home.tsx
@@ -61,7 +61,7 @@ export const Home: React.FC = () => {
     if (!!homePage && !!filter.startDate && !isReady) {
       setIsReady(true);
     }
-  }, [homePage]);
+  }, [homePage, filter.startDate, isReady]);
 
   React.useEffect(() => {
     // stops invalid requests before filter is synced with date

--- a/app/subscriber/src/features/home/Home.tsx
+++ b/app/subscriber/src/features/home/Home.tsx
@@ -25,6 +25,7 @@ export const Home: React.FC = () => {
 
   const [content, setContent] = React.useState<IContentSearchResult[]>([]);
   const [selected, setSelected] = React.useState<IContentModel[]>([]);
+  const [isReady, setIsReady] = React.useState<boolean>(false);
   const [settings] = React.useState<IFilterSettingsModel>(
     createFilterSettings(
       filter.startDate ?? moment().startOf('day').toISOString(),
@@ -57,8 +58,14 @@ export const Home: React.FC = () => {
   }, [actions]);
 
   React.useEffect(() => {
+    if (!!homePage && !!filter.startDate && !isReady) {
+      setIsReady(true);
+    }
+  }, [homePage]);
+
+  React.useEffect(() => {
     // stops invalid requests before filter is synced with date
-    if (!filter.startDate || !actions.length) return;
+    if (!isReady) return;
     fetchResults(
       generateQuery(
         filterFormat({
@@ -72,7 +79,7 @@ export const Home: React.FC = () => {
         }),
       ),
     );
-  }, [fetchResults, filter, settings, contentType, actions, homePage]);
+  }, [isReady, filter.startDate]);
 
   return (
     <styled.Home>

--- a/app/subscriber/src/features/home/Home.tsx
+++ b/app/subscriber/src/features/home/Home.tsx
@@ -79,6 +79,8 @@ export const Home: React.FC = () => {
         }),
       ),
     );
+    // only run when filter is ready, and when filter.startDate changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isReady, filter.startDate]);
 
   return (

--- a/app/subscriber/src/features/top-stories/TopStories.tsx
+++ b/app/subscriber/src/features/top-stories/TopStories.tsx
@@ -28,7 +28,7 @@ export const TopStories: React.FC = () => {
     if (!actions.length || !filter.startDate) return;
 
     let actionFilters = getFilterActions(actions);
-    const topStoryAction = actionFilters[ActionName.Commentary];
+    const topStoryAction = actionFilters[ActionName.TopStory];
 
     findContentWithElasticsearch(
       generateQuery(


### PR DESCRIPTION
- filter was firing before `homePage` action was determined, now uses `isReady` flag before firing
- top stories now correctly showing content
- also fix misalignment i saw during demo

![image](https://github.com/bcgov/tno/assets/15724124/c20ab6ea-2d95-4b27-9ec8-d29fb310773f)

(before)
![image](https://github.com/bcgov/tno/assets/15724124/578a81ab-0aaa-440d-b280-119f29f72335)



