### PR TITLE
Fix add to report

### DIFF
--- a/app/subscriber/src/features/my-reports/ReportPreview.tsx
+++ b/app/subscriber/src/features/my-reports/ReportPreview.tsx
@@ -134,7 +134,7 @@ export const ReportPreview = ({ report, onFetch, onClose }: IReportPreviewProps)
         >
           <Button
             variant="secondary"
-            onClick={() => instance?.id && handleRefresh(instance?.id, true)}
+            onClick={() => instance?.id && handleRefresh(instance?.id, true).catch(() => {})}
             disabled={isSubmitting}
           >
             Refresh
@@ -155,7 +155,9 @@ export const ReportPreview = ({ report, onFetch, onClose }: IReportPreviewProps)
               (value) => instance?.status === value,
             ) ? (
               <Button
-                onClick={() => report && instance && handleSend(report, instance.id)}
+                onClick={() =>
+                  report && instance && handleSend(report, instance.id).catch(() => {})
+                }
                 disabled={isSubmitting}
               >
                 Send
@@ -163,7 +165,7 @@ export const ReportPreview = ({ report, onFetch, onClose }: IReportPreviewProps)
               </Button>
             ) : (
               <Button
-                onClick={() => report && handleGenerate(report, true)}
+                onClick={() => report && handleGenerate(report, true).catch(() => {})}
                 disabled={isSubmitting}
                 variant="success"
               >

--- a/app/subscriber/src/store/hooks/subscriber/useReports.ts
+++ b/app/subscriber/src/store/hooks/subscriber/useReports.ts
@@ -208,6 +208,7 @@ export const useReports = (): [IProfileState, IReportController] => {
             if (!response.data) return reports;
             var contains = false;
             const results = reports.map((r) => {
+              // If the report exists then we don't need to add it.
               if (r.id === id) contains = true;
               return r.id === id ? response.data! : r;
             });


### PR DESCRIPTION
Now when adding content to a report it will ensure that it generates a new instance if it is required, and it will update local state so that the user can go view the report and see the content has been added.

## Add to Report

![image](https://github.com/bcgov/tno/assets/3180256/872ee48d-90a9-4d19-aa6c-03dcd8cb508c)
