### PR TITLE
TNO-1944 Fix reporting service

### DIFF
--- a/api/net/Areas/Admin/Controllers/ReportController.cs
+++ b/api/net/Areas/Admin/Controllers/ReportController.cs
@@ -173,7 +173,7 @@ public class ReportController : ControllerBase
     [SwaggerOperation(Tags = new[] { "Report" })]
     public IActionResult Update(ReportModel model)
     {
-        var result = _reportService.UpdateAndSave(model.ToEntity(_serializerOptions));
+        var result = _reportService.UpdateAndSave(model.ToEntity(_serializerOptions, true));
         var report = _reportService.FindById(result.Id) ?? throw new NoContentException("Report does not exist");
         return new JsonResult(new ReportModel(report, _serializerOptions));
     }

--- a/api/net/Areas/Services/Controllers/ReportInstanceController.cs
+++ b/api/net/Areas/Services/Controllers/ReportInstanceController.cs
@@ -109,7 +109,7 @@ public class ReportInstanceController : ControllerBase
     [SwaggerOperation(Tags = new[] { "ReportInstance" })]
     public async Task<IActionResult> UpdateAsync(ReportInstanceModel model)
     {
-        var result = _reportInstanceService.UpdateAndSave((Entities.ReportInstance)model) ?? throw new NoContentException();
+        var result = _reportInstanceService.UpdateAndSave((Entities.ReportInstance)model, true) ?? throw new NoContentException();
         var ownerId = result.OwnerId ?? result.Report?.OwnerId;
         if (ownerId.HasValue)
         {

--- a/api/net/Areas/Subscriber/Controllers/ReportController.cs
+++ b/api/net/Areas/Subscriber/Controllers/ReportController.cs
@@ -222,7 +222,7 @@ public class ReportController : ControllerBase
         if (updateInstances && instanceModel != null)
         {
             // Only update the first instance.
-            instance = _reportInstanceService.Update((Entities.ReportInstance)instanceModel);
+            instance = _reportInstanceService.Update((Entities.ReportInstance)instanceModel, true);
         }
         _reportInstanceService.CommitTransaction();
         var report = _reportService.FindById(result.Id) ?? throw new NoContentException("Report does not exist");
@@ -354,7 +354,7 @@ public class ReportController : ControllerBase
                 return c;
             });
             currentInstance.ContentManyToMany.AddRange(newContent);
-            currentInstance = _reportInstanceService.UpdateAndSave(currentInstance);
+            currentInstance = _reportInstanceService.UpdateAndSave(currentInstance, true);
             instances = _reportService.GetLatestInstances(id, user.Id);
             currentInstance.ContentManyToMany.Clear();
             currentInstance.ContentManyToMany.AddRange(_reportInstanceService.GetContentForInstance(currentInstance.Id));

--- a/api/net/Areas/Subscriber/Controllers/ReportInstanceController.cs
+++ b/api/net/Areas/Subscriber/Controllers/ReportInstanceController.cs
@@ -76,7 +76,7 @@ public class ReportInstanceController : ControllerBase
 
     #region Endpoints
     /// <summary>
-    /// Find content for the specified 'id'.
+    /// Find report instance for the specified 'id'.
     /// </summary>
     /// <param name="id"></param>
     /// <param name="includeContent"></param>
@@ -103,7 +103,7 @@ public class ReportInstanceController : ControllerBase
     }
 
     /// <summary>
-    /// Add content for the specified 'id'.
+    /// Add report instance for the specified 'id'.
     /// </summary>
     /// <param name="model"></param>
     /// <returns></returns>
@@ -125,7 +125,7 @@ public class ReportInstanceController : ControllerBase
     }
 
     /// <summary>
-    /// Update content for the specified 'id'.
+    /// Update report instance for the specified 'id'.
     /// </summary>
     /// <param name="model"></param>
     /// <returns></returns>
@@ -141,12 +141,12 @@ public class ReportInstanceController : ControllerBase
         var instance = _reportInstanceService.FindByKey(model.Id) ?? throw new NoContentException("Report does not exist");
         if (instance.OwnerId != user.Id) throw new NotAuthorizedException("Not authorized to update this report"); // Report is not public
         _reportInstanceService.ClearChangeTracker();
-        _reportInstanceService.UpdateAndSave((Entities.ReportInstance)model);
+        _reportInstanceService.UpdateAndSave((Entities.ReportInstance)model, true);
         return FindById(model.Id);
     }
 
     /// <summary>
-    /// Delete content for the specified 'id'.
+    /// Delete report instance for the specified 'id'.
     /// </summary>
     /// <param name="model"></param>
     /// <returns></returns>

