### PR TITLE
fix: #tno-2354 - sped up response time from adding a topic

### DIFF
--- a/app/editor/src/store/hooks/admin/useTopics.ts
+++ b/app/editor/src/store/hooks/admin/useTopics.ts
@@ -1,7 +1,14 @@
 import React from 'react';
 import { useAjaxWrapper, useLookup } from 'store/hooks';
 import { IAdminState, useAdminStore } from 'store/slices';
-import { IPaged, ITopicFilter, ITopicModel, useApiAdminTopics } from 'tno-core';
+import {
+  IPaged,
+  ITopicFilter,
+  ITopicModel,
+  saveToLocalStorage,
+  StorageKeys,
+  useApiAdminTopics,
+} from 'tno-core';
 
 interface ITopicController {
   findAllTopics: () => Promise<ITopicModel[]>;
@@ -45,12 +52,14 @@ export const useTopics = (): [IAdminState, ITopicController] => {
       },
       addTopic: async (model: ITopicModel) => {
         const response = await dispatch<ITopicModel>('add-topic', () => api.addTopic(model));
+        let items: ITopicModel[] = [];
+
         store.storeTopics((topics) => {
-          var items = [...topics];
+          items = [...topics];
           items.splice(model.sortOrder, 0, response.data);
           return items;
         });
-        await lookup.getLookups();
+        saveToLocalStorage(StorageKeys.Topics, items, store.storeTopics);
         return response.data;
       },
       updateTopic: async (model: ITopicModel) => {

--- a/app/editor/src/store/hooks/lookup/useLookup.ts
+++ b/app/editor/src/store/hooks/lookup/useLookup.ts
@@ -219,7 +219,7 @@ export const useLookup = (): [ILookupState, ILookupController] => {
           'lookup',
         );
       },
-      getTopics: async () => {
+      getTopics: async (refresh?: boolean) => {
         return await fetchIfNoneMatch<ITopicModel[]>(
           StorageKeys.Topics,
           dispatch,
@@ -227,6 +227,8 @@ export const useLookup = (): [ILookupState, ILookupController] => {
           (results) => {
             const values = results ?? [];
             store.storeTopics(values);
+            if (!!refresh)
+              saveToLocalStorage(StorageKeys.Topics, values, store.storeTopics);
             return values;
           },
           true,

--- a/app/editor/src/store/hooks/lookup/useLookup.ts
+++ b/app/editor/src/store/hooks/lookup/useLookup.ts
@@ -227,8 +227,7 @@ export const useLookup = (): [ILookupState, ILookupController] => {
           (results) => {
             const values = results ?? [];
             store.storeTopics(values);
-            if (!!refresh)
-              saveToLocalStorage(StorageKeys.Topics, values, store.storeTopics);
+            if (!!refresh) saveToLocalStorage(StorageKeys.Topics, values, store.storeTopics);
             return values;
           },
           true,


### PR DESCRIPTION
- do not make a call to refresh ALL lookups just because we added a new topic
- when adding a new topic, just update Topics in redux and localstorage
- may be a new pattern here to increase responsiveness in lists?