### PR TITLE
TNO-2324 Fix FFmpeg Service

### DIFF
--- a/api/net/Areas/Admin/Controllers/SeriesController.cs
+++ b/api/net/Areas/Admin/Controllers/SeriesController.cs
@@ -139,11 +139,11 @@ public class SeriesController : ControllerBase
     public IActionResult Merge(int id, int fromId)
     {
         // make sure the merge target exists
-        var result = _service.FindById(id) ?? throw new NoContentException();
+        var _ = _service.FindById(id) ?? throw new NoContentException();
         // make sure the merge source exists
-        result = _service.FindById(fromId) ?? throw new NoContentException();
+        _ = _service.FindById(fromId) ?? throw new NoContentException();
         // merge the source into the target
-        result = _service.Merge(id, fromId);
+        var result = _service.Merge(id, fromId) ?? throw new NoContentException();
         return new JsonResult(new SeriesModel(result));
     }
 

--- a/app/editor/src/features/content/form/components/upload/Upload.tsx
+++ b/app/editor/src/features/content/form/components/upload/Upload.tsx
@@ -208,12 +208,7 @@ export const Upload: React.FC<IUploadProps> = ({
                     : handleFFmpeg(values)
                 }
                 disabled={
-                  !onDownload ||
-                  !!file ||
-                  !downloadable ||
-                  !fileName ||
-                  !fileReference ||
-                  processing
+                  !onDownload || !file || !downloadable || !fileName || !fileReference || processing
                 }
                 className="file-name"
                 tooltip="Process file"
@@ -224,7 +219,7 @@ export const Upload: React.FC<IUploadProps> = ({
             <Button
               variant={ButtonVariant.link}
               onClick={() => onDownload?.()}
-              disabled={!onDownload || !!file || !downloadable || !fileName || !fileReference}
+              disabled={!onDownload || !file || !downloadable || !fileName || !fileReference}
               className="file-name"
               tooltip={`Download ${!!fileName ? fileName : 'not available'}`}
             >

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -509,11 +509,11 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '0.25'
-          memory: 250M
+          cpus: '1'
+          memory: 2G
         reservations:
           cpus: '0.05'
-          memory: 50M
+          memory: 100M
     env_file:
       - services/net/ffmpeg/.env
     ports:

--- a/services/net/capture/Dockerfile
+++ b/services/net/capture/Dockerfile
@@ -7,10 +7,8 @@ ENV ASPNETCORE_ENVIRONMENT=Production
 
 # Switch to root for package installs
 USER 0
-# RUN dotnet tool install --global dotnet-ef
 
 WORKDIR /src
-
 COPY services/net/command services/net/command
 COPY services/net/capture services/net/capture
 COPY libs/net libs/net
@@ -23,7 +21,7 @@ RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0 as deploy
 
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+RUN apt-get update --fix-missing && apt-get -y upgrade && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends procps curl ffmpeg libc6-dev libgdiplus
 
 WORKDIR /app

--- a/services/net/ffmpeg/Dockerfile
+++ b/services/net/ffmpeg/Dockerfile
@@ -20,21 +20,15 @@ RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0 as deploy
 
+RUN apt-get update --fix-missing && apt-get -y upgrade && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends procps curl ffmpeg libc6-dev libgdiplus
+
 WORKDIR /app
 COPY --from=build /build .
 
 # This volume is the local storage for uploaded files.
 RUN mkdir /data
 VOLUME /data
-
-# [Optional] Uncomment this section to install additional OS packages.
-RUN apt-get update --fix-missing && apt-get -y upgrade && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends procps curl ffmpeg \
-      libc6-dev libgdiplus libgdiplus libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev \
-      gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
-      gstreamer1.0-libav gstreamer1.0-tools gstreamer1.0-alsa gstreamer1.0-gl gstreamer1.0-gtk3 gstreamer1.0-qt5 gstreamer1.0-pulseaudio
-      # gstreamer1.0-x
-      # For some reason gstreamer1.0-x cannot be installed.
 
 # Run container by default as user with id 1001 (default)
 USER 1001

--- a/services/net/ffmpeg/TNO.Services.FFmpeg.csproj
+++ b/services/net/ffmpeg/TNO.Services.FFmpeg.csproj
@@ -15,6 +15,9 @@
     <ProjectReference Include="..\..\..\libs\net\kafka\TNO.Kafka.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="FTTLib.dll" Version="1.1.5" />
+  </ItemGroup>
 
   <ItemGroup>
     <Content Include="*.json">


### PR DESCRIPTION
Fixing the FFmpeg Service we use to process QuickTime 10 `.mov` files.  This provides Editors a simple way to convert QuickTime files that do not play in browsers to `.mp3` and `.mp4`.

## Editor Form

The Processing button provides a way to apply the configured conversion for the selected media type.

![image](https://github.com/bcgov/tno/assets/3180256/fdf498c2-6a7a-4dea-941b-ecd5147b79b2)
