### PR TITLE
TNO-1944 Fix Editor report admin

### DIFF
--- a/api/net/Areas/Admin/Controllers/ReportInstanceController.cs
+++ b/api/net/Areas/Admin/Controllers/ReportInstanceController.cs
@@ -147,7 +147,7 @@ public class ReportInstanceController : ControllerBase
         var user = _userService.FindByUsername(username) ?? throw new NotAuthorizedException($"User [{username}] does not exist");
 
         instance.Status = ReportStatus.Submitted;
-        instance = _reportInstanceService.UpdateAndSave(instance, true);
+        instance = _reportInstanceService.UpdateAndSave(instance);
 
         var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.Content, instance.ReportId, instance.Id, new { })
         {

--- a/api/net/Areas/Subscriber/Controllers/ReportInstanceController.cs
+++ b/api/net/Areas/Subscriber/Controllers/ReportInstanceController.cs
@@ -244,7 +244,7 @@ public class ReportInstanceController : ControllerBase
         if (instance.OwnerId != user.Id) throw new NotAuthorizedException("Not authorized to publish this report"); // User does not own the report
 
         instance.Status = Entities.ReportStatus.Submitted;
-        instance = _reportInstanceService.UpdateAndSave(instance, true);
+        instance = _reportInstanceService.UpdateAndSave(instance);
 
         var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.Content, instance.ReportId, instance.Id, new { })
         {

--- a/app/editor/src/features/admin/reports/ReportFormInstances.tsx
+++ b/app/editor/src/features/admin/reports/ReportFormInstances.tsx
@@ -22,7 +22,7 @@ export const ReportFormInstance: React.FC = () => {
 
   React.useEffect(() => {
     findInstancesForReportId(values.id).then((instances) => {
-      setInstances(instances);
+      setInstances(instances ?? []);
     });
     // Only load the report instances when clicking on the tab.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -84,6 +84,7 @@ export const ReportFormInstance: React.FC = () => {
           onPreview: handlePreview,
         })}
         showActive={false}
+        showPaging={false}
       />
       <Modal
         headerText="Confirm Removal"

--- a/app/editor/src/features/admin/reports/components/ReportSectionContent.tsx
+++ b/app/editor/src/features/admin/reports/components/ReportSectionContent.tsx
@@ -62,6 +62,10 @@ export const ReportSectionContent = ({ index }: IReportSectionContentProps) => {
       <Col>
         <label>Options</label>
         <FormikCheckbox
+          name={`sections.${index}.settings.hideEmpty`}
+          label="Hide section if empty"
+        />
+        <FormikCheckbox
           name={`sections.${index}.settings.showHeadlines`}
           label="Show Headlines"
           tooltip="Display the story headlines in this section.  This is similar to a table of contents, but only for this section"

--- a/libs/net/dal/Services/Interfaces/IReportInstanceService.cs
+++ b/libs/net/dal/Services/Interfaces/IReportInstanceService.cs
@@ -9,8 +9,10 @@ public interface IReportInstanceService : IBaseService<ReportInstance, long>
     /// </summary>
     /// <param name="reportId"></param>
     /// <param name="ownerId"></param>
+    /// <param name="skip"></param>
+    /// <param name="take"></param>
     /// <returns></returns>
-    IEnumerable<ReportInstance> FindInstancesForReportId(int reportId, int? ownerId);
+    IEnumerable<ReportInstance> FindInstancesForReportId(int reportId, int? ownerId, int skip = 0, int take = 10);
 
 
     /// <summary>
@@ -19,12 +21,4 @@ public interface IReportInstanceService : IBaseService<ReportInstance, long>
     /// <param name="id"></param>
     /// <returns></returns>
     IEnumerable<ReportInstanceContent> GetContentForInstance(long id);
-
-    /// <summary>
-    /// Update only the instance and not the content.
-    /// </summary>
-    /// <param name="instance"></param>
-    /// <param name="instanceOnly"></param>
-    /// <returns></returns>
-    ReportInstance UpdateAndSave(ReportInstance instance, bool instanceOnly = false);
 }

--- a/libs/net/dal/Services/ReportInstanceService.cs
+++ b/libs/net/dal/Services/ReportInstanceService.cs
@@ -40,8 +40,10 @@ public class ReportInstanceService : BaseService<ReportInstance, long>, IReportI
     /// </summary>
     /// <param name="reportId"></param>
     /// <param name="ownerId"></param>
+    /// <param name="skip"></param>
+    /// <param name="take"></param>
     /// <returns></returns>
-    public IEnumerable<ReportInstance> FindInstancesForReportId(int reportId, int? ownerId)
+    public IEnumerable<ReportInstance> FindInstancesForReportId(int reportId, int? ownerId, int skip = 0, int take = 10)
     {
         var query = this.Context.ReportInstances
             .AsNoTracking()
@@ -51,7 +53,7 @@ public class ReportInstanceService : BaseService<ReportInstance, long>, IReportI
         if (ownerId.HasValue)
             query = query.Where(ri => ri.OwnerId == ownerId);
 
-        query = query.OrderByDescending(ri => ri.Id);
+        query = query.OrderByDescending(ri => ri.Id).Skip(skip).Take(take);
 
         return query.ToArray();
     }
@@ -252,27 +254,6 @@ public class ReportInstanceService : BaseService<ReportInstance, long>, IReportI
         this.Context.ResetVersion(original);
 
         return base.Update(original);
-    }
-
-    /// <summary>
-    /// Update and save the specified 'instance'
-    /// </summary>
-    /// <param name="instance"></param>
-    /// <param name="instanceOnly"></param>
-    /// <returns></returns>
-    public ReportInstance UpdateAndSave(ReportInstance instance, bool instanceOnly = false)
-    {
-        if (instanceOnly)
-        {
-            base.Update(instance);
-            this.Context.CommitTransaction();
-        }
-        else
-        {
-            base.UpdateAndSave(instance);
-        }
-
-        return instance;
     }
     #endregion
 }

