### PR TITLE
TNO-2306 Remove section ToC

### DIFF
--- a/app/editor/src/features/admin/reports/utils/createReportSection.ts
+++ b/app/editor/src/features/admin/reports/utils/createReportSection.ts
@@ -17,8 +17,7 @@ export const createReportSection = (
       label: '',
       useAllContent: type === ReportSectionTypeName.MediaAnalytics,
       removeDuplicates: false,
-      showHeadlines:
-        type === ReportSectionTypeName.Content || type === ReportSectionTypeName.TableOfContents,
+      showHeadlines: type === ReportSectionTypeName.TableOfContents,
       showFullStory: type === ReportSectionTypeName.Content,
       showImage: type === ReportSectionTypeName.Gallery,
       hideEmpty: false,

--- a/app/subscriber/src/features/my-reports/admin/components/ReportSectionContent.tsx
+++ b/app/subscriber/src/features/my-reports/admin/components/ReportSectionContent.tsx
@@ -135,11 +135,6 @@ export const ReportSectionContent = React.forwardRef<HTMLDivElement, IReportSect
               tooltip="Remove content from this section that is in above sections"
             />
             <FormikCheckbox
-              name={`sections.${index}.settings.showHeadlines`}
-              label="Show Headlines"
-              tooltip="Display the story headline for each content item in this section"
-            />
-            <FormikCheckbox
               name={`sections.${index}.settings.showFullStory`}
               label="Show Full Story"
               tooltip="Display the full story for each content item in this section"


### PR DESCRIPTION
Removed the ability to add a Table of Content within a report section in the Subscriber app.  This feature is still available to the Editor app.

![image](https://github.com/bcgov/tno/assets/3180256/bbee7536-b2eb-4daa-b951-f30b30eecd66)
