### PR TITLE
TNO-2404 Fix papers sort

### DIFF
--- a/app/editor/src/features/content/papers/Papers.tsx
+++ b/app/editor/src/features/content/papers/Papers.tsx
@@ -27,11 +27,12 @@ import { IContentListAdvancedFilter, IContentListFilter } from '../interfaces';
 import { defaultPage } from '../list-view/constants';
 import { queryToFilter, queryToFilterAdvanced } from '../list-view/utils';
 import { ReportActions } from './components';
-import { defaultPaperFilter, defaultTotals } from './constants';
-import { useColumns, usePaperSources } from './hooks';
+import { defaultPaperFilter, defaultSort, defaultTotals } from './constants';
+import { useColumns, usePaperSources, useSortContent } from './hooks';
 import { ITotalsInfo } from './interfaces';
 import { PaperToolbar } from './PaperToolbar';
 import * as styled from './styled';
+import { calcTotals } from './utils';
 
 export interface IPapersProps extends React.HTMLAttributes<HTMLDivElement> {}
 
@@ -52,6 +53,7 @@ const Papers: React.FC<IPapersProps> = (props) => {
   const toFilter = useElasticsearch();
   const castContentToSearchResult = useCastContentToSearchResult();
   const { isReady: settingsReady } = useSettings(true);
+  const sortContent = useSortContent();
 
   // This configures the shared storage between this list and any content tabs
   // that are opened.  Mainly used for navigation in the tab
@@ -66,36 +68,6 @@ const Papers: React.FC<IPapersProps> = (props) => {
   const [totals, setTotals] = React.useState<ITotalsInfo>(defaultTotals);
 
   const selectedIds = selected.map((i) => i.id.toString());
-
-  const calcTotals = React.useCallback(
-    (items: IContentSearchResult[], filter: IContentListFilter) => {
-      const topStories = items.filter((i) => i.isTopStory).length;
-      const commentary = items.filter((i) => i.isCommentary).length;
-      const featuredStories = items.filter((i) => i.isFeaturedStory).length;
-      const published = items.filter((i) =>
-        [ContentStatusName.Publish, ContentStatusName.Published].includes(i.status),
-      ).length;
-      if (
-        !filter.topStory &&
-        !filter.commentary &&
-        !filter.featuredStory &&
-        !filter.onlyPublished
-      ) {
-        setTotals((totals) => ({
-          ...totals,
-          topStories,
-          commentary,
-          featuredStories,
-          published,
-        }));
-      }
-      if (filter.topStory) setTotals((totals) => ({ ...totals, topStories }));
-      if (filter.commentary) setTotals((totals) => ({ ...totals, commentary }));
-      if (filter.featuredStory) setTotals((totals) => ({ ...totals, featuredStories }));
-      if (filter.onlyPublished) setTotals((totals) => ({ ...totals, published }));
-    },
-    [],
-  );
 
   hub.useHubEffect(MessageTargetName.ContentUpdated, (message) => {
     getContent(message.id)
@@ -126,7 +98,7 @@ const Papers: React.FC<IPapersProps> = (props) => {
                   : true,
               );
             }
-            calcTotals(newPage.items, filter);
+            setTotals((values) => calcTotals(newPage.items, filter, values));
             return newPage;
           });
         }
