### PR TITLE
accessing localhost:40001 results in a 'page not found'

### DIFF
--- a/auth/keycloak/Dockerfile
+++ b/auth/keycloak/Dockerfile
@@ -6,6 +6,4 @@ EXPOSE 8080
 COPY ./config/*.json /tmp/
 
 # ENTRYPOINT ["tail", "-f", "/dev/null"]
-ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "start-dev","--import-realm"]
-
-# ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "start-dev","--import-realm","--http-relative-path=/auth"]
+ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "start-dev","--import-realm","--http-relative-path=/auth"]

--- a/auth/keycloak/Dockerfile
+++ b/auth/keycloak/Dockerfile
@@ -6,4 +6,6 @@ EXPOSE 8080
 COPY ./config/*.json /tmp/
 
 # ENTRYPOINT ["tail", "-f", "/dev/null"]
-ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "start-dev", "--import-realm"]
+ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "start-dev","--import-realm"]
+
+# ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "start-dev","--import-realm","--http-relative-path=/auth"]


### PR DESCRIPTION
Since everyone is migrating using the existing machines, there should be no issues following the guidelines. However, I cleaned up images, docker cache and rebuilt the project. I discovered 2 problems, one of which can be fixed. 

After I executed 
`make setup` 
`make up n=database`
`make up n=keycloak`

and then accessed `localhost:40001`, 

it redirected to `http://localhost:40001/auth/`, showing a `page not found` error. 

![image](https://github.com/bcgov/tno/assets/35620699/115f0069-5ead-4136-9037-a890afc6268c)


Referring to the discussion in this thread [link](https://keycloak.discourse.group/t/keycloak-17-0-0-results-in-page-not-found-for-admin-url/13682), I modified the Docker file and then I could normally enter the Keycloak admin.