### PR TITLE
fix: #tno-2301 - nav under content in paper is in sync

### DIFF
--- a/app/editor/src/features/content/form/ContentNavigation.tsx
+++ b/app/editor/src/features/content/form/ContentNavigation.tsx
@@ -34,6 +34,7 @@ export const ContentNavigation: React.FC<IContentNavigationProps> = ({
   const { combined } = useCombinedView(values.contentType);
 
   const [currentItems] = useLocalStorage('currentContent', null);
+  const [, setCurrentItemId] = useLocalStorage('currentContentItemId', -1);
 
   const [indexPosition, setIndexPosition] = useState(0);
   const [enablePrev, setEnablePrev] = useState(false);
@@ -54,6 +55,7 @@ export const ContentNavigation: React.FC<IContentNavigationProps> = ({
     if (currentItems != null) {
       const targetId = (currentItems as IContentSearchResult[])[indexPosition + offset]?.id;
       if (!!targetId) {
+        setCurrentItemId(targetId);
         navigate(getContentPath(combined, targetId, values.contentType, combinedPath));
       }
     }

--- a/app/editor/src/features/content/list-view/ContentListView.tsx
+++ b/app/editor/src/features/content/list-view/ContentListView.tsx
@@ -61,12 +61,17 @@ const ContentListView: React.FC = () => {
   // This configures the shared storage between this list and any content tabs
   // that are opened.  Mainly used for navigation in the tab
   const [, setCurrentItems] = useLocalStorage('currentContent', {} as IContentSearchResult[]);
+  const [currentItemId, setCurrentItemId] = useLocalStorage('currentContentItemId', -1);
 
   // Stores the current page
   const [currentResultsPage, setCurrentResultsPage] = React.useState(defaultPage);
   React.useEffect(() => {
     setCurrentItems(currentResultsPage.items);
   }, [currentResultsPage, setCurrentItems]);
+  // if the user navigates next/previous in another window change the highlited row
+  React.useEffect(() => {
+    if (currentItemId !== -1) setContentId(currentItemId.toString());
+  }, [currentItemId, setContentId]);
 
   React.useEffect(() => {
     // Extract query string values and place them into redux store.
@@ -290,6 +295,7 @@ const ContentListView: React.FC = () => {
   ) => {
     setContentType(row.original.contentType);
     setContentId(row.original.id.toString());
+    setCurrentItemId(row.original.id);
     if (event.ctrlKey) navigate(row.original.id, '/contents', NavigateOptions.NewTab);
     else navigate(row.original.id);
   };

--- a/app/editor/src/features/content/papers/Papers.tsx
+++ b/app/editor/src/features/content/papers/Papers.tsx
@@ -64,12 +64,17 @@ const Papers: React.FC<IPapersProps> = (props) => {
   // This configures the shared storage between this list and any content tabs
   // that are opened.  Mainly used for navigation in the tab
   const [, setCurrentItems] = useLocalStorage('currentContent', {} as IContentSearchResult[]);
+  const [currentItemId, setCurrentItemId] = useLocalStorage('currentContentItemId', -1);
 
   // Stores the current page
   const [currentResultsPage, setCurrentResultsPage] = React.useState(defaultPage);
   React.useEffect(() => {
     setCurrentItems(currentResultsPage.items);
   }, [currentResultsPage, setCurrentItems]);
+  // if the user navigates next/previous in another window change the highlited row
+  React.useEffect(() => {
+    if (currentItemId !== -1) setContentId(currentItemId.toString());
+  }, [currentItemId, setContentId]);
 
   // Message process related states & logic:
   const [isProcessingMessages, setIsProcessingMessages] = React.useState<boolean>(false);
@@ -239,6 +244,7 @@ const Papers: React.FC<IPapersProps> = (props) => {
   ) => {
     if (cell.index > 0 && cell.index !== 5) {
       setContentId(row.original.id.toString());
+      setCurrentItemId(row.original.id);
       if (event.ctrlKey) navigate(row.original.id, '/contents', NavigateOptions.NewTab);
       else navigate(row.original.id);
     }


### PR DESCRIPTION
- if the user navigates in a content tab/window the currently highlited row will be selected