### PR TITLE
TNO-2445: Search terms not always appearing on saved searches

### DIFF
--- a/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
@@ -76,6 +76,7 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ onSearch }) => 
     },
     { storeSearchFilter },
   ] = useContent();
+
   const genQuery = useElastic();
   const { expanded, setExpanded } = useSearchPageContext();
   const [{ userInfo }] = useApp();
@@ -85,6 +86,13 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ onSearch }) => 
 
   const [searchName, setSearchName] = React.useState<string>(activeFilter?.name ?? '');
   const [query, setQuery] = React.useState<string>(search.search ?? '');
+
+  // replace query with search when search is present
+  React.useEffect(() => {
+    if (!query && !!search.search) {
+      setQuery(search.search);
+    }
+  }, [search]);
 
   const displayFiltersAsDropdownCookieKey = 'advancedSearch:displayFiltersAsDropdown';
   const [displayFiltersAsDropdown, setDisplayFiltersAsDropdown] = React.useState<boolean>(() => {

--- a/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
@@ -92,7 +92,7 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ onSearch }) => 
     if (!query && !!search.search) {
       setQuery(search.search);
     }
-  }, [search]);
+  }, [search, query]);
 
   const displayFiltersAsDropdownCookieKey = 'advancedSearch:displayFiltersAsDropdown';
   const [displayFiltersAsDropdown, setDisplayFiltersAsDropdown] = React.useState<boolean>(() => {


### PR DESCRIPTION
Fix state sync issue for advanced search - will now display search terms always (previously would be overridden on refresh/ state change)