### PR TITLE
TNO-2479 Admin paper sources

### DIFF
--- a/app/editor/src/features/admin/sources/SourceDetails.tsx
+++ b/app/editor/src/features/admin/sources/SourceDetails.tsx
@@ -124,6 +124,7 @@ const SourceDetails: React.FC<ISourceDetailsProps> = () => {
       <Col>
         <FormikCheckbox label="Enabled" name="isEnabled" />
         <FormikCheckbox label="Use in Topics" name="useInTopics" />
+        <FormikCheckbox label="Default filter for papers" name="configuration.isDailyPaper" />
         <FormikCheckbox label="Automatically transcribe when saved" name="autoTranscribe" />
         <FormikCheckbox label="Disable transcript requests" name="disableTranscribe" />
       </Col>

--- a/app/editor/src/features/admin/sources/SourceList.tsx
+++ b/app/editor/src/features/admin/sources/SourceList.tsx
@@ -91,7 +91,6 @@ const SourceList: React.FC<ISourceListProps> = (props) => {
         data={items}
         columns={columns}
         showSort={true}
-        onRowClick={(row) => navigate(`${row.original.id}`)}
         pagingEnabled={false}
       />
     </styled.SourceList>

--- a/app/editor/src/features/admin/sources/constants/columns.tsx
+++ b/app/editor/src/features/admin/sources/constants/columns.tsx
@@ -1,23 +1,21 @@
-import { CellCheckbox, CellEllipsis, ISourceModel, ITableHookColumn } from 'tno-core';
+import { CellCheckbox, CellEllipsis, ISourceModel, ITableHookColumn, Link } from 'tno-core';
 
 export const columns: ITableHookColumn<ISourceModel>[] = [
   {
     label: 'Name',
     accessor: 'name',
     width: 3,
-    cell: (cell) => <CellEllipsis>{cell.original.name}</CellEllipsis>,
+    cell: (cell) => (
+      <Link to={`${cell.original.id}`}>
+        <CellEllipsis>{cell.original.name}</CellEllipsis>
+      </Link>
+    ),
   },
   {
     label: 'Code',
     accessor: 'code',
     width: 2,
     cell: (cell) => <CellEllipsis>{cell.original.code}</CellEllipsis>,
-  },
-  {
-    label: 'Description',
-    accessor: 'description',
-    width: 5,
-    cell: (cell) => <CellEllipsis>{cell.original.description}</CellEllipsis>,
   },
   {
     label: 'Order',
@@ -32,6 +30,13 @@ export const columns: ITableHookColumn<ISourceModel>[] = [
     width: 1,
     hAlign: 'center',
     cell: (cell) => <CellCheckbox checked={cell.original.useInTopics} />,
+  },
+  {
+    label: 'Paper',
+    accessor: 'configuration.isDailyPaper',
+    width: 1,
+    hAlign: 'center',
+    cell: (cell) => <CellCheckbox checked={cell.original.configuration.isDailyPaper} />,
   },
   {
     label: 'Enabled',

--- a/app/editor/src/features/content/papers/Papers.tsx
+++ b/app/editor/src/features/content/papers/Papers.tsx
@@ -3,7 +3,7 @@ import { NavigateOptions, useTab } from 'components/tab-control';
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
-import { useApiHub, useContent, useLocalStorage, useLookup, useSettings } from 'store/hooks';
+import { useApiHub, useContent, useLocalStorage, useSettings } from 'store/hooks';
 import { IContentSearchResult, storeContentFilterAdvanced } from 'store/slices';
 import { useCastContentToSearchResult } from 'store/slices/content/hooks/useCastContentToSearchResult';
 import {
@@ -28,7 +28,7 @@ import { defaultPage } from '../list-view/constants';
 import { queryToFilter, queryToFilterAdvanced } from '../list-view/utils';
 import { ReportActions } from './components';
 import { defaultPaperFilter, defaultTotals } from './constants';
-import { useColumns } from './hooks';
+import { useColumns, usePaperSources } from './hooks';
 import { ITotalsInfo } from './interfaces';
 import { PaperToolbar } from './PaperToolbar';
 import * as styled from './styled';
@@ -46,7 +46,7 @@ const Papers: React.FC<IPapersProps> = (props) => {
     { filterPaper: filter, filterPaperAdvanced: filterAdvanced },
     { findContentWithElasticsearch, storeFilterPaper, updateContent: updateStatus, getContent },
   ] = useContent();
-  const [{ sources }] = useLookup();
+  const paperSources = usePaperSources();
   const { navigate } = useTab();
   const hub = useApiHub();
   const toFilter = useElasticsearch();
@@ -194,12 +194,12 @@ const Papers: React.FC<IPapersProps> = (props) => {
   React.useEffect(() => {
     // Extract query string values and place them into redux store.
     if (!window.location.search) {
-      replaceQueryParams(defaultPaperFilter(sources), { includeEmpty: false });
+      replaceQueryParams(defaultPaperFilter(paperSources), { includeEmpty: false });
     }
     storeFilterPaper({
       ...queryToFilter(
         {
-          ...defaultPaperFilter(sources),
+          ...defaultPaperFilter(paperSources),
         },
         window.location.search,
       ),

--- a/app/editor/src/features/content/papers/components/ContentFilter.tsx
+++ b/app/editor/src/features/content/papers/components/ContentFilter.tsx
@@ -13,7 +13,7 @@ import {
   ToggleGroup,
 } from 'tno-core';
 
-import { defaultSources } from '../constants';
+import { usePaperSources } from '../hooks';
 import * as styled from './styled';
 
 export interface IContentFilter {
@@ -29,7 +29,8 @@ export interface IContentFilter {
  * @returns Component.
  */
 export const ContentFilter: React.FC<IContentFilter> = ({ onFilterChange, filter }) => {
-  const [{ mediaTypeOptions, sourceOptions, sources }] = useLookupOptions();
+  const [{ mediaTypeOptions, sourceOptions }] = useLookupOptions();
+  const paperSources = usePaperSources();
 
   return (
     <styled.ContentFilter label="FILTER CONTENT" icon={<FaFilter />}>
@@ -140,7 +141,7 @@ export const ContentFilter: React.FC<IContentFilter> = ({ onFilterChange, filter
               onClick={() => {
                 onFilterChange({
                   ...filter,
-                  sourceIds: defaultSources(sources).map((s) => s.id),
+                  sourceIds: paperSources.map((s) => s.id),
                 });
               }}
             >

--- a/app/editor/src/features/content/papers/constants/defaultPaperFilter.ts
+++ b/app/editor/src/features/content/papers/constants/defaultPaperFilter.ts
@@ -2,8 +2,6 @@ import { IContentListFilter } from 'features/content/interfaces';
 import { defaultPage } from 'features/content/list-view/constants';
 import { ContentTypeName, ISourceModel } from 'tno-core';
 
-import { defaultSources } from '.';
-
 /**
  * Creates a default paper filter.
  * @param sources An array of sources.
@@ -20,7 +18,7 @@ export const defaultPaperFilter = (sources: ISourceModel[] = []): IContentListFi
     otherSource: '',
     mediaTypeIds: [],
     excludeSourceIds: [],
-    sourceIds: defaultSources(sources).map((s) => s.id),
+    sourceIds: sources.map((s) => s.id),
     ownerId: 0,
     userId: '',
     timeFrame: 0,

--- a/app/editor/src/features/content/papers/constants/defaultSources.ts
+++ b/app/editor/src/features/content/papers/constants/defaultSources.ts
@@ -1,5 +1,0 @@
-import { ISourceModel } from 'tno-core';
-
-/** Filter and return the default sources. */
-export const defaultSources = (sources: ISourceModel[]) =>
-  sources?.filter((source) => ['GLOBE', 'POST', 'PROVINCE', 'TC', 'SUN'].includes(source.code));

--- a/app/editor/src/features/content/papers/constants/index.ts
+++ b/app/editor/src/features/content/papers/constants/index.ts
@@ -1,4 +1,3 @@
 export * from './defaultPaperFilter';
-export * from './defaultSources';
 export * from './defaultTotals';
 export * from './PublishedStatuses';

--- a/app/editor/src/features/content/papers/hooks/index.ts
+++ b/app/editor/src/features/content/papers/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useActionFilters';
 export * from './useColumns';
+export * from './usePaperSources';

--- a/app/editor/src/features/content/papers/hooks/usePaperSources.ts
+++ b/app/editor/src/features/content/papers/hooks/usePaperSources.ts
@@ -1,0 +1,8 @@
+import { useLookupOptions } from 'store/hooks';
+
+/** Filter and return the default sources. */
+export const usePaperSources = () => {
+  const [{ sources }] = useLookupOptions();
+
+  return sources?.filter((source) => !!source.configuration.isDailyPaper);
+};

--- a/libs/net/models/Areas/Admin/Source/SourceModel.cs
+++ b/libs/net/models/Areas/Admin/Source/SourceModel.cs
@@ -1,7 +1,5 @@
-using TNO.API.Models;
 using System.Text.Json;
-using TNO.Entities;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using TNO.API.Models;
 
 namespace TNO.API.Areas.Admin.Models.Source;
 


### PR DESCRIPTION
Admins can now configure which sources are used in the default Papers filter.

## Admin Sources

![image](https://github.com/bcgov/tno/assets/3180256/0371057b-7b04-46ce-bc65-f5effb16dc6b)

## Editor Papers

![image](https://github.com/bcgov/tno/assets/3180256/01186706-dcd1-4ded-ab07-11c509756f53)
