### PR TITLE
fix: #tno-2502 - show quotes without refresh

### DIFF
--- a/api/net/Areas/Services/Controllers/ContentController.cs
+++ b/api/net/Areas/Services/Controllers/ContentController.cs
@@ -437,7 +437,7 @@ public class ContentController : ControllerBase
             StatusCode = StatusCodes.Status400BadRequest
         };
 
-        await _kafkaMessenger.SendMessageAsync(_kafkaHubOptions.HubTopic, new KafkaHubMessage(HubEvent.SendAll, new KafkaInvocationMessage(MessageTarget.ContentUpdated, new[] { new ContentMessageModel(content, "file") })));
+        await _kafkaMessenger.SendMessageAsync(_kafkaHubOptions.HubTopic, new KafkaHubMessage(HubEvent.SendAll, new KafkaInvocationMessage(MessageTarget.ContentUpdated, new[] { new ContentMessageModel(content, "quotes") })));
 
         return new JsonResult(new ContentModel(content, _serializerOptions));
     }

--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -608,7 +608,7 @@ const ContentForm: React.FC<IContentFormProps> = ({
                               setShowValidationToast={setShowValidationToast}
                             />
                             <Tab
-                              label="Quotes"
+                              label={`Quotes (${props.values.quotes.length})`}
                               onClick={() => setActive('quotes')}
                               active={active === 'quotes'}
                             />

--- a/app/editor/src/features/content/form/hooks/useContentForm.ts
+++ b/app/editor/src/features/content/form/hooks/useContentForm.ts
@@ -143,10 +143,17 @@ export const useContentForm = ({
             // TODO: Don't overwrite the user's edits.
             fetchContent(message.id);
           } catch {}
-        } else if (message.reason === 'file') {
+        } else if (message.reason) {
           getContent(form.id)
             .then((values) => {
-              setForm({ ...form, fileReferences: values?.fileReferences ?? [] });
+              switch (message.reason) {
+                case 'file':
+                  setForm({ ...form, fileReferences: values?.fileReferences ?? [] });
+                  break;
+                case 'quotes':
+                  setForm({ ...form, quotes: values?.quotes ?? [] });
+                  break;
+              }
             })
             .catch(() => {});
         }


### PR DESCRIPTION
- fixed the SignalR message to be 'quotes' instead of 'file'
- updated onContentUpdated to disply quotes if SignalR message comes through with quotes
- updated Quotes tab to show count of quotes