### PR TITLE
feat: #tno-2517 - switch Event of the day report to use Topic Scores

### DIFF
--- a/libs/net/dal/Migrations/1.0.146/Up/PostUp/00-Filters-EventOfTheDay.sql
+++ b/libs/net/dal/Migrations/1.0.146/Up/PostUp/00-Filters-EventOfTheDay.sql
@@ -64,7 +64,7 @@ SET "query" =
       }
     }
   },
-  "size": 0,
+  "size": 512,
   "query": {
     "bool": {
       "must": [


### PR DESCRIPTION
- instead of using just count of articles, the report uses the value of the Topic.Score to define percentages
- fixed size parameter in query - the pie chart uses the content, whereas the bullet list below it uses the aggregate - confusing...