### PR TITLE
[UPDATED] TNO-2138, TNO-2139: Press gallery enhancements

### DIFF
--- a/app/subscriber/src/components/content-list/ContentRow.tsx
+++ b/app/subscriber/src/components/content-list/ContentRow.tsx
@@ -60,7 +60,7 @@ export const ContentRow: React.FC<IContentRowProps> = ({
         {viewOptions.sentiment && determineToneIcon(item.tonePools[0])}
         {showDate && (
           <div className="date">{`${moment(item.publishedOn).format('DD-MMM-YYYY')} ${
-            showTime ? `(${moment(item.publishedOn).format('HH:mm:ss')})` : ''
+            showTime ? `(${moment(item.publishedOn).format('HH:mm')})` : ''
           }`}</div>
         )}
         <Link to={`/view/${item.id}`} className="headline">

--- a/app/subscriber/src/features/press-gallery/PressGallery.tsx
+++ b/app/subscriber/src/features/press-gallery/PressGallery.tsx
@@ -30,12 +30,13 @@ export const PressGallery: React.FC = () => {
 
   const [content, setContent] = React.useState<IContentSearchResult[]>([]);
   const [pressMembers, setPressMembers] = React.useState<IPressMember[]>([]);
+  // initial load underway no requests at this time
   const [initialLoad, setInitialLoad] = React.useState(false);
   const [selected, setSelected] = React.useState<IContentModel[]>([]);
   const [dateOptions, setDateOptions] = React.useState<IDateOptions[]>([]);
   const [aliases, setAliases] = React.useState<string[]>([]);
   const [loading, setLoading] = React.useState(false);
-  const [groupedContent, setGroupedContent] = React.useState<IGroupedDates[] | undefined>();
+  const [contentByDate, setContentByDate] = React.useState<IGroupedDates | undefined>();
   const [pressSettings] = React.useState<IFilterSettingsModel>(
     createFilterSettings(`${moment().startOf('day')}`, `${moment().subtract('2', 'weeks')}`),
   );
@@ -79,16 +80,7 @@ export const PressGallery: React.FC = () => {
         acc[date].push(content);
         return acc;
       }, {});
-      // !groupedContent?.length &&
-      setGroupedContent(
-        Object.entries(grouped).map(
-          ([key, value]) =>
-            ({
-              date: key,
-              content: value as IContentSearchResult[],
-            } as IGroupedDates),
-        ),
-      );
+      setContentByDate(grouped);
     }
   }, [content]);
 
@@ -189,7 +181,7 @@ export const PressGallery: React.FC = () => {
             return {
               label: `${d.label} ${
                 !pressGalleryFilter.dateFilter
-                  ? `(${groupedContent?.find((c) => c.date === d.label)?.content.length ?? 0})`
+                  ? `(${contentByDate?.[d.label as keyof IGroupedDates]?.length ?? 0})`
                   : ''
               }`,
               value: d.value,

--- a/app/subscriber/src/features/press-gallery/interfaces/IGroupedDates.ts
+++ b/app/subscriber/src/features/press-gallery/interfaces/IGroupedDates.ts
@@ -1,0 +1,6 @@
+import { IContentSearchResult } from 'features/utils/interfaces';
+
+export interface IGroupedDates {
+  date: string;
+  content: IContentSearchResult[];
+}

--- a/app/subscriber/src/features/press-gallery/interfaces/IGroupedDates.ts
+++ b/app/subscriber/src/features/press-gallery/interfaces/IGroupedDates.ts
@@ -1,6 +1,5 @@
 import { IContentSearchResult } from 'features/utils/interfaces';
 
 export interface IGroupedDates {
-  date: string;
-  content: IContentSearchResult[];
+  [key: string]: IContentSearchResult[];
 }

--- a/app/subscriber/src/features/press-gallery/interfaces/index.ts
+++ b/app/subscriber/src/features/press-gallery/interfaces/index.ts
@@ -1,2 +1,3 @@
 export * from './IDateOptions';
+export * from './IGroupedDates';
 export * from './IPressMember';

--- a/app/subscriber/src/features/press-gallery/styled/PressGallery.tsx
+++ b/app/subscriber/src/features/press-gallery/styled/PressGallery.tsx
@@ -2,51 +2,20 @@ import styled from 'styled-components';
 
 export const PressGallery = styled.div`
   .tool-bar {
+    margin-left: auto;
+    margin-right: auto;
+    width: fit-content;
     .reset {
-      margin-top: 0.5em;
-      margin-left: 0.5em;
+      margin-top: auto;
+      margin-bottom: auto;
+      height: 20px;
+      width: 20px;
+      margin-left: 1em;
+      color: ${({ theme }) => theme.css.btnBkPrimary};
       &:hover {
         cursor: pointer;
         transform: scale(1.1);
       }
     }
-    .folder-sub-menu {
-      margin-left: auto;
-    }
-    .or {
-      margin-right: 0.5em;
-    }
-    .date-navigator {
-      margin-left: auto;
-      margin-right: auto;
-      input {
-        margin-top: 0.25em;
-      }
-    }
-  }
-  .table {
-    width: 100%;
-    .group {
-      background-color: #f9f9f9 !important;
-    }
-    .header {
-      background-color: #f5f6fa;
-      font-size: 0.8em;
-      /* box shadow only on bottom */
-      box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
-      border: none;
-      color: #7c7e8a;
-
-      .column {
-        background-color: #f5f6fa;
-      }
-    }
-    .rows {
-      cursor: pointer;
-    }
-  }
-  .headline {
-    /* link color */
-    color: #3847aa;
   }
 `;

--- a/app/subscriber/src/features/press-gallery/utils/index.ts
+++ b/app/subscriber/src/features/press-gallery/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './generateDates';
+export * from './seperateAlias';

--- a/app/subscriber/src/features/press-gallery/utils/seperateAlias.ts
+++ b/app/subscriber/src/features/press-gallery/utils/seperateAlias.ts
@@ -1,7 +1,7 @@
 /**
- * @desc This function takes an array of strings and seperates them by comma or space
- * @param {string[]} alias - An array of strings
- * @returns {string[]} - An array of strings
+ * @description - Seperate alias into individual strings
+ * @param {string[]} alias - The alias to be seperated, may contain strings that are comma seperated or by space
+ * @returns {string[]} - The alias seperated into individual strings
  */
 export const seperateAlias = (alias: string[]) => {
   return alias.map((a) => a.split(/,\s*|\s+/)).flat();

--- a/app/subscriber/src/features/press-gallery/utils/seperateAlias.ts
+++ b/app/subscriber/src/features/press-gallery/utils/seperateAlias.ts
@@ -1,0 +1,8 @@
+/**
+ * @desc This function takes an array of strings and seperates them by comma or space
+ * @param {string[]} alias - An array of strings
+ * @returns {string[]} - An array of strings
+ */
+export const seperateAlias = (alias: string[]) => {
+  return alias.map((a) => a.split(/,\s*|\s+/)).flat();
+};


### PR DESCRIPTION
- fixed issued filter was broken when searching for a comma separated alias
- small styling changes 
- remove additional requests for total hits on press gallery, it also interferes too much now that the OR is no longer required. Hits are constantly changing

![image](https://github.com/bcgov/tno/assets/15724124/8e32e714-9505-4557-98f4-de5b4b772abf)
