### PR TITLE
TNO-2381: Add source name when grouped by time

### DIFF
--- a/app/subscriber/src/components/content-list/ContentRow.tsx
+++ b/app/subscriber/src/components/content-list/ContentRow.tsx
@@ -41,6 +41,7 @@ export const ContentRow: React.FC<IContentRowProps> = ({
     activeFileReference,
     setActiveFileReference,
     activeStream,
+    groupBy,
   } = React.useContext(ContentListContext);
 
   return (
@@ -67,6 +68,9 @@ export const ContentRow: React.FC<IContentRowProps> = ({
         <Link to={`/view/${item.id}`} className="headline">
           {item.headline}
         </Link>
+        <Show visible={groupBy === 'time'}>
+          {item.source && <div className="source">{item.source.name}</div>}
+        </Show>
         <Show visible={viewOptions.section}>
           {item.section && <div className="section">{item.section}</div>}
           {item.page && <div className="page-number">{item.page}</div>}

--- a/app/subscriber/src/components/content-list/styled/ContentRow.tsx
+++ b/app/subscriber/src/components/content-list/styled/ContentRow.tsx
@@ -83,6 +83,10 @@ export const ContentRow = styled(Col)`
     font-family: ${(props) => props.theme.css.fPrimary};
   }
 
+  .source {
+    margin-right: 0.5rem;
+  }
+
   .page-number {
     margin-left: 0.25rem;
   }


### PR DESCRIPTION
Quick break from Evening Overview ticket..

Small ticket to display source when grouped by time. Previously source was only displayed as the group header which caused issues when organizing by time.

![image](https://github.com/bcgov/tno/assets/15724124/e8d94b0a-46fa-4865-b898-3e48c936a63e)
