### PR TITLE
TNO-2464: New time input for folder schedules

### DIFF
--- a/app/subscriber/src/components/form/timeinput/TimeInput.tsx
+++ b/app/subscriber/src/components/form/timeinput/TimeInput.tsx
@@ -1,0 +1,179 @@
+import React, { InputHTMLAttributes } from 'react';
+import { FaClock } from 'react-icons/fa6';
+import { Col, Error, Row, Show } from 'tno-core';
+
+import * as styled from './styled';
+
+export interface ITimeInputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'children' | 'dangerouslySetInnerHTML'> {
+  label?: string;
+  /**
+   * Display errors.
+   */
+  error?: string;
+}
+
+/** Component that will enforce the HH:MM:SS time format */
+export const TimeInput: React.FC<ITimeInputProps> = ({ label, error, ...rest }) => {
+  const [showMenuOptions, setShowMenuOptions] = React.useState(false);
+  const [hours, setHours] = React.useState('');
+  const [minutes, setMinutes] = React.useState('');
+  const [seconds, setSeconds] = React.useState('');
+  const [value, setValue] = React.useState('');
+  const menuRef = React.useRef<HTMLDivElement>(null);
+  const hourOptions = Array.from({ length: 24 }, (_, i) => String(i).padStart(2, '0'));
+  const minuteSecondOptions = Array.from({ length: 60 }, (_, i) => String(i).padStart(2, '0'));
+
+  React.useEffect(() => {
+    const incomingValue = String(rest.value);
+    // update if no user input yet and external value is differnt (navigating through list)
+    if (!value || incomingValue !== value) {
+      const isValidTimeFormat = /^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$/.test(
+        incomingValue,
+      );
+      if (isValidTimeFormat) {
+        setValue(incomingValue);
+      }
+    }
+    // only update if value changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rest.value]);
+
+  React.useEffect(() => {
+    if (hours || minutes || seconds) {
+      // Check if any of these are non-empty
+      setValue(`${hours}:${minutes}:${seconds}`);
+    } else {
+      !rest.value && setValue(''); // Set to empty to avoid "::"
+    }
+    // only update when hours, minutes, or seconds change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hours, minutes, seconds]);
+
+  // keep value in sync with hours, minutes, and seconds
+  React.useEffect(() => {
+    if (value.length === 8) {
+      const [hour, minute, second] = value.split(':');
+      setHours(hour);
+      setMinutes(minute);
+      setSeconds(second);
+    }
+  }, [value]);
+
+  // Click outside handler close menu
+  const handleClickOutside = (event: any) => {
+    if (menuRef.current && !menuRef.current.contains(event.target)) {
+      setShowMenuOptions(false);
+    }
+  };
+
+  React.useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <styled.TimeInput {...rest}>
+      <Show visible={!!label}>
+        <label className={rest.required ? 'required' : ''}>{label}</label>
+      </Show>
+      <div className="input-area">
+        <input
+          type="text"
+          value={value}
+          className="masked-input"
+          onChange={(e) => {
+            const input = e.target.value;
+            const originalInput = value;
+            let numericInput = input.replace(/[^0-9]/g, ''); // do not allow any non-numeric characters
+
+            let formattedTime = numericInput;
+            if (numericInput.length > 6) {
+              numericInput = numericInput.slice(0, 6); // Ensure max length of 6 digits
+            }
+            if (numericInput.length > 4) {
+              formattedTime = `${numericInput.slice(0, 2)}:${numericInput.slice(
+                2,
+                4,
+              )}:${numericInput.slice(4)}`;
+            } else if (numericInput.length > 2) {
+              formattedTime = `${numericInput.slice(0, 2)}:${numericInput.slice(2)}`;
+            }
+
+            // this fixes backspace issue on first character
+            if (input.length < originalInput.length) {
+              setValue(input);
+            } else {
+              // enforce HH:MM:SS format with only valid numbers (eg 32:99:99 is invalid)
+              const regex = /^([0-1]?[0-9]|2[0-3])?(:([0-5]?[0-9])(:([0-5]?[0-9])?)?)?$/;
+              if (regex.test(formattedTime)) {
+                setValue(formattedTime);
+              }
+            }
+          }}
+          placeholder="hh:mm:ss"
+          maxLength={8}
+        />
+        {<FaClock onClick={() => setShowMenuOptions(true)} />}
+      </div>
+      {showMenuOptions && (
+        <>
+          <div className="arrow-up"></div>
+          <Row className="time-menu" ref={menuRef}>
+            <Col className="select-col">
+              <div className="col-header">Hour</div>
+              <div className="hour-menu">
+                {hourOptions.map((hour) => (
+                  <div
+                    className={`time-opt ${hour === hours ? 'selected' : ''}`}
+                    onClick={() => {
+                      setHours(String(hour));
+                    }}
+                    key={`${hour.toString()}-hour`}
+                  >
+                    {hour}
+                  </div>
+                ))}
+              </div>
+            </Col>
+            <Col className="select-col">
+              <div className="col-header">Minute</div>
+              <div className="minute-menu">
+                {minuteSecondOptions.map((minute) => (
+                  <div
+                    className={`time-opt ${minute === minutes ? 'selected' : ''}`}
+                    onClick={() => {
+                      setMinutes(String(minute));
+                    }}
+                    key={`${minute.toString()}-minute`}
+                  >
+                    {minute}
+                  </div>
+                ))}
+              </div>
+            </Col>
+            <Col className="select-col">
+              <div className="col-header">Seconds</div>
+              <div className="second-menu">
+                {minuteSecondOptions.map((second) => (
+                  <div
+                    className={`time-opt ${second === seconds ? 'selected' : ''}`}
+                    onClick={() => {
+                      setSeconds(String(second));
+                    }}
+                    key={`${second.toString()}-second`}
+                  >
+                    {second}
+                  </div>
+                ))}
+              </div>
+            </Col>
+          </Row>
+        </>
+      )}
+      <Error error={error} />
+    </styled.TimeInput>
+  );
+};

--- a/app/subscriber/src/components/form/timeinput/index.ts
+++ b/app/subscriber/src/components/form/timeinput/index.ts
@@ -1,0 +1,1 @@
+export * from './TimeInput';

--- a/app/subscriber/src/components/form/timeinput/styled/TimeInput.tsx
+++ b/app/subscriber/src/components/form/timeinput/styled/TimeInput.tsx
@@ -1,0 +1,116 @@
+import { InputHTMLAttributes } from 'react';
+import styled from 'styled-components';
+
+export const TimeInput = styled.div<InputHTMLAttributes<HTMLInputElement>>`
+  margin-right: 0.5em;
+  border: none;
+  box-shadow: none;
+  outline: none;
+  .arrow-up {
+    position: absolute;
+    width: 0;
+    height: 0;
+    z-index: 2000;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    border-bottom: 10px solid ${(props) => props.theme.css.inputGrey};
+    margin-left: 6em;
+    margin-top: -9px;
+  }
+  .hour-menu,
+  .minute-menu,
+  .second-menu {
+    max-height: 20em;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+  .select-col {
+    margin-right: 0.5em;
+  }
+  .time-opt {
+    &.selected {
+      background-color: ${(props) => props.theme.css.btnBkPrimary};
+      color: white;
+    }
+    width: 2em;
+    display: flex;
+    justify-content: center;
+    &:hover {
+      cursor: pointer;
+      background-color: ${(props) => props.theme.css.btnBkPrimary};
+      color: white;
+    }
+  }
+  width: ${(props) => props.width};
+  .time-menu {
+    font-size: 1.15em;
+    box-shadow: 0 0 3px;
+    z-index: 1000;
+    max-height: 22em;
+    position: absolute;
+    background-color: ${(props) => props.theme.css.inputGrey};
+    margin-left: 5em;
+    padding: 1em;
+    border: 1px solid ${(props) => props.theme.css.inputGrey};
+  }
+  .input-area {
+    border: 1px solid ${(props) => props.theme.css.linePrimaryColor};
+    border-radius: 0.25rem;
+    display: flex;
+    align-items: center;
+    width: 8em;
+    svg {
+      margin-left: 0.5em;
+      margin-bottom: 0.25em;
+      color: ${(props) => props.theme.css.iconPrimaryColor};
+      &:hover {
+        cursor: pointer;
+      }
+    }
+  }
+
+  .col-header {
+    font-weight: 700;
+    text-decoration: underline;
+  }
+
+  .minute-menu,
+  .second-menu {
+    .time-opt {
+      margin-left: 0.5em;
+    }
+  }
+
+  label {
+    font-weight: 700;
+  }
+
+  .required:after {
+    content: ' *';
+    color: ${(props) => props.theme.css.dangerColor};
+    font-weight: 700;
+  }
+
+  .masked-input {
+    border: none;
+    border-radius: 0.25em;
+    outline: none;
+    padding: 0.375rem 0.75rem;
+
+    width: 4.25em;
+    :required {
+      border-color: ${(props) => props.theme.css.inputRequiredBorderColor};
+    }
+  }
+
+  input[role='alert'] {
+    border-color: ${(props) => props.theme.css.dangerColor};
+    filter: grayscale(100%) brightness(65%) sepia(25%) hue-rotate(-50deg) saturate(600%)
+      contrast(0.8);
+  }
+
+  input[disabled] {
+    color: hsl(0, 0%, 50%);
+    background-color: hsl(0, 0%, 95%);
+  }
+`;

--- a/app/subscriber/src/components/form/timeinput/styled/index.ts
+++ b/app/subscriber/src/components/form/timeinput/styled/index.ts
@@ -1,0 +1,1 @@
+export * from './TimeInput';

--- a/app/subscriber/src/features/my-folders/Schedule.tsx
+++ b/app/subscriber/src/features/my-folders/Schedule.tsx
@@ -1,19 +1,11 @@
+import { TimeInput } from 'components/form/timeinput';
 import moment from 'moment';
 import * as React from 'react';
 import ReactDatePicker from 'react-datepicker';
 import { FaInfoCircle } from 'react-icons/fa';
 import { FaGear } from 'react-icons/fa6';
 import { Tooltip } from 'react-tooltip';
-import {
-  Checkbox,
-  Col,
-  FieldSize,
-  IFolderScheduleModel,
-  Row,
-  Show,
-  Text,
-  TimeInput,
-} from 'tno-core';
+import { Checkbox, Col, FieldSize, IFolderScheduleModel, Row, Show, Text } from 'tno-core';
 
 import { daysOfWeek } from './constants/daysOfWeek';
 
@@ -52,8 +44,8 @@ export const Schedule: React.FC<IScheduleProps> = ({ folderSchedule, onScheduleC
                 <Col>
                   <TimeInput
                     label="Run schedule at:"
-                    placeholder='e.g. "13:00:00"'
-                    value={folderSchedule && folderSchedule?.startAt}
+                    placeholder="hh:mm:ss"
+                    value={!!folderSchedule ? folderSchedule?.startAt : ''}
                     width={FieldSize.Small}
                     onChange={(e) => {
                       onScheduleChange?.({
@@ -63,7 +55,7 @@ export const Schedule: React.FC<IScheduleProps> = ({ folderSchedule, onScheduleC
                     }}
                   />
                 </Col>
-                <Col>
+                <Col className="start-after-col">
                   <label>Start after:</label>
                   <ReactDatePicker
                     minDate={new Date()}

--- a/app/subscriber/src/features/my-folders/styled/ConfigureFolder.tsx
+++ b/app/subscriber/src/features/my-folders/styled/ConfigureFolder.tsx
@@ -10,20 +10,15 @@ export const ConfigureFolder = styled(PageSection)`
     color: ${(props) => props.theme.css.iconGrayColor};
     align-self: center;
   }
-  .time-inputs {
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
-    input {
-      height: 2.5rem;
-      box-sizing: border-box;
-      border-radius: 0.5rem;
-      border-thickness: 0.1rem;
-      border-color: black;
-      box-shadow: none;
-    }
-  }
   .react-datepicker-ignore-onclickoutside {
     border-radius: 0.5rem;
+    height: 1.5em;
+  }
+  .react-datepicker__input-container {
+    input {
+      height: 1.6rem;
+      border-radius: 0.25em;
+    }
   }
   button:not(.react-datepicker__close-icon):not(.warning):not(.danger):not(.cancel) {
     background-color: ${(props) => props.theme.css.btnBkPrimary};


### PR DESCRIPTION
This is currently not in tno-core, I could update our shared `TimeInput`, but am unsure of whether this is valid for our other use cases. For now it is isolated to the subscriber app. The shared input uses an external library called `MaskedInput`, this one is from scratch.

Features:
- user may click the clock face to reveal hour/minute/time options and click the desired inputs
- user may also type hh:mm:ss - this will automatically append the : when required 
- the menu will stay in sync with what the user inputs, for example if I type 11:11:11, clicking the clockface will show the 11 11 11 options selected
- clicking anywhere off the menu will close it
- only valid hh:mm:ss will be accepted, enforced by regex

![image](https://github.com/bcgov/tno/assets/15724124/415d423d-3534-4d99-a419-2bc7b4cc3c3d)
