### PR TITLE
TNO 2248 new tab for reports preview

### DIFF
--- a/app/editor/src/features/admin/reports/ReportFormPreview.tsx
+++ b/app/editor/src/features/admin/reports/ReportFormPreview.tsx
@@ -13,7 +13,7 @@ export interface IReportFormPreviewProps {}
  * @returns Component.
  */
 export const ReportFormPreview: React.FC<IReportFormPreviewProps> = () => {
-  const { values, preview, setPreview } = useReportTemplateContext();
+  const { values, preview, setPreview, openPreview } = useReportTemplateContext();
   const [, { sendReport, previewReport }] = useReports();
 
   const [sendTo, setSendTo] = React.useState('');
@@ -48,6 +48,9 @@ export const ReportFormPreview: React.FC<IReportFormPreviewProps> = () => {
     },
     [previewReport, setPreview],
   );
+  React.useEffect(() => {
+    preview && openPreview();
+  }, [preview, openPreview]);
 
   return (
     <>
@@ -83,16 +86,6 @@ export const ReportFormPreview: React.FC<IReportFormPreviewProps> = () => {
           </Col>
         )}
       </Row>
-      <Col className="preview-report">
-        <div
-          className="preview-subject"
-          dangerouslySetInnerHTML={{ __html: preview?.subject ?? '' }}
-        ></div>
-        <div
-          className="preview-body"
-          dangerouslySetInnerHTML={{ __html: preview?.body ?? '' }}
-        ></div>
-      </Col>
     </>
   );
 };

--- a/app/editor/src/features/admin/reports/ReportTemplateContext.tsx
+++ b/app/editor/src/features/admin/reports/ReportTemplateContext.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { IReportModel, IReportResultModel } from 'tno-core';
 
 import { defaultReport } from './constants';
+import { openPreviewInNewTab } from './utils/openPreviewInNewTab';
 
 /*******************************************************************
  * All related report context code is in a single file because it will never be used separately.
@@ -20,6 +21,8 @@ export interface IReportTemplateContext {
   values: IReportModel;
   /** Formik setFieldValue function */
   setFieldValue: (field: string, value: any, shouldValidate?: boolean | undefined) => void;
+  /** Open the preview in a new tab. */
+  openPreview: () => void;
 }
 
 /**
@@ -30,6 +33,7 @@ export const ReportTemplateContext = React.createContext<IReportTemplateContext>
   setPreview: (value: React.SetStateAction<IReportResultModel | undefined>) => {},
   values: defaultReport,
   setFieldValue: (field: string, value: any, shouldValidate?: boolean | undefined) => {},
+  openPreview: () => {},
 });
 
 /**
@@ -63,8 +67,12 @@ export const ReportTemplateContextProvider: React.FC<IReportTemplateContextProvi
 
   const [preview, setPreview] = React.useState<IReportResultModel | undefined>(value);
 
+  const openPreview = () => preview && openPreviewInNewTab(preview);
+
   return (
-    <ReportTemplateContext.Provider value={{ preview, setPreview, values, setFieldValue }}>
+    <ReportTemplateContext.Provider
+      value={{ preview, setPreview, values, setFieldValue, openPreview }}
+    >
       {children}
     </ReportTemplateContext.Provider>
   );

--- a/app/editor/src/features/admin/reports/utils/openPreviewInNewTab.ts
+++ b/app/editor/src/features/admin/reports/utils/openPreviewInNewTab.ts
@@ -2,16 +2,54 @@ import { IReportResultModel } from 'tno-core';
 
 export const openPreviewInNewTab = (previewContent: IReportResultModel) => {
   const previewHTML = `
-      <html>
-      <head>
-        <title>Report Preview</title>
-      </head>
-      <body>
-        <h1> ${previewContent.subject}</h1>
+    <html>
+    <head>
+      <title>Report Preview: ${previewContent.subject}</title>
+      <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .header { 
+          background-color: #f3f3f3; 
+          padding: 10px; 
+          text-align: center; 
+          position: relative;
+        }
+        .content { 
+          margin-top: 20px;
+          position: relative;
+        }
+        .close-btn {
+          display: inline-block; 
+          padding: 5px 15px; 
+          background-color:transparent; 
+          color: white; 
+          text-decoration: none; 
+          color: #007bff;
+          border: 2px solid #007bff;
+          border-radius:5px; 
+          cursor: pointer;
+          position: absolute;
+          right: 10px;
+          font-size: 16px;
+        }        
+        .close-btn-top {
+          top: 10px;
+        }
+        .close-btn:hover {
+          background-color: #0056b3;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="header">
+        <h2>Report Preview: ${previewContent.subject}</h2>
+        <button onclick="window.close();" class="close-btn close-btn-top">Close</button>
+      </div>
+      <div class="content">
         <div>${previewContent.body}</div>
-      </body>
-      </html>
-    `;
+      </div>
+    </body>
+    </html>
+  `;
 
   const blob = new Blob([previewHTML], { type: 'text/html' });
   const url = URL.createObjectURL(blob);

--- a/app/editor/src/features/admin/reports/utils/openPreviewInNewTab.ts
+++ b/app/editor/src/features/admin/reports/utils/openPreviewInNewTab.ts
@@ -1,0 +1,19 @@
+import { IReportResultModel } from 'tno-core';
+
+export const openPreviewInNewTab = (previewContent: IReportResultModel) => {
+  const previewHTML = `
+      <html>
+      <head>
+        <title>Report Preview</title>
+      </head>
+      <body>
+        <h1>Preview Subject: ${previewContent.subject}</h1>
+        <div>${previewContent.body}</div>
+      </body>
+      </html>
+    `;
+
+  const blob = new Blob([previewHTML], { type: 'text/html' });
+  const url = URL.createObjectURL(blob);
+  window.open(url, '_blank');
+};

--- a/app/editor/src/features/admin/reports/utils/openPreviewInNewTab.ts
+++ b/app/editor/src/features/admin/reports/utils/openPreviewInNewTab.ts
@@ -15,5 +15,9 @@ export const openPreviewInNewTab = (previewContent: IReportResultModel) => {
 
   const blob = new Blob([previewHTML], { type: 'text/html' });
   const url = URL.createObjectURL(blob);
-  window.open(url, '_blank');
+  const windowName = 'ReportPreviewWindow';
+  const previewWindow = window.open(url, windowName);
+  if (previewWindow) {
+    previewWindow.focus();
+  }
 };

--- a/app/editor/src/features/admin/reports/utils/openPreviewInNewTab.ts
+++ b/app/editor/src/features/admin/reports/utils/openPreviewInNewTab.ts
@@ -7,7 +7,7 @@ export const openPreviewInNewTab = (previewContent: IReportResultModel) => {
         <title>Report Preview</title>
       </head>
       <body>
-        <h1>Preview Subject: ${previewContent.subject}</h1>
+        <h1> ${previewContent.subject}</h1>
         <div>${previewContent.body}</div>
       </body>
       </html>


### PR DESCRIPTION
In editor | admin | report

To create a new tab after clicking "generate preview" to display the report without any parent styles.

