### PR TITLE
TNO-2322: Press Gallery serach inaccuracy 

### DIFF
--- a/app/editor/src/features/admin/contributors/ContributorForm.tsx
+++ b/app/editor/src/features/admin/contributors/ContributorForm.tsx
@@ -91,7 +91,12 @@ const ContributorForm: React.FC = () => {
           <div className="form-container">
             <Col className="form-inputs">
               <FormikText width={FieldSize.Large} name="name" label="Name" />
-              <FormikText width={FieldSize.Large} name="aliases" label="Aliases" />
+              <FormikText
+                width={FieldSize.Large}
+                name="aliases"
+                label="Aliases"
+                tooltip="Create a comma seperated list of values to search by. ex.) John Doe, J. Doe, Sir Doe"
+              />
 
               <FormikSelect
                 label="Source"

--- a/app/subscriber/src/components/basic-search/styled/BasicSearch.tsx
+++ b/app/subscriber/src/components/basic-search/styled/BasicSearch.tsx
@@ -42,9 +42,6 @@ export const BasicSearch = styled(Row)<{ inHeader?: boolean }>`
   @media only screen and (max-width: 900px) {
     width: '';
   }
-  @media only screen and (min-width: 900px) {
-    width: 30%;
-  }
   .icon-search {
     border: 0.5px solid ${(props) => props.theme.css.linePrimaryColor};
     border-radius: 1.5em;
@@ -112,7 +109,6 @@ export const BasicSearch = styled(Row)<{ inHeader?: boolean }>`
   /* BUTTON APPEAR ON RIGHT SIDE OF SEARCH IF SCREEN IS LESS THAN 900px */
   @media only screen and (max-width: 900px) {
     .search-button {
-      margin-left: auto;
       margin-right: 0.5em;
     }
   }

--- a/app/subscriber/src/features/press-gallery/utils/seperateAlias.ts
+++ b/app/subscriber/src/features/press-gallery/utils/seperateAlias.ts
@@ -1,8 +1,11 @@
 /**
  * @description - Seperate alias into individual strings
  * @param {string[]} alias - The alias to be seperated, may contain strings that are comma seperated or by space
- * @returns {string[]} - The alias seperated into individual strings
+ * @returns {string[]} - The alias seperated into individual strings, wrapped in double quotes to be used in the Elasticsearch query
  */
 export const seperateAlias = (alias: string[]) => {
-  return alias.map((a) => a.split(/,\s*|\s+/)).flat();
+  return alias
+    .map((a) => a.split(/,\s*/)) // Only split on comma followed by any amount of whitespace
+    .flat()
+    .map((alias) => `"${alias}"`);
 };


### PR DESCRIPTION
In this PR:

- Add tooltip so user knows how to create aliases
- Fix responsiveness of search bar in header
- Remove white space separation and only separate alias values on `,` followed by any amount of white space