### PR TITLE
TNO-2420: Add Transcript to Advanced section (Editor)

### DIFF
--- a/app/editor/src/features/content/constants/AdvancedSearchKeys.ts
+++ b/app/editor/src/features/content/constants/AdvancedSearchKeys.ts
@@ -13,4 +13,5 @@ export enum AdvancedSearchKeys {
   PublishedOn = 'publishedOn',
   CreatedOn = 'createdOn',
   UpdatedOn = 'updatedOn',
+  Body = 'body',
 }

--- a/app/editor/src/features/content/constants/advancedSearchOptions.ts
+++ b/app/editor/src/features/content/constants/advancedSearchOptions.ts
@@ -7,7 +7,7 @@ export const advancedSearchOptions = [
   new OptionItem('Headline', AdvancedSearchKeys.Headline),
   new OptionItem('Summary', AdvancedSearchKeys.Summary),
   new OptionItem('Story', AdvancedSearchKeys.Story),
-  new OptionItem('Transcript', AdvancedSearchKeys.Story),
+  new OptionItem('Transcript', AdvancedSearchKeys.Body),
   new OptionItem('Source', AdvancedSearchKeys.Source),
   new OptionItem('Byline', AdvancedSearchKeys.Byline),
   new OptionItem('Section', AdvancedSearchKeys.Section),


### PR DESCRIPTION
This ticket was to add Transcript, Byline, and Summary. All three were already present; however, Transcript was pointed to `story` instead of `body`