### PR TITLE
bug: #tno-2302 - add resume after sleep

### DIFF
--- a/services/net/content/ContentManager.cs
+++ b/services/net/content/ContentManager.cs
@@ -136,6 +136,9 @@ public class ContentManager : ServiceManager<ContentOptions>
             // It could also result in a longer than planned delay if the action manager is awaited (currently it is).
             this.Logger.LogDebug("Service sleeping for {delay:n0} ms", delay);
             await Task.Delay(delay);
+
+            // after the service has slept, it needs to be woken up
+            this.State.Resume();
         }
     }
 


### PR DESCRIPTION
- we should probably apply some sort of exponential backoff here or at least sniff the thrown exception to see if it is transient and then determine whether to retry or perma-fail