### PR TITLE
TNO-2406 Keep HTML tags retrieving data

### DIFF
--- a/services/net/filemonitor/FilemonitorAction.cs
+++ b/services/net/filemonitor/FilemonitorAction.cs
@@ -361,7 +361,7 @@ public class FileMonitorAction : IngestAction<FileMonitorOptions>
                 try
                 {
                     XmlNodeList nodeList = story.GetElementsByTagName(value);
-                    result = nodeList is not null && nodeList.Count > 0 ? nodeList[0]!.InnerText : "";
+                    result = nodeList is not null && nodeList.Count > 0 ? nodeList[0]!.InnerXml : "";
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
The InnerText property was striping the HTML tags.
The InnerXml returns a string without stripping the tags.