--- a/openshift/kustomize/api/base/deploy.yaml
+++ b/openshift/kustomize/api/base/deploy.yaml
@@ -71,8 +71,8 @@ spec:
               mountPath: /mnt/ingest
           resources:
             limits:
-              cpu: 300m
-              memory: 750Mi
+              cpu: 500m
+              memory: 1536Mi
             requests:
               cpu: 100m
               memory: 350Mi

--- a/openshift/kustomize/api/base/statefulset.yaml
+++ b/openshift/kustomize/api/base/statefulset.yaml
@@ -87,8 +87,8 @@ spec:
               mountPath: /mnt/ingest
           resources:
             limits:
-              cpu: 300m
-              memory: 750Mi
+              cpu: 500m
+              memory: 1536Mi
             requests:
               cpu: 100m
               memory: 350Mi

--- a/openshift/kustomize/api/overlays/dev/kustomization.yaml
+++ b/openshift/kustomize/api/overlays/dev/kustomization.yaml
@@ -128,10 +128,10 @@ patches:
   #       value: 150Mi
   #     - op: replace
   #       path: /spec/template/spec/containers/0/resources/limits/cpu
-  #       value: 300m
+  #       value: 500m
   #     - op: replace
   #       path: /spec/template/spec/containers/0/resources/limits/memory
-  #       value: 300Mi
+  #       value: 1536Mi
   #     - op: replace
   #       path: /spec/triggers/1/imageChangeParams/from/name
   #       value: api:dev
@@ -150,10 +150,10 @@ patches:
         value: 350Mi
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/cpu
-        value: 300m
+        value: 500m
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 750Mi
+        value: 1536Mi
       - op: replace
         path: /spec/template/spec/containers/0/image
         value: image-registry.openshift-image-registry.svc:5000/9b301c-tools/api:dev

--- a/openshift/kustomize/api/overlays/prod/kustomization.yaml
+++ b/openshift/kustomize/api/overlays/prod/kustomization.yaml
@@ -128,10 +128,10 @@ patches:
   #       value: 150Mi
   #     - op: replace
   #       path: /spec/template/spec/containers/0/resources/limits/cpu
-  #       value: 300m
+  #       value: 500m
   #     - op: replace
   #       path: /spec/template/spec/containers/0/resources/limits/memory
-  #       value: 300Mi
+  #       value: 1536Mi
   #     - op: replace
   #       path: /spec/triggers/1/imageChangeParams/from/name
   #       value: api:prod
