### PR TITLE
findUsers by keyword instead of Username. #TNO-2401

### DIFF
--- a/app/editor/src/features/admin/reports/ReportFormDetails.tsx
+++ b/app/editor/src/features/admin/reports/ReportFormDetails.tsx
@@ -45,7 +45,7 @@ export const ReportFormDetails: React.FC = () => {
   }, [userInfo?.id]);
 
   const handleFindUsers = debounce(async (text: string) => {
-    const results = await findUsers({ quantity: 50, username: text }, true);
+    const results = await findUsers({ quantity: 50, keyword: text }, true);
     setUserOptions(getUserOptions(results.items));
     return results;
   }, 500);


### PR DESCRIPTION
To prevent confusion in the owner dropdown results, we search for users across multiple fields related to the user's name.