### PR TITLE
fix: #tno-2384 - fix issues with series add/search

### DIFF
--- a/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
@@ -250,8 +250,8 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ onSearch }) => 
               >
                 <MediaSection
                   displayFiltersAsDropdown={displayFiltersAsDropdown}
-                  sources={sources}
-                  mediaTypes={mediaTypes}
+                  sources={sources.filter((s) => s.isEnabled)}
+                  mediaTypes={mediaTypes.filter((s) => s.isEnabled)}
                 />
               </ExpandableRow>
             </Col>

--- a/app/subscriber/src/features/search-page/components/advanced-search/components/sections/ContributorSection.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/components/sections/ContributorSection.tsx
@@ -20,9 +20,11 @@ export const ContributorSection: React.FC<IFilterDisplayProps> = ({ displayFilte
   const filter = search.filter;
   const contributorOptions = useMemo(
     () =>
-      contributors.map((c) => {
-        return { value: c.id, label: c.name };
-      }),
+      contributors
+        .filter((c) => c.isEnabled)
+        .map((c) => {
+          return { value: c.id, label: c.name };
+        }),
     [contributors],
   );
   return (

--- a/app/subscriber/src/features/search-page/components/advanced-search/components/sections/SeriesSection.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/components/sections/SeriesSection.tsx
@@ -25,7 +25,7 @@ export const SeriesSection: React.FC<IFilterDisplayProps> = ({ displayFiltersAsD
   const seriesOptions = useMemo(
     () =>
       series
-        .filter((f) => !f.isOther)
+        .filter((f) => f.isEnabled && !f.isOther)
         .map((s) => {
           return { value: s.id, label: s.name };
         }),

--- a/libs/net/models/Areas/Services/Models/Content/ContentModel.cs
+++ b/libs/net/models/Areas/Services/Models/Content/ContentModel.cs
@@ -322,7 +322,7 @@ public class ContentModel : AuditColumnsModel
 
         if (!String.IsNullOrWhiteSpace(model.OtherSeries))
         {
-            entity.Series = new Entities.Series(model.OtherSeries, model.SourceId);
+            entity.Series = new Entities.Series(model.OtherSeries, true, model.SourceId);
         }
 
         entity.ActionsManyToMany.AddRange(model.Actions.Select(a => a.ToEntity(entity.Id)));

--- a/libs/net/models/Areas/Subscriber/Models/Series/SeriesModel.cs
+++ b/libs/net/models/Areas/Subscriber/Models/Series/SeriesModel.cs
@@ -17,6 +17,12 @@ public class SeriesModel : BaseTypeModel<int>
     /// get/set - Whether to show the topics on the content form.
     /// </summary>
     public bool UseInTopics { get; set; }
+
+    /// <summary>
+    /// get/set - Is a secondary source - generally added via use of "Other" field.
+    /// Will not be displayed in the primary Series/Source dropdown or in search filters
+    /// </summary>
+    public bool IsOther { get; set; }
     #endregion
 
     #region Constructors
@@ -33,6 +39,7 @@ public class SeriesModel : BaseTypeModel<int>
     {
         this.SourceId = entity.SourceId;
         this.UseInTopics = entity.UseInTopics;
+        this.IsOther = entity.IsOther;
     }
     #endregion
 }


### PR DESCRIPTION
- migrated content that comes in with a new Series value will be added as `isOther`
- these items are now hidden in the Subscriber Advanced Search page
  - all Series that are isOther OR isDisabled
  - all Media Sources that are set to isDisabled
  - all Contributors that are set to isDisabled