@@ -150,10 +150,10 @@ patches:
         value: 350Mi
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/cpu
-        value: 300m
+        value: 500m
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 750Mi
+        value: 1536Mi
       - op: replace
         path: /spec/template/spec/containers/0/image
         value: image-registry.openshift-image-registry.svc:5000/9b301c-tools/api:prod

--- a/openshift/kustomize/api/overlays/test/kustomization.yaml
+++ b/openshift/kustomize/api/overlays/test/kustomization.yaml
@@ -128,10 +128,10 @@ patches:
   #       value: 150Mi
   #     - op: replace
   #       path: /spec/template/spec/containers/0/resources/limits/cpu
-  #       value: 300m
+  #       value: 500m
   #     - op: replace
   #       path: /spec/template/spec/containers/0/resources/limits/memory
-  #       value: 300Mi
+  #       value: 1536Mi
   #     - op: replace
   #       path: /spec/triggers/1/imageChangeParams/from/name
   #       value: api:test
@@ -150,10 +150,10 @@ patches:
         value: 350Mi
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/cpu
-        value: 300m
+        value: 500m
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 750Mi
+        value: 1536Mi
       - op: replace
         path: /spec/template/spec/containers/0/image
         value: image-registry.openshift-image-registry.svc:5000/9b301c-tools/api:test

--- a/openshift/kustomize/services/build/base/reporting.yaml
+++ b/openshift/kustomize/services/build/base/reporting.yaml
@@ -1,0 +1,59 @@
+---
+# The final build image.
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: reporting-service
+  annotations:
+    description: Destination for built images.
+    created-by: jeremy.foster
+  labels:
+    name: reporting-service
+    part-of: tno
+    version: 1.0.0
+    component: reporting
+    managed-by: kustomize
+
+---
+# The build config that will be created will be named for the branch you created it for.
+kind: BuildConfig
+apiVersion: build.openshift.io/v1
+metadata:
+  name: reporting-service.dev
+  annotations:
+    description: Build image from Dockerfile in git repo.
+    created-by: jeremy.foster
+  labels:
+    name: reporting-service
+    part-of: tno
+    version: 1.0.0
+    component: reporting
+    managed-by: kustomize
+    branch: dev
+spec:
+  completionDeadlineSeconds: 1800
+  triggers:
+    - type: ImageChange
+    - type: ConfigChange
+  runPolicy: Serial
+  source:
+    git:
+      uri: https://github.com/fosol/tno.git
+      ref: tno-1944
+    contextDir: ./
+  strategy:
+    type: Docker
+    dockerStrategy:
+      imageOptimizationPolicy: SkipLayers
+      dockerfilePath: services/net/reporting/Dockerfile
+  output:
+    to:
+      kind: ImageStreamTag
+      name: reporting-service:latest
+  resources:
+    requests:
+      cpu: 20m
+      memory: 250Mi
+    limits:
+      cpu: 500m
+      memory: 2Gi

--- a/services/net/reporting/ReportingManager.cs
+++ b/services/net/reporting/ReportingManager.cs
@@ -413,10 +413,12 @@ public class ReportingManager : ServiceManager<ReportingOptions>
                 this.Logger.LogWarning($"Report [{report.Name}] {request.GenerateInstance}has malformed content. It will be generated, but may not match expectations.");
 
             // Update instance
-            instance.Subject = subject;
-            instance.Body = fullTextFormatBody;
-            instance.ContentManyToMany.AddRange(reportInstanceContents);
-            instance.ContentManyToMany.ForEach(ric => ric.InstanceId = instanceModel.Id);
+            instanceModel.Subject = subject;
+            instanceModel.Body = fullTextFormatBody;
+            instanceModel.Content = reportInstanceContents.Select((ric) => new API.Areas.Services.Models.ReportInstance.ReportInstanceContentModel(ric)
+            {
+                InstanceId = instanceModel.Id
+            });
             instanceModel = await this.Api.UpdateReportInstanceAsync(instanceModel) ?? throw new InvalidOperationException("Report instance failed to be returned by API");
         }
 


### PR DESCRIPTION
Fixing issue that was resulting in report instances not saving their content.  

> Note reports that don't include content from their prior report will be empty until new content is received.  We need a better way to inform the user of this, as it just looks broken otherwise.

## Summary

- Updated Editor app
- Fixed Reporting Service