@@ -167,10 +139,17 @@ const Papers: React.FC<IPapersProps> = (props) => {
     async (filter: IContentListFilter & Partial<IContentListAdvancedFilter>) => {
       try {
         setIsLoading(true);
-        const results = await findContentWithElasticsearch(toFilter(filter), true);
+        const results = await findContentWithElasticsearch(
+          toFilter({
+            ...filter,
+          }),
+          true,
+        );
         const items = results.hits.hits
           .filter((h) => !!h._source)
-          .map((h) => castContentToSearchResult(h._source! as IContentModel));
+          .map((h) => h._source! as IContentModel)
+          .sort(sortContent(filter.sort))
+          .map((c) => castContentToSearchResult(c));
         const page = new Page(
           1,
           filter.pageSize,
@@ -178,7 +157,7 @@ const Papers: React.FC<IPapersProps> = (props) => {
           (results.hits?.total as SearchTotalHits).value,
         );
         setCurrentResultsPage(page);
-        calcTotals(page.items, filter);
+        setTotals((values) => calcTotals(page.items, filter, values));
         return page;
       } catch (error) {
         throw error;
@@ -186,7 +165,7 @@ const Papers: React.FC<IPapersProps> = (props) => {
         setIsLoading(false);
       }
     },
-    [calcTotals, castContentToSearchResult, findContentWithElasticsearch, toFilter],
+    [castContentToSearchResult, findContentWithElasticsearch, toFilter, sortContent],
   );
 
   const columns = useColumns({ fetch, onClickUse: handleClickUse });
@@ -253,7 +232,7 @@ const Papers: React.FC<IPapersProps> = (props) => {
   const handleChangeSort = React.useCallback(
     (sort: ITableSort<IContentSearchResult>[]) => {
       const sorts = sort.filter((s) => s.isSorted).map((s) => ({ id: s.id, desc: s.isSortedDesc }));
-      storeFilterPaper({ ...filter, sort: sorts });
+      storeFilterPaper({ ...filter, sort: sorts.length ? sorts : defaultSort });
     },
     [filter, storeFilterPaper],
   );

--- a/app/editor/src/features/content/papers/constants/defaultPaperFilter.ts
+++ b/app/editor/src/features/content/papers/constants/defaultPaperFilter.ts
@@ -2,6 +2,8 @@ import { IContentListFilter } from 'features/content/interfaces';
 import { defaultPage } from 'features/content/list-view/constants';
 import { ContentTypeName, ISourceModel } from 'tno-core';
 
+import { defaultSort } from './defaultSort';
+
 /**
  * Creates a default paper filter.
  * @param sources An array of sources.
@@ -25,6 +27,6 @@ export const defaultPaperFilter = (sources: ISourceModel[] = []): IContentListFi
     commentary: false,
     topStory: false,
     featuredStory: false,
-    sort: [],
+    sort: defaultSort,
   };
 };

--- a/app/editor/src/features/content/papers/constants/defaultSort.ts
+++ b/app/editor/src/features/content/papers/constants/defaultSort.ts
@@ -1,0 +1,7 @@
+import { ISortBy } from 'features/interfaces';
+
+export const defaultSort: ISortBy[] = [
+  { id: 'source.sortOrder' },
+  { id: 'otherSource' },
+  { id: 'page' },
+];

--- a/app/editor/src/features/content/papers/constants/index.ts
+++ b/app/editor/src/features/content/papers/constants/index.ts
@@ -1,3 +1,4 @@
 export * from './defaultPaperFilter';
+export * from './defaultSort';
 export * from './defaultTotals';
 export * from './PublishedStatuses';

--- a/app/editor/src/features/content/papers/hooks/index.ts
+++ b/app/editor/src/features/content/papers/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useActionFilters';
 export * from './useColumns';
 export * from './usePaperSources';
+export * from './useSortContent';

--- a/app/editor/src/features/content/papers/hooks/useSortContent.ts
+++ b/app/editor/src/features/content/papers/hooks/useSortContent.ts
@@ -1,0 +1,36 @@
+import { ISortBy } from 'features/interfaces';
+import { getIn } from 'formik';
+import { useLookup } from 'store/hooks';
+import { IContentModel } from 'tno-core';
+
+import { defaultSort } from '../constants';
+
+/**
+ * Provides a function to sort content.
+ * Handles issue where source.sortOrder is different that what is indexed.
+ * @returns Function to sort content.
+ */
+export const useSortContent = () => {
+  const [{ sources }] = useLookup();
+
+  return (sort: ISortBy[] = defaultSort) =>
+    (a: IContentModel, b: IContentModel) => {
+      for (var index in sort) {
+        const sortBy = sort[index];
+        let value1 = getIn(a, sortBy.id) ?? '';
+        let value2 = getIn(b, sortBy.id) ?? '';
+
+        if (sortBy.id.startsWith('source.')) {
+          const source1 = sources.find((s) => s.id === a.sourceId);
+          const source2 = sources.find((s) => s.id === b.sourceId);
+          value1 = getIn(source1, sortBy.id.replace('source.', ''));
+          value2 = getIn(source2, sortBy.id.replace('source.', ''));
+        }
+
+        if (value1 === value2) continue; // Check the next sort by.
+        return (value1 > value2 ? 1 : -1) * (sortBy.desc ? -1 : 1);
+      }
+
+      return 0;
+    };
+};

--- a/app/editor/src/features/content/papers/utils/calcTotals.ts
+++ b/app/editor/src/features/content/papers/utils/calcTotals.ts
@@ -1,0 +1,39 @@
+import { IContentListFilter } from 'features/content/interfaces';
+import { IContentSearchResult } from 'store/slices';
+import { ContentStatusName } from 'tno-core';
+
+import { ITotalsInfo } from '../interfaces';
+
+/**
+ * Calculates the new totals based on the search results and filter.
+ * @param items An array of search results.
+ * @param filter The filter currently applied to the search.
+ * @param values The current total values.
+ * @returns New total values.
+ */
+export const calcTotals = (
+  items: IContentSearchResult[],
+  filter: IContentListFilter,
+  values: ITotalsInfo,
+) => {
+  const topStories = items.filter((i) => i.isTopStory).length;
+  const commentary = items.filter((i) => i.isCommentary).length;
+  const featuredStories = items.filter((i) => i.isFeaturedStory).length;
+  const published = items.filter((i) =>
+    [ContentStatusName.Publish, ContentStatusName.Published].includes(i.status),
+  ).length;
+  if (!filter.topStory && !filter.commentary && !filter.featuredStory && !filter.onlyPublished) {
+    return {
+      ...values,
+      topStories,
+      commentary,
+      featuredStories,
+      published,
+    };
+  }
+  if (filter.topStory) return { ...values, topStories };
+  if (filter.commentary) return { ...values, commentary };
+  if (filter.featuredStory) return { ...values, featuredStories };
+  if (filter.onlyPublished) return { ...values, published };
+  return values;
+};

--- a/app/editor/src/features/content/papers/utils/index.ts
+++ b/app/editor/src/features/content/papers/utils/index.ts
@@ -1,1 +1,3 @@
+export * from './calcTotals';
 export * from './changeStatus';
+export * from './sortContent';

--- a/app/editor/src/features/content/papers/utils/sortContent.ts
+++ b/app/editor/src/features/content/papers/utils/sortContent.ts
@@ -1,0 +1,24 @@
+import { ISortBy } from 'features/interfaces';
+import { getIn } from 'formik';
+import { IContentModel } from 'tno-core';
+
+import { defaultSort } from '../constants';
+
+/**
+ * Sorts the specified items.
+ * @param sort An array of sort by property paths.
+ * @returns How to sort the specified items.
+ */
+export const sortContent = (sort: ISortBy[] = defaultSort) => {
+  return (a: IContentModel, b: IContentModel) => {
+    for (var index in sort) {
+      const sortBy = sort[index];
+      let value1 = getIn(a, sortBy.id) ?? '';
+      let value2 = getIn(b, sortBy.id) ?? '';
+      if (value1 === value2) continue; // Check the next sort by.
+      return (value1 > value2 ? 1 : -1) * (sortBy.desc ? -1 : 1);
+    }
+
+    return 0;
+  };
+};

--- a/app/editor/src/store/slices/content/contentSlice.ts
+++ b/app/editor/src/store/slices/content/contentSlice.ts
@@ -47,7 +47,7 @@ export const initialContentState: IContentState = {
     commentary: false,
     topStory: false,
     featuredStory: false,
-    sort: [],
+    sort: [{ id: 'source.sortOrder' }, { id: 'otherSource' }, { id: 'page' }],
   },
   filterPaperAdvanced: {
     fieldType: AdvancedSearchKeys.Headline,


### PR DESCRIPTION
The default sort for the Editor Papers should be the `source.sortOrder` then the `page`.  Additionally, if an Editor changes the `source.sortOrder` it will resort the content in the UI to handle this scenario.

Ideally we would reindex the Source in Elasticsearch to resolve this issue, but I've created a separate story for this.