### PR TITLE
TNO-1986: Persist checked items until action is performed

### DIFF
--- a/app/subscriber/src/components/content-list/ContentList.tsx
+++ b/app/subscriber/src/components/content-list/ContentList.tsx
@@ -29,6 +29,8 @@ export interface IContentListProps {
   scrollWithin?: boolean;
   /** determine whether or not to show the series title */
   showSeries?: boolean;
+  /** Whether to store the state of the checkboxes in cache */
+  cacheCheck?: boolean;
 }
 
 export const ContentList: React.FC<IContentListProps> = ({
@@ -41,12 +43,42 @@ export const ContentList: React.FC<IContentListProps> = ({
   scrollWithin = false,
   showSeries = false,
   showTime = false,
+  cacheCheck = true,
 }) => {
   const navigate = useNavigate();
   const { groupBy, setActiveStream, activeFileReference } = React.useContext(ContentListContext);
   const grouped = groupContent(groupBy, [...content]);
   const [, { stream }] = useContent();
   const [{ settings }] = useLookup();
+
+  // just on init we want to see if anything in local storage
+  React.useEffect(() => {
+    if (!cacheCheck) return;
+    const existing = localStorage.getItem('selected');
+    if (existing) {
+      onContentSelected(JSON.parse(existing));
+    }
+    // only want to fire once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // this will update the local storage with the selected content
+  React.useEffect(() => {
+    if (!cacheCheck) return;
+    const existing = localStorage.getItem('selected');
+    let array;
+    if (existing) {
+      array = JSON.parse(existing);
+    } else {
+      array = [];
+    }
+    if (array.lenth !== selected.length) {
+      array = selected;
+    }
+    localStorage.setItem('selected', JSON.stringify(array));
+    // only want to fire when selected changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selected]);
 
   const handleCheckboxChange = React.useCallback(
     (item: IContentModel, isChecked: boolean) => {

--- a/app/subscriber/src/components/tool-bar/AddToFolderMenu.tsx
+++ b/app/subscriber/src/components/tool-bar/AddToFolderMenu.tsx
@@ -9,15 +9,17 @@ import * as styled from './styled';
 
 export interface IAddToFolderMenuProps {
   content: IContentModel[];
+  /** Callback to clear the selected content. */
+  onClear?: () => void;
 }
 
-export const AddToFolderMenu: React.FC<IAddToFolderMenuProps> = ({ content }) => {
+export const AddToFolderMenu: React.FC<IAddToFolderMenuProps> = ({ content, onClear }) => {
   return (
     <styled.AddToMenu>
       <div data-tooltip-id="tooltip-add-to-folder" className="action">
         <FaFolderPlus /> <span>ADD TO FOLDER</span>
         <TooltipMenu clickable openOnClick id="tooltip-add-to-folder" place="bottom">
-          <FolderMenu content={toFolderContent(content)} />
+          <FolderMenu content={toFolderContent(content)} onClear={onClear} />
         </TooltipMenu>
       </div>
     </styled.AddToMenu>

--- a/app/subscriber/src/components/tool-bar/AddToReportMenu.tsx
+++ b/app/subscriber/src/components/tool-bar/AddToReportMenu.tsx
@@ -10,8 +10,10 @@ import { toInstanceContent } from './utils';
 
 export interface IAddToReportMenuProps {
   content: IContentModel[];
+  // Callback to clear the selected content.
+  onClear?: () => void;
 }
-export const AddToReportMenu: React.FC<IAddToReportMenuProps> = ({ content }) => {
+export const AddToReportMenu: React.FC<IAddToReportMenuProps> = ({ content, onClear }) => {
   const [{ myReports }, { addContentToReport, findMyReports, getReport, generateReport }] =
     useReports();
   const [{ requests }] = useApp();
@@ -63,9 +65,10 @@ export const AddToReportMenu: React.FC<IAddToReportMenuProps> = ({ content }) =>
             <Link to={`reports/${report.id}/content`}>{report.name}</Link>
           </div>
         ));
+        onClear?.();
       } catch {}
     },
-    [activeReport, content, addContentToReport],
+    [activeReport, content, addContentToReport, onClear],
   );
 
   // ensure no concurrency errors rather than getting from profile store

--- a/app/subscriber/src/components/tool-bar/ContentActionBar.tsx
+++ b/app/subscriber/src/components/tool-bar/ContentActionBar.tsx
@@ -25,6 +25,8 @@ export interface IContentActionBarProps {
   removeFolderItem?: Function;
   /** whether to disable AddtoFolderMenu */
   disableAddToFolder?: boolean;
+  /** Event to fire when selection should be cleared */
+  onClear?: () => void;
 }
 
 export const ContentActionBar: React.FC<IContentActionBarProps> = ({
@@ -33,6 +35,7 @@ export const ContentActionBar: React.FC<IContentActionBarProps> = ({
   showBackButton,
   onBack,
   onSelectAll,
+  onClear,
   removeFolderItem,
   disableAddToFolder,
 }) => {
@@ -100,8 +103,9 @@ export const ContentActionBar: React.FC<IContentActionBarProps> = ({
         <div className="right-side-items">
           <Row>
             <ShareMenu content={content} />
-            {disableAddToFolder ? null : <AddToFolderMenu content={content} />}
+            {disableAddToFolder ? null : <AddToFolderMenu onClear={onClear} content={content} />}
             <AddToReportMenu content={content} />
+            <AddToReportMenu content={content} onClear={onClear} />
             {!!removeFolderItem && <RemoveFromFolder onClick={removeFolderItem} />}
           </Row>
         </div>

--- a/app/subscriber/src/components/tool-bar/ContentActionBar.tsx
+++ b/app/subscriber/src/components/tool-bar/ContentActionBar.tsx
@@ -104,7 +104,6 @@ export const ContentActionBar: React.FC<IContentActionBarProps> = ({
           <Row>
             <ShareMenu content={content} />
             {disableAddToFolder ? null : <AddToFolderMenu onClear={onClear} content={content} />}
-            <AddToReportMenu content={content} />
             <AddToReportMenu content={content} onClear={onClear} />
             {!!removeFolderItem && <RemoveFromFolder onClick={removeFolderItem} />}
           </Row>

--- a/app/subscriber/src/features/content/view-content/FolderMenu.tsx
+++ b/app/subscriber/src/features/content/view-content/FolderMenu.tsx
@@ -20,10 +20,12 @@ import * as styled from './styled';
 export interface IFolderMenuProps {
   /** The current content that is being viewed. */
   content?: IFolderContentModel[];
+  /** Callback to clear the selected content. */
+  onClear?: () => void;
 }
 
 /** The submenu that appears in the tooltip when clicking on "Add folder" from the content tool bar */
-export const FolderMenu: React.FC<IFolderMenuProps> = ({ content }) => {
+export const FolderMenu: React.FC<IFolderMenuProps> = ({ content, onClear }) => {
   const [{ myFolders }, { findMyFolders, addFolder, updateFolder }] = useFolders();
   const [folderName, setFolderName] = React.useState('');
   const [{ myReports }, { storeReportContent, storeMyReports }] = useProfileStore();
@@ -59,10 +61,11 @@ export const FolderMenu: React.FC<IFolderMenuProps> = ({ content }) => {
             </div>
           ));
           setFolderName('');
+          onClear?.();
         })
         .catch(() => {});
     }
-  }, [addFolder, content, folderName]);
+  }, [addFolder, content, folderName, onClear]);
 
   const handleUpdate = React.useCallback(
     async (folder: IFolderModel) => {
@@ -110,11 +113,12 @@ export const FolderMenu: React.FC<IFolderMenuProps> = ({ content }) => {
                 <Link to={navUrl}>{folder.name}</Link>
               </div>
             ));
+            onClear?.();
           })
           .catch(() => {});
       }
     },
-    [content, myReports, storeMyReports, storeReportContent, updateFolder],
+    [content, myReports, storeMyReports, storeReportContent, updateFolder, onClear],
   );
 
   return (

--- a/app/subscriber/src/features/home/Home.tsx
+++ b/app/subscriber/src/features/home/Home.tsx
@@ -77,6 +77,7 @@ export const Home: React.FC = () => {
         <ContentListActionBar
           content={selected}
           onSelectAll={(e) => (e.target.checked ? setSelected(content) : setSelected([]))}
+          onClear={() => setSelected([])}
         />
       </Row>
       <DateFilter filter={filter} storeFilter={storeFilter} />


### PR DESCRIPTION
Now when checking an item in the content list view:

- it will stay checked until an action is performed (Add to folder, Add to report)
- we store these values in cache and ensure that it is synchronized with the current state 
- currently this does not clear when closing the app (if this is desired behaviour we could use session storage instead)
