### PR TITLE
comment out REACT_APP_KEYCLOAK_AUTH_SERVER_URL in subscriber app

### DIFF
--- a/tools/scripts/gen-env-files.sh
+++ b/tools/scripts/gen-env-files.sh
@@ -318,7 +318,7 @@ echo \
 CHOKIDAR_USEPOLLING=true
 WDS_SOCKET_PORT=$portNginxSubscriber
 #API_URL=http://api:80/
-REACT_APP_KEYCLOAK_AUTH_SERVER_URL=http://host.docker.internal:$portKeycloak/auth" >> ./app/subscriber/.env
+#REACT_APP_KEYCLOAK_AUTH_SERVER_URL=http://host.docker.internal:$portKeycloak/auth" >> ./app/subscriber/.env
     echo "./app/subscriber/.env created"
 fi
 


### PR DESCRIPTION
When I cleaned the .env and rebuild the project, I found that old REACT_APP_KEYCLOAK_AUTH_SERVER_URL from subscriber needs to comment out, it blocks us to get access to the subscriber page.