### PR TITLE
TNO-2227 Allow signalR to update content while submitting

### DIFF
--- a/app/editor/src/features/content/form/hooks/useContentForm.ts
+++ b/app/editor/src/features/content/form/hooks/useContentForm.ts
@@ -138,7 +138,7 @@ export const useContentForm = ({
   const onContentUpdated = React.useCallback(
     async (message: IContentMessageModel) => {
       if (form.id === message.id) {
-        if (form.version !== message.version && !isSubmitting) {
+        if (form.version !== message.version) {
           try {
             // TODO: Don't overwrite the user's edits.
             fetchContent(message.id);
@@ -159,7 +159,7 @@ export const useContentForm = ({
         }
       }
     },
-    [fetchContent, form, getContent, isSubmitting],
+    [fetchContent, form, getContent],
   );
 
   hub.useHubEffect(MessageTargetName.ContentUpdated, onContentUpdated);


### PR DESCRIPTION
The issue was triggered because of two factors.

Every time a content is Unpublished, the indexing service acts on it, so we have two versions increases when:

- The form is updated
- When indexing service updates.

So we have a two step version increase on each update.

What happens is, when you unpublish (or publish unpublished content), the indexing service needs to handle this status change, but most of the times, when the service changes and sends SignalR the message to fetch the data, the for is still submitting, so is always one version earlier then the version handled by the indexing service.

Removing the !isSubmitting check, guarantees that, the version of the content will always be up to date when performing a second action (Unpublishing or Re-Publishing) without refreshing the screen.