### PR TITLE
Tno 2365 move email alerts to service manager

### DIFF
--- a/libs/net/services/Managers/IngestManager`.cs
+++ b/libs/net/services/Managers/IngestManager`.cs
@@ -2,6 +2,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using TNO.API.Areas.Services.Models.Ingest;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 using TNO.Services.Config;
 
 namespace TNO.Services.Managers;
@@ -33,16 +35,20 @@ public abstract class IngestManager<TActionManager, TOption> : ServiceManager<TO
     /// Creates a new instance of a IngestManager object, initializes with specified parameters.
     /// </summary>
     /// <param name="api">Service to communicate with the api.</param>
+    /// <param name="chesService"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="factory">Ingest manager factory.</param>
     /// <param name="options">Configuration options.</param>
     /// <param name="logger">Logging client.</param>
     public IngestManager(
         IServiceProvider serviceProvider,
         IApiService api,
+        IChesService chesService,
+        IOptions<ChesOptions> chesOptions,
         IngestManagerFactory<TActionManager, TOption> factory,
         IOptions<TOption> options,
         ILogger<IngestManager<TActionManager, TOption>> logger)
-        : base(api, options, logger)
+        : base(api, chesService, chesOptions, options, logger)
     {
         _factory = factory;
         _serviceScope = serviceProvider.CreateScope();

--- a/libs/net/services/Managers/ServiceManager`.cs
+++ b/libs/net/services/Managers/ServiceManager`.cs
@@ -94,7 +94,7 @@ public abstract class ServiceManager<TOption> : IServiceManager
             }
             catch (ChesException ex)
             {
-                this.Logger.LogError(ex, "Ches exception while sending email. {response}", ex.Data["body"] ?? "");
+                this.Logger.LogError(ex, "Ches exception while sending email. {response}", ex.Data.Contains("body") ? ex.Data["body"] : ex.Message);
             }
             catch (Exception ex)
             {

--- a/libs/net/services/Managers/ServiceManager`.cs
+++ b/libs/net/services/Managers/ServiceManager`.cs
@@ -54,7 +54,8 @@ public abstract class ServiceManager<TOption> : IServiceManager
     /// Creates a new instance of a ServiceManager object, initializes with specified parameters.
     /// </summary>
     /// <param name="api">Service to communicate with the api.</param>
-    /// <param name="factory">Data source manager factory.</param>
+    /// <param name="chesService"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="options">Configuration options.</param>
     /// <param name="logger">Logging client.</param>
     public ServiceManager(

--- a/services/net/capture/CaptureManager.cs
+++ b/services/net/capture/CaptureManager.cs
@@ -4,6 +4,8 @@ using TNO.Services.Managers;
 using TNO.Services.Capture.Config;
 using TNO.API.Areas.Services.Models.Ingest;
 using TNO.Models.Extensions;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 
 namespace TNO.Services.Capture;
 
@@ -18,16 +20,20 @@ public class CaptureManager : IngestManager<CaptureIngestActionManager, CaptureO
     /// </summary>
     /// <param name="serviceProvider"></param>
     /// <param name="api"></param>
+    /// <param name="chesService"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="factory"></param>
     /// <param name="options"></param>
     /// <param name="logger"></param>
     public CaptureManager(
         IServiceProvider serviceProvider,
         IApiService api,
+        IChesService chesService,
+        IOptions<ChesOptions> chesOptions,
         IngestManagerFactory<CaptureIngestActionManager, CaptureOptions> factory,
         IOptions<CaptureOptions> options,
         ILogger<CaptureManager> logger)
-        : base(serviceProvider, api, factory, options, logger)
+        : base(serviceProvider, api, chesService, chesOptions, factory, options, logger)
     {
     }
 

--- a/services/net/clip/ClipManager.cs
+++ b/services/net/clip/ClipManager.cs
@@ -4,6 +4,8 @@ using TNO.Services.Managers;
 using TNO.Services.Clip.Config;
 using TNO.API.Areas.Services.Models.Ingest;
 using TNO.Models.Extensions;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 
 namespace TNO.Services.Clip;
 
@@ -18,16 +20,20 @@ public class ClipManager : IngestManager<ClipIngestActionManager, ClipOptions>
     /// </summary>
     /// <param name="serviceProvider"></param>
     /// <param name="api"></param>
+    /// <param name="chesService"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="factory"></param>
     /// <param name="options"></param>
     /// <param name="logger"></param>
     public ClipManager(
         IServiceProvider serviceProvider,
         IApiService api,
+        IChesService chesService,
+        IOptions<ChesOptions> chesOptions,
         IngestManagerFactory<ClipIngestActionManager, ClipOptions> factory,
         IOptions<ClipOptions> options,
         ILogger<ClipManager> logger)
-        : base(serviceProvider, api, factory, options, logger)
+        : base(serviceProvider, api, chesService, chesOptions, factory, options, logger)
     {
     }
 

--- a/services/net/command/CommandManager.cs
+++ b/services/net/command/CommandManager.cs
@@ -2,6 +2,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using TNO.Services.Managers;
 using TNO.Services.Command.Config;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 
 namespace TNO.Services.Command;
 
@@ -16,16 +18,20 @@ public class CommandManager : IngestManager<CommandIngestActionManager, CommandO
     /// </summary>
     /// <param name="serviceProvider"></param>
     /// <param name="api"></param>
+    /// <param name="chesService"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="factory"></param>
     /// <param name="options"></param>
     /// <param name="logger"></param>
     public CommandManager(
         IServiceProvider serviceProvider,
         IApiService api,
+        IChesService chesService,
+        IOptions<ChesOptions> chesOptions,
         IngestManagerFactory<CommandIngestActionManager, CommandOptions> factory,
         IOptions<CommandOptions> options,
         ILogger<CommandManager> logger)
-        : base(serviceProvider, api, factory, options, logger)
+        : base(serviceProvider, api, chesService, chesOptions, factory, options, logger)
     {
     }
     #endregion

--- a/services/net/content/ContentManager.cs
+++ b/services/net/content/ContentManager.cs
@@ -49,6 +49,8 @@ public class ContentManager : ServiceManager<ContentOptions>
     /// <param name="kafkaAdmin"></param>
     /// <param name="kafkaListener"></param>
     /// <param name="api"></param>
+    /// <param name="chesService"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="options"></param>
     /// <param name="logger"></param>
     public ContentManager(

--- a/services/net/contentmigration/ContentMigrationManager.cs
+++ b/services/net/contentmigration/ContentMigrationManager.cs
@@ -2,6 +2,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using TNO.Services.Managers;
 using TNO.Services.ContentMigration.Config;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 
 namespace TNO.Services.ContentMigration;
 
@@ -16,16 +18,20 @@ public class ContentMigrationManager : IngestManager<ContentMigrationIngestActio
     /// </summary>
     /// <param name="serviceProvider"></param>
     /// <param name="api"></param>
+    /// <param name="chesService"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="factory"></param>
     /// <param name="options"></param>
     /// <param name="logger"></param>
     public ContentMigrationManager(
         IServiceProvider serviceProvider,
         IApiService api,
+        IChesService chesService,
+        IOptions<ChesOptions> chesOptions,
         IngestManagerFactory<ContentMigrationIngestActionManager, ContentMigrationOptions> factory,
         IOptions<ContentMigrationOptions> options,
         ILogger<ContentMigrationManager> logger)
-        : base(serviceProvider, api, factory, options, logger)
+        : base(serviceProvider, api, chesService, chesOptions, factory, options, logger)
     {
     }
     #endregion

--- a/services/net/filecopy/FileCopyManager.cs
+++ b/services/net/filecopy/FileCopyManager.cs
@@ -10,6 +10,8 @@ using TNO.Core.Exceptions;
 using TNO.Entities;
 using TNO.Models.Extensions;
 using System.Web;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 
 namespace TNO.Services.FileCopy;
 
@@ -39,14 +41,18 @@ public class FileCopyManager : ServiceManager<FileCopyOptions>
     /// </summary>
     /// <param name="listener"></param>
     /// <param name="api"></param>
+    /// <param name="chesService"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="options"></param>
     /// <param name="logger"></param>
     public FileCopyManager(
         IKafkaListener<string, FileRequestModel> listener,
         IApiService api,
+        IChesService chesService,
+        IOptions<ChesOptions> chesOptions,
         IOptions<FileCopyOptions> options,
         ILogger<FileCopyManager> logger)
-        : base(api, options, logger)
+        : base(api, chesService, chesOptions, options, logger)
     {
         this.Listener = listener;
         this.Listener.IsLongRunningJob = true;

--- a/services/net/filemonitor/FilemonitorManager.cs
+++ b/services/net/filemonitor/FilemonitorManager.cs
@@ -2,6 +2,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using TNO.Services.Managers;
 using TNO.Services.FileMonitor.Config;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 
 namespace TNO.Services.FileMonitor;
 
@@ -16,16 +18,20 @@ public class FileMonitorManager : IngestManager<FileMonitorIngestActionManager, 
     /// </summary>
     /// <param name="serviceProvider"></param>
     /// <param name="api"></param>
+    /// <param name="chesService"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="factory"></param>
     /// <param name="options"></param>
     /// <param name="logger"></param>
     public FileMonitorManager(
         IServiceProvider serviceProvider,
         IApiService api,
+        IChesService chesService,
+        IOptions<ChesOptions> chesOptions,
         IngestManagerFactory<FileMonitorIngestActionManager, FileMonitorOptions> factory,
         IOptions<FileMonitorOptions> options,
         ILogger<FileMonitorManager> logger)
-        : base(serviceProvider, api, factory, options, logger)
+        : base(serviceProvider, api, chesService, chesOptions, factory, options, logger)
     {
     }
     #endregion

--- a/services/net/image/ImageManager.cs
+++ b/services/net/image/ImageManager.cs
@@ -2,6 +2,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using TNO.Services.Managers;
 using TNO.Services.Image.Config;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 
 namespace TNO.Services.Image;
 
@@ -16,16 +18,20 @@ public class ImageManager : IngestManager<ImageIngestActionManager, ImageOptions
     /// </summary>
     /// <param name="serviceProvider"></param>
     /// <param name="api"></param>
+    /// <param name="chesService"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="factory"></param>
     /// <param name="options"></param>
     /// <param name="logger"></param>
     public ImageManager(
         IServiceProvider serviceProvider,
         IApiService api,
+        IChesService chesService,
+        IOptions<ChesOptions> chesOptions,
         IngestManagerFactory<ImageIngestActionManager, ImageOptions> factory,
         IOptions<ImageOptions> options,
         ILogger<ImageManager> logger)
-        : base(serviceProvider, api, factory, options, logger)
+        : base(serviceProvider, api, chesService, chesOptions, factory, options, logger)
     {
     }
     #endregion

--- a/services/net/nlp/NLPManager.cs
+++ b/services/net/nlp/NLPManager.cs
@@ -3,6 +3,8 @@ using Confluent.Kafka;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using TNO.API.Areas.Services.Models.Content;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 using TNO.Core.Exceptions;
 using TNO.Entities;
 using TNO.Kafka;
@@ -47,15 +49,19 @@ public class NlpManager : ServiceManager<NLPOptions>
     /// <param name="consumer"></param>
     /// <param name="producer"></param>
     /// <param name="api"></param>
+    /// <param name="chesService"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="options"></param>
     /// <param name="logger"></param>
     public NlpManager(
         IKafkaListener<string, NlpRequestModel> consumer,
         IKafkaMessenger producer,
         IApiService api,
+        IChesService chesService,
+        IOptions<ChesOptions> chesOptions,
         IOptions<NLPOptions> options,
         ILogger<NlpManager> logger)
-        : base(api, options, logger)
+        : base(api, chesService, chesOptions, options, logger)
     {
         this.Producer = producer;
         this.Listener = consumer;

--- a/services/net/notification/NotificationManager.cs
+++ b/services/net/notification/NotificationManager.cs
@@ -44,16 +44,6 @@ public class NotificationManager : ServiceManager<NotificationOptions>
     protected INotificationEngine NotificationEngine { get; }
 
     /// <summary>
-    /// get - CHES service.
-    /// </summary>
-    protected IChesService Ches { get; }
-
-    /// <summary>
-    /// get - CHES options.
-    /// </summary>
-    protected ChesOptions ChesOptions { get; }
-
-    /// <summary>
     /// get - Template options.
     /// </summary>
     protected TemplateOptions TemplateOptions { get; }
@@ -91,12 +81,10 @@ public class NotificationManager : ServiceManager<NotificationOptions>
         IOptions<TemplateOptions> reportingOptions,
         INotificationValidator notificationValidator,
         ILogger<NotificationManager> logger)
-        : base(api, notificationOptions, logger)
+        : base(api, chesService, chesOptions, notificationOptions, logger)
     {
         _user = user;
         this.NotificationEngine = notificationEngine;
-        this.Ches = chesService;
-        this.ChesOptions = chesOptions.Value;
         this.TemplateOptions = reportingOptions.Value;
         _serializationOptions = serializationOptions.Value;
         this.NotificationValidator = notificationValidator as NotificationValidator ?? throw new ArgumentException("NotificationValidator must be of the correct type");
@@ -108,39 +96,6 @@ public class NotificationManager : ServiceManager<NotificationOptions>
     #endregion
 
     #region Methods
-    /// <summary>
-    /// Send email alert of failure.
-    /// </summary>
-    /// <param name="subject"></param>
-    /// <param name="message"></param>
-    /// <returns></returns>
-    public async Task SendEmailAsync(string subject, string message)
-    {
-        if (this.Options.SendEmailOnFailure)
-        {
-            try
-            {
-                var email = new TNO.Ches.Models.EmailModel(this.ChesOptions.From, this.Options.EmailTo, subject, message);
-                await this.Ches.SendEmailAsync(email);
-            }
-            catch (Exception ex)
-            {
-                this.Logger.LogError(ex, "Email failed to send");
-            }
-        }
-    }
-
-    /// <summary>
-    /// Send email alert of failure.
-    /// </summary>
-    /// <param name="subject"></param>
-    /// <param name="ex"></param>
-    /// <returns></returns>
-    public async Task SendEmailAsync(string subject, Exception ex)
-    {
-        await this.SendEmailAsync($"Notification Service - {subject}", $"<div>{ex.Message}</div>{Environment.NewLine}<div>{ex.StackTrace}</div>");
-    }
-
     /// <summary>
     /// Listen to active topics and import content.
     /// </summary>

--- a/services/net/reporting/ReportingManager.cs
+++ b/services/net/reporting/ReportingManager.cs
@@ -48,16 +48,6 @@ public class ReportingManager : ServiceManager<ReportingOptions>
     /// get - Razor report template engine.
     /// </summary>
     protected IReportEngine ReportEngine { get; }
-
-    /// <summary>
-    /// get - CHES service.
-    /// </summary>
-    protected IChesService Ches { get; }
-
-    /// <summary>
-    /// get - CHES options.
-    /// </summary>
-    protected ChesOptions ChesOptions { get; }
     #endregion
 
     #region Constructors
@@ -83,12 +73,10 @@ public class ReportingManager : ServiceManager<ReportingOptions>
         IOptions<JsonSerializerOptions> serializationOptions,
         IOptions<ReportingOptions> reportOptions,
         ILogger<ReportingManager> logger)
-        : base(api, reportOptions, logger)
+        : base(api, chesService, chesOptions, reportOptions, logger)
     {
         _user = user;
         this.ReportEngine = reportEngine;
-        this.Ches = chesService;
-        this.ChesOptions = chesOptions.Value;
         _serializationOptions = serializationOptions.Value;
         this.Listener = listener;
         this.Listener.IsLongRunningJob = true;
@@ -98,43 +86,6 @@ public class ReportingManager : ServiceManager<ReportingOptions>
     #endregion
 
     #region Methods
-    /// <summary>
-    /// Send email alert of failure.
-    /// </summary>
-    /// <param name="subject"></param>
-    /// <param name="message"></param>
-    /// <returns></returns>
-    public async Task SendEmailAsync(string subject, string message)
-    {
-        if (this.Options.SendEmailOnFailure)
-        {
-            try
-            {
-                var email = new TNO.Ches.Models.EmailModel(this.ChesOptions.From, this.Options.EmailTo, subject, message);
-                await this.Ches.SendEmailAsync(email);
-            }
-            catch (ChesException ex)
-            {
-                this.Logger.LogError(ex, "Email failed to send. {error}", ex.Data);
-            }
-            catch (Exception ex)
-            {
-                this.Logger.LogError(ex, "Email failed to send");
-            }
-        }
-    }
-
-    /// <summary>
-    /// Send email alert of failure.
-    /// </summary>
-    /// <param name="subject"></param>
-    /// <param name="ex"></param>
-    /// <returns></returns>
-    public async Task SendEmailAsync(string subject, Exception ex)
-    {
-        await this.SendEmailAsync($"Reporting Service - {subject}", $"<div>{ex.GetAllMessages()}</div>{Environment.NewLine}<div>{ex.StackTrace}</div>");
-    }
-
     /// <summary>
     /// Listen to active topics and import content.
     /// </summary>

--- a/services/net/scheduler/SchedulerManager.cs
+++ b/services/net/scheduler/SchedulerManager.cs
@@ -18,17 +18,6 @@ namespace TNO.Services.Scheduler;
 /// </summary>
 public class SchedulerManager : ServiceManager<SchedulerOptions>
 {
-    #region Properties
-    /// <summary>
-    /// get - CHES service.
-    /// </summary>
-    protected IChesService Ches { get; }
-
-    /// <summary>
-    /// get - CHES options.
-    /// </summary>
-    protected ChesOptions ChesOptions { get; }
-    #endregion
     #region Constructors
     /// <summary>
     /// Creates a new instance of a SchedulerManager object, initializes with specified parameters.
@@ -44,59 +33,12 @@ public class SchedulerManager : ServiceManager<SchedulerOptions>
         IOptions<ChesOptions> chesOptions,
         IOptions<SchedulerOptions> options,
         ILogger<SchedulerManager> logger)
-        : base(api, options, logger)
+        : base(api, chesService, chesOptions, options, logger)
     {
-        this.Ches = chesService;
-        this.ChesOptions = chesOptions.Value;
     }
     #endregion
 
     #region Methods
-    /// <summary>
-    /// Send email alert of failure.
-    /// </summary>
-    /// <param name="subject"></param>
-    /// <param name="message"></param>
-    /// <returns></returns>
-    public async Task SendEmailAsync(string subject, string message)
-    {
-        if (this.Options.SendEmailOnFailure)
-        {
-            try
-            {
-                var email = new TNO.Ches.Models.EmailModel(this.ChesOptions.From, this.Options.EmailTo, subject, message);
-                await this.Ches.SendEmailAsync(email);
-            }
-            catch (Exception ex)
-            {
-                if (ex is ChesException chesEx)
-                {
-                    this.Logger.LogError(ex, "Ches exception while sending email. {response}", chesEx.Data["body"] ?? "");
-                }
-                else
-                {
-                    this.Logger.LogError(ex, "Email failed to send. {error}", ex.Data);
-                }
-            }
-        }
-    }
-
-    /// <summary>
-    /// Send email alert of failure.
-    /// </summary>
-    /// <param name="subject"></param>
-    /// <param name="ex"></param>
-    /// <returns></returns>
-    public async Task SendEmailAsync(string subject, Exception ex)
-    {
-        string serviceName = "Scheduler";
-        string errorMsg = $"<div>An error occured while executing the {serviceName} service.</div>{Environment.NewLine}" +
-        $"<div>Error Message:</div>{Environment.NewLine}" +
-        $"<div>{ex.GetAllMessages()}</div>{Environment.NewLine}" +
-        $"<div>StackTrace:</div>{Environment.NewLine}" +
-        $"<div>{ex.StackTrace}</div>";
-        await this.SendEmailAsync($"{serviceName} Service - {subject}", errorMsg);
-    }
 
     /// <summary>
     /// Continuous loop fetches event configurations and sends messages to Kafka when scheduled.

--- a/services/net/syndication/SyndicationManager.cs
+++ b/services/net/syndication/SyndicationManager.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using TNO.Ches;
+using TNO.Ches.Configuration;
 using TNO.Services.Managers;
 using TNO.Services.Syndication.Config;
 
@@ -16,16 +18,20 @@ public class SyndicationManager : IngestManager<SyndicationIngestActionManager, 
     /// </summary>
     /// <param name="serviceProvider"></param>
     /// <param name="api"></param>
+    /// <param name="chesService"></param>
+    /// <param name="chesOptions"></param>
     /// <param name="factory"></param>
     /// <param name="options"></param>
     /// <param name="logger"></param>
     public SyndicationManager(
         IServiceProvider serviceProvider,
         IApiService api,
+        IChesService chesService,
+        IOptions<ChesOptions> chesOptions,
         IngestManagerFactory<SyndicationIngestActionManager, SyndicationOptions> factory,
         IOptions<SyndicationOptions> options,
         ILogger<SyndicationManager> logger)
-        : base(serviceProvider, api, factory, options, logger)
+        : base(serviceProvider, api, chesService, chesOptions, factory, options, logger)
     {
     }
     #endregion

--- a/services/net/transcription/TranscriptionManager.cs
+++ b/services/net/transcription/TranscriptionManager.cs
@@ -36,16 +36,6 @@ public class TranscriptionManager : ServiceManager<TranscriptionOptions>
     /// get - Kafka Consumer object.
     /// </summary>
     protected IKafkaListener<string, TranscriptRequestModel> Listener { get; private set; }
-
-    /// <summary>
-    /// get - CHES service.
-    /// </summary>
-    protected IChesService Ches { get; }
-
-    /// <summary>
-    /// get - CHES options.
-    /// </summary>
-    protected ChesOptions ChesOptions { get; }
     #endregion
 
     #region Constructors
@@ -65,10 +55,8 @@ public class TranscriptionManager : ServiceManager<TranscriptionOptions>
         IOptions<ChesOptions> chesOptions,
         IOptions<TranscriptionOptions> options,
         ILogger<TranscriptionManager> logger)
-        : base(api, options, logger)
+        : base(api, chesService, chesOptions, options, logger)
     {
-        this.Ches = chesService;
-        this.ChesOptions = chesOptions.Value;
         this.Listener = listener;
         this.Listener.IsLongRunningJob = true;
         this.Listener.OnError += ListenerErrorHandler;
@@ -77,39 +65,6 @@ public class TranscriptionManager : ServiceManager<TranscriptionOptions>
     #endregion
 
     #region Methods
-    /// <summary>
-    /// Send email alert of failure.
-    /// </summary>
-    /// <param name="subject"></param>
-    /// <param name="message"></param>
-    /// <returns></returns>
-    public async Task SendEmailAsync(string subject, string message)
-    {
-        if (this.Options.SendEmailOnFailure)
-        {
-            try
-            {
-                var email = new TNO.Ches.Models.EmailModel(this.ChesOptions.From, this.Options.EmailTo, subject, message);
-                await this.Ches.SendEmailAsync(email);
-            }
-            catch (Exception ex)
-            {
-                this.Logger.LogError(ex, "Email failed to send");
-            }
-        }
-    }
-
-    /// <summary>
-    /// Send email alert of failure.
-    /// </summary>
-    /// <param name="subject"></param>
-    /// <param name="ex"></param>
-    /// <returns></returns>
-    public async Task SendEmailAsync(string subject, Exception ex)
-    {
-        await this.SendEmailAsync($"Transcription Service - {subject}", $"<div>{ex.Message}</div>{Environment.NewLine}<div>{ex.StackTrace}</div>");
-    }
-
     /// <summary>
     /// Listen to active topics and import content.
     /// </summary>


### PR DESCRIPTION
The method SendEmailAsync was moved to the ServiceManager class as @kylgarmor suggested.
Some refactor were necessary since other services relied on Service Manager, but it avoided some duplicated code, and if we need to send emails from other services we are ready for that.
I was able to make some local tests, and they went great.
When @Fosol get an email from dev, please forward it to me to make sure we have a good format for sending it. (And if we need to fix it, is going to be in only one place.