### PR TITLE
fix: #tno-2328 - fixed issue in indexing and updating

### DIFF
--- a/api/net/Areas/Editor/Controllers/ContentController.cs
+++ b/api/net/Areas/Editor/Controllers/ContentController.cs
@@ -309,7 +309,10 @@ public class ContentController : ControllerBase
 
         if (!String.IsNullOrWhiteSpace(_kafkaOptions.IndexingTopic))
         {
-            await _kafkaMessenger.SendMessageAsync(_kafkaOptions.IndexingTopic, new IndexRequestModel(updatedContent.Id, user.Id, IndexAction.Index));
+            if (updatedContent.Status == ContentStatus.Publish || updatedContent.Status == ContentStatus.Published)
+                await _kafkaMessenger.SendMessageAsync(_kafkaOptions.IndexingTopic, new IndexRequestModel(updatedContent.Id, user.Id, IndexAction.Publish));
+            else
+                await _kafkaMessenger.SendMessageAsync(_kafkaOptions.IndexingTopic, new IndexRequestModel(updatedContent.Id, user.Id, IndexAction.Index));
         }
         else
             _logger.LogWarning("Kafka indexing topic not configured.");

--- a/app/editor/src/features/admin/event-of-the-day/EventOfTheDayList.tsx
+++ b/app/editor/src/features/admin/event-of-the-day/EventOfTheDayList.tsx
@@ -9,6 +9,7 @@ import {
   FlexboxTable,
   FormPage,
   getSortableOptions,
+  IContentTopicModel,
   IFolderContentModel,
   IOptionItem,
   ITopicModel,
@@ -101,7 +102,11 @@ const EventOfTheDayList: React.FC = () => {
 
   const handleSubmit = async (values: IFolderContentModel) => {
     try {
-      const result = await updateContentTopics(values.contentId, values.content!.topics);
+      var result: IContentTopicModel[];
+      if (values.content!.topics[0].id === topicIdNotApplicable)
+        result = await updateContentTopics(values.contentId, undefined);
+      else result = await updateContentTopics(values.contentId, values.content!.topics);
+
       let index = items.findIndex((el) => el.contentId === values.contentId);
       let results = [...items];
       results[index].content!.topics = result;


### PR DESCRIPTION
- need to check current status of content when updating it
- if content is in a state of Publish | Published, it gets re-published, else it just gets re-indexed
- if the users sets the Topic to "Not Applicable" send an empty list of topics instead of thgat "magic" topic