### PR TITLE
TNO-2290: Fix filter media type query bugs

### DIFF
--- a/app/subscriber/src/components/date-filter/DateFilter.tsx
+++ b/app/subscriber/src/components/date-filter/DateFilter.tsx
@@ -2,30 +2,27 @@ import moment from 'moment';
 import React from 'react';
 import ReactDatePicker from 'react-datepicker';
 import { FaCalendarDay, FaCaretLeft, FaCaretRight } from 'react-icons/fa6';
+import { useContent } from 'store/hooks';
 import { IFilterSettingsModel } from 'tno-core';
 
 import * as styled from './styled';
 
 export interface IDateFilterProps {
+  loaded?: boolean;
   filter: IFilterSettingsModel;
   storeFilter: (filter: IFilterSettingsModel) => void;
 }
 
 /** Custom date filter for the subscriber home page. Control the calendar state with custom button, custom styling also applied. Also allows user to navigate a day at a time via arrow buttons. */
-export const DateFilter: React.FC<IDateFilterProps> = ({ filter, storeFilter }) => {
+export const DateFilter: React.FC<IDateFilterProps> = ({ loaded, filter, storeFilter }) => {
   /** control state of open calendar from outside components. i.e custom calendar button */
+  const [
+    {
+      mediaType: { filter: storedFilter },
+    },
+  ] = useContent();
   const [open, setOpen] = React.useState(false);
 
-  React.useEffect(() => {
-    if (!filter.startDate) {
-      storeFilter({
-        ...filter,
-        startDate: moment().startOf('day').toISOString(),
-        endDate: moment().endOf('day').toISOString(),
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filter]);
   // /** close calendar after a date has been selected, and fetch related content */
   React.useEffect(() => {
     setOpen(false);
@@ -33,14 +30,23 @@ export const DateFilter: React.FC<IDateFilterProps> = ({ filter, storeFilter }) 
 
   /** update state variable when date changes, can be controlled via date picker or arrows */
   React.useEffect(() => {
-    storeFilter({
-      ...filter,
-      startDate: moment(filter.startDate).startOf('day').toISOString(),
-      endDate: moment(filter.startDate).endOf('day').toISOString(),
-    });
+    if (!filter.startDate) {
+      storeFilter({
+        ...filter,
+        startDate: moment().startOf('day').toISOString(),
+        endDate: moment().endOf('day').toISOString(),
+      });
+      return;
+    } else if (storedFilter.startDate !== filter.startDate) {
+      storeFilter({
+        ...filter,
+        startDate: moment(filter.startDate).startOf('day').toISOString(),
+        endDate: moment(filter.startDate).endOf('day').toISOString(),
+      });
+    }
     // only want the above to trigger when date changes, not when filterAdvanced changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filter.startDate]);
+  }, [filter, filter?.startDate]);
 
   /** function to help manipulate the current date based on user input */
   const adjustDate = (days: number, direction: 'forwards' | 'backwards') => {

--- a/app/subscriber/src/features/filter-media/FilterMedia.tsx
+++ b/app/subscriber/src/features/filter-media/FilterMedia.tsx
@@ -3,7 +3,7 @@ import { ContentList } from 'components/content-list';
 import { DateFilter } from 'components/date-filter';
 import { ContentListActionBar } from 'components/tool-bar';
 import { IContentSearchResult } from 'features/utils/interfaces';
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import { useContent } from 'store/hooks';
 import { generateQuery, IContentModel, Show } from 'tno-core';
 

--- a/app/subscriber/src/features/filter-media/PreviousResults.tsx
+++ b/app/subscriber/src/features/filter-media/PreviousResults.tsx
@@ -2,7 +2,7 @@ import { IContentSearchResult } from 'features/utils/interfaces';
 import moment from 'moment';
 import React from 'react';
 import { useContent } from 'store/hooks';
-import { generateQuery, Row } from 'tno-core';
+import { Row } from 'tno-core';
 
 import { IPreviousDate } from './interfaces';
 import * as styled from './styled';


### PR DESCRIPTION
Reduced # of calls from ~10 to 1 on Filter Media page, by reducing redundant queries, and combining 5 separate queries for 5 days, into 1.

Before: 
<img width="1616" alt="Screenshot 2024-02-16 at 11 56 30 AM" src="https://github.com/bcgov/tno/assets/7937856/db59eb6f-3a75-4793-a7d4-472f5727dc06">

After:
<img width="1460" alt="Screenshot 2024-02-28 at 3 28 45 PM" src="https://github.com/bcgov/tno/assets/7937856/a46d5391-54ac-40c7-99d3-fcf2aa1b3366">
