### PR TITLE
Tno 2440 fix subscriber report panel width issue

### DIFF
--- a/app/subscriber/src/features/my-reports/styled/MyReports.tsx
+++ b/app/subscriber/src/features/my-reports/styled/MyReports.tsx
@@ -183,6 +183,7 @@ export const MyReports = styled.div`
   }
 
   .report-preview {
+    min-width: 0;
     .report-title {
       h2 {
         margin: 0.5rem;

--- a/app/subscriber/src/features/my-reports/styled/MyReports.tsx
+++ b/app/subscriber/src/features/my-reports/styled/MyReports.tsx
@@ -183,7 +183,7 @@ export const MyReports = styled.div`
   }
 
   .report-preview {
-    min-width: 0;
+    min-width: min-content;
     .report-title {
       h2 {
         margin: 0.5rem;


### PR DESCRIPTION
![image](https://github.com/bcgov/tno/assets/35620699/9a777a72-f5b6-4e88-a9fe-125a5a6745c6)
This page inherited min-width: fit-content from the template, set it to min-content, and fixed the issue.