--- a/app/editor/src/features/admin/reports/ReportFormDetails.tsx
+++ b/app/editor/src/features/admin/reports/ReportFormDetails.tsx
@@ -5,6 +5,8 @@ import React from 'react';
 import { useApp } from 'store/hooks';
 import { useUsers } from 'store/hooks/admin';
 import {
+  Button,
+  ButtonVariant,
   Col,
   FieldSize,
   FormikCheckbox,
@@ -24,7 +26,7 @@ import {
  * @returns Component.
  */
 export const ReportFormDetails: React.FC = () => {
-  const { values, setFieldValue } = useFormikContext<IReportModel>();
+  const { values, setFieldValue, setValues } = useFormikContext<IReportModel>();
   const [{ userInfo }] = useApp();
   const [{ users }, { findUsers }] = useUsers();
 
@@ -48,6 +50,27 @@ export const ReportFormDetails: React.FC = () => {
     return results;
   }, 500);
 
+  const handleReassignOwnership = React.useCallback(() => {
+    const report = {
+      ...values,
+      sections: values.sections.map((section) => ({
+        ...section,
+        filter: section.filter ? { ...section.filter, ownerId: values.ownerId } : section.filter,
+        folder: section.folder
+          ? {
+              ...section.folder,
+              ownerId: values.ownerId,
+              filter: section.folder.filter
+                ? { ...section.folder.filter, ownerId: values.ownerId }
+                : section.folder.filter,
+            }
+          : section.folder,
+      })),
+    };
+    setValues(report);
+    console.debug(report.sections);
+  }, [setValues, values]);
+
   return (
     <>
       <Col className="form-inputs">
@@ -65,23 +88,31 @@ export const ReportFormDetails: React.FC = () => {
           placeholder="Enter unique report name"
         />
         <FormikTextArea name="description" label="Description" />
-        <FormikSelect
-          name="ownerId"
-          label="Owner"
-          options={userOptions}
-          value={userOptions.find((u) => u.value === values.ownerId) || ''}
-          onChange={(e) => {
-            const option = e as OptionItem;
-            setFieldValue(
-              'values.ownerId',
-              option?.value ? parseInt(option.value.toString()) : undefined,
-            );
-          }}
-          onInputChange={(newValue) => {
-            // TODO: Does not need to fire when an option is manually selected.
-            handleFindUsers(newValue);
-          }}
-        />
+        <Row alignItems="end">
+          <FormikSelect
+            name="ownerId"
+            label="Owner"
+            options={userOptions}
+            value={userOptions.find((u) => u.value === values.ownerId) || ''}
+            width="50ch"
+            onChange={(e) => {
+              const option = e as OptionItem;
+              setFieldValue(
+                'values.ownerId',
+                option?.value ? parseInt(option.value.toString()) : undefined,
+              );
+            }}
+            onInputChange={(newValue) => {
+              // TODO: Does not need to fire when an option is manually selected.
+              handleFindUsers(newValue);
+            }}
+          />
+          <Col className="frm-in">
+            <Button variant={ButtonVariant.secondary} onClick={() => handleReassignOwnership()}>
+              Apply ownership to filters/folders in report
+            </Button>
+          </Col>
+        </Row>
         <Row alignItems="center">
           <FormikText
             width={FieldSize.Tiny}

--- a/app/editor/src/features/content/papers/PaperToolbar.tsx
+++ b/app/editor/src/features/content/papers/PaperToolbar.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { FaFileImage, FaFileInvoice } from 'react-icons/fa';
 import { FaFileArrowUp } from 'react-icons/fa6';
-import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useContent, useLookup, useLookupOptions, useNotifications, useReports } from 'store/hooks';
 import {
@@ -34,7 +33,6 @@ export interface IPaperToolbarProps {
  * @returns Component.
  */
 export const PaperToolbar: React.FC<IPaperToolbarProps> = ({ onSearch }) => {
-  const navigate = useNavigate();
   const [{ filterPaper: filter }, { storeFilterPaper }] = useContent();
   const [{ mediaTypeOptions }] = useLookupOptions();
   const [{ publishReport }] = useReports();
@@ -89,8 +87,7 @@ export const PaperToolbar: React.FC<IPaperToolbarProps> = ({ onSearch }) => {
             onClick={(e) => {
               if (frontPageImagesReportId) {
                 const route = getPreviewReportRoute(+frontPageImagesReportId);
-                if (!e.ctrlKey) navigate(route);
-                else window.open(route, '_blank');
+                window.open(route, '_blank');
               } else
                 toast.error(
                   `Configuration setting "${Settings.FrontPageImagesReport}" is missing.`,
@@ -103,8 +100,7 @@ export const PaperToolbar: React.FC<IPaperToolbarProps> = ({ onSearch }) => {
             onClick={(e) => {
               if (morningReportId) {
                 const route = getPreviewReportRoute(+morningReportId);
-                if (!e.ctrlKey) navigate(route);
-                else window.open(route, '_blank');
+                window.open(route, '_blank');
               } else toast.error(`Configuration setting "${Settings.MorningReport}" is missing.`);
             }}
           />

--- a/app/editor/src/store/hooks/editor/useReportInstances.ts
+++ b/app/editor/src/store/hooks/editor/useReportInstances.ts
@@ -3,7 +3,10 @@ import { useAjaxWrapper } from 'store/hooks';
 import { IReportResultModel, useApiEditorReportInstances } from 'tno-core';
 
 interface IReportInstanceController {
-  viewReportInstance: (reportInstanceId: number) => Promise<IReportResultModel>;
+  viewReportInstance: (
+    reportInstanceId: number,
+    regenerate?: boolean,
+  ) => Promise<IReportResultModel>;
 }
 
 export const useReportInstances = (): [IReportInstanceController] => {
@@ -12,9 +15,9 @@ export const useReportInstances = (): [IReportInstanceController] => {
 
   const controller = React.useMemo(
     () => ({
-      viewReportInstance: async (reportInstanceId: number) => {
+      viewReportInstance: async (reportInstanceId: number, regenerate: boolean = false) => {
         const response = await dispatch<IReportResultModel>('view-report-instance', () =>
-          api.viewReportInstance(reportInstanceId),
+          api.viewReportInstance(reportInstanceId, regenerate),
         );
         return response.data;
       },

--- a/libs/net/dal/Extensions/JsonDocumentExtensions.cs
+++ b/libs/net/dal/Extensions/JsonDocumentExtensions.cs
@@ -58,7 +58,7 @@ public static class JsonDocumentExtensions
         var json = JsonNode.Parse(query.ToJson())?.AsObject();
         if (json == null || previousInstancePublishedOn == null) return query;
 
-        var jIncludeOnlyLatestPosted = JsonNode.Parse($"{{ \"range\": {{ \"postedOn\": {{ \"gte\": \"{previousInstancePublishedOn.Value.ToLocalTime():yyyy-MM-dd}\", \"time_zone\": \"US/Pacific\" }} }} }}");
+        var jIncludeOnlyLatestPosted = JsonNode.Parse($"{{ \"range\": {{ \"postedOn\": {{ \"gte\": \"{previousInstancePublishedOn.Value.ToLocalTime():yyyy-MM-ddTHH:mm:ss}\", \"time_zone\": \"US/Pacific\" }} }} }}");
         if (json.TryGetPropertyValue("query", out JsonNode? jQuery))
         {
             if (jQuery?.AsObject().TryGetPropertyValue("bool", out JsonNode? jQueryBool) == true)

--- a/libs/net/dal/Services/Interfaces/IReportInstanceService.cs
+++ b/libs/net/dal/Services/Interfaces/IReportInstanceService.cs
@@ -21,4 +21,20 @@ public interface IReportInstanceService : IBaseService<ReportInstance, long>
     /// <param name="id"></param>
     /// <returns></returns>
     IEnumerable<ReportInstanceContent> GetContentForInstance(long id);
+
+    /// <summary>
+    /// Update the report instance in the context, but do not save to the database yet.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <param name="updateChildren"></param>
+    /// <returns></returns>
+    ReportInstance Update(ReportInstance entity, bool updateChildren = false);
+
+    /// <summary>
+    /// Update the report instance in the context, but do not save to the database yet.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <param name="updateChildren"></param>
+    /// <returns></returns>
+    ReportInstance UpdateAndSave(ReportInstance entity, bool updateChildren = false);
 }

--- a/libs/net/models/Areas/Admin/Report/ReportSectionModel.cs
+++ b/libs/net/models/Areas/Admin/Report/ReportSectionModel.cs
@@ -122,6 +122,8 @@ public class ReportSectionModel : BaseTypeWithAuditColumnsModel<int>
             IsEnabled = model.IsEnabled,
             SortOrder = model.SortOrder,
             Settings = JsonDocument.Parse(JsonSerializer.Serialize(model.Settings)),
+            Filter = model.Filter != null ? (Entities.Filter)model.Filter : null,
+            Folder = model.Folder != null ? (Entities.Folder)model.Folder : null,
             Version = model.Version ?? 0
         };
 


### PR DESCRIPTION
Several bug fixes related to reports.  Administrators can now reassign ownership of a report and all its filters and folders to a new user.  Subscribers will now only be presented with the 'Strat next report' button when the current report has already been sent out.

## Summary 

- Updated Editor app
- Updated Subscriber app
- Updated API
- Updated Reporting Service

## Editor Report Admin

![image](https://github.com/bcgov/tno/assets/3180256/5ef36227-da7c-4994-af72-e44337364dbc)

## Subscriber My Reports

![image](https://github.com/bcgov/tno/assets/3180256/e05676cd-40f2-4ed8-a0c7-b8a666253fdb)
