### PR TITLE
TNO-2541 Enable Draft Reports/Fix Schedule Display

### DIFF
--- a/app/subscriber/src/components/section/Section.tsx
+++ b/app/subscriber/src/components/section/Section.tsx
@@ -11,7 +11,7 @@ export interface ISectionProps {
   open?: boolean;
   showOpen?: boolean;
   className?: string;
-  children?: React.ReactNode;
+  children?: React.ReactNode | ((props: ISectionProps) => React.ReactNode);
   onChange?: (open: boolean) => void;
 }
 
@@ -65,7 +65,23 @@ export const Section: React.FC<ISectionProps> = ({
           </div>
         )}
       </div>
-      {open && <div className="section-body">{children}</div>}
+      {open && (
+        <div className="section-body">
+          {typeof children === 'function'
+            ? (children as (props: ISectionProps) => React.ReactNode)({
+                icon,
+                label,
+                actions,
+                open,
+                showOpen,
+                className,
+                children,
+                onChange,
+                ...rest,
+              })
+            : children}
+        </div>
+      )}
     </styled.Section>
   );
 };

--- a/app/subscriber/src/features/my-reports/ReportCard.tsx
+++ b/app/subscriber/src/features/my-reports/ReportCard.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { FaChartPie, FaNewspaper, FaPen, FaTrashCan } from 'react-icons/fa6';
 import { Link } from 'react-router-dom';
 import { useApp, useReports } from 'store/hooks';
-import { Col, IReportModel, ReportSectionTypeName, Row, Spinner } from 'tno-core';
+import { Col, IReportModel, ReportSectionTypeName, Row, Show, Spinner } from 'tno-core';
 
 import { ReportKindIcon } from './components';
 import { calcNextScheduleSend, getLastSent } from './utils';
@@ -77,71 +77,81 @@ export const ReportCard: React.FC<IReportCardProps> = ({
         }
       }}
     >
-      <Row gap="1rem">
-        <Col flex="1" gap="1rem">
-          <div>
+      {() => (
+        <Row gap="1rem">
+          <Col flex="1" gap="1rem">
             <div>
-              <h3 className="upper">Report Description</h3>
-              <p>{report.description ? report.description : 'NO DESCRIPTION PROVIDED'}</p>
-            </div>
-          </div>
-          <div>
-            <h3 className="upper">Status</h3>
-            <Row>
-              <Col>Last sent:</Col>
-              <Col flex="1">{formatDate(getLastSent(report), true)}</Col>
-            </Row>
-            {report.instances.length > 0 && (
-              <Row>
-                <Col>Draft created:</Col>
-                <Col flex="1">{formatDate(report.instances[0].publishedOn ?? '', true)}</Col>
-              </Row>
-            )}
-          </div>
-        </Col>
-        <Col flex="1" gap="1rem">
-          <div>
-            <h3 className="upper">Settings</h3>
-            <Link to={`/reports/${report.id}`}>edit settings</Link>
-          </div>
-          {report.events.map((schedule, index) => {
-            return (
-              <div key={`${schedule.id}-${index}`}>
-                <Row>
-                  <h3>Schedule {index + 1}</h3>
-                  <Col flex="1">
-                    {schedule.isEnabled ? (
-                      <span className="report-schedule-enabled">enabled</span>
-                    ) : (
-                      <span className="report-schedule-disabled">disabled</span>
-                    )}
-                  </Col>
-                  {schedule.settings.autoSend && <Col>autosend</Col>}
-                </Row>
-                <Row>
-                  <Col flex="1">Next scheduled send:</Col>
-                  <Col flex="1" alignItems="flex-end">
-                    {formatDate(calcNextScheduleSend(schedule) ?? '', true)}
-                  </Col>
-                </Row>
+              <div>
+                <h3 className="upper">Report Description</h3>
+                <p>{report.description ? report.description : 'NO DESCRIPTION PROVIDED'}</p>
               </div>
-            );
-          })}
-          <Row justifyContent="flex-end">
-            <Action
-              icon={<FaTrashCan />}
-              onClick={() => {
-                onDelete?.(report);
-              }}
-            />
-          </Row>
-        </Col>
-        {isLoading && (
-          <Col alignContent="center" justifyContent="center">
-            <Spinner />
+            </div>
+            <div>
+              <h3 className="upper">Status</h3>
+              <Row>
+                <Col>Last sent:</Col>
+                <Col flex="1">{formatDate(getLastSent(report), true)}</Col>
+              </Row>
+              {report.instances.length > 0 && (
+                <Row>
+                  <Col>Draft created:</Col>
+                  <Col flex="1">{formatDate(report.instances[0].publishedOn ?? '', true)}</Col>
+                </Row>
+              )}
+            </div>
           </Col>
-        )}
-      </Row>
+          <Col flex="1" gap="1rem" className="report-card-schedule">
+            <div>
+              <h3 className="upper">Settings</h3>
+              <Link to={`/reports/${report.id}`}>edit settings</Link>
+            </div>
+            <Show visible={!report.events.some((e) => e.isEnabled)}>
+              <Row>Manual Report</Row>
+            </Show>
+            <Show visible={report.events.some((e) => e.isEnabled)}>
+              {report.events.map((schedule, index) => {
+                const nextSend = formatDate(calcNextScheduleSend(report, schedule) ?? '', true);
+                return (
+                  <div key={`${schedule.id}-${index}`}>
+                    <Row>
+                      <h3>Schedule {index + 1}</h3>
+                      <Col flex="1">
+                        {schedule.isEnabled ? (
+                          <span className="report-schedule-enabled">enabled</span>
+                        ) : (
+                          <span className="report-schedule-disabled">disabled</span>
+                        )}
+                      </Col>
+                      {schedule.settings.autoSend ? <Col>auto send</Col> : <Col>auto</Col>}
+                    </Row>
+                    <Row>
+                      <Col flex="1">
+                        Next scheduled {schedule.settings.autoSend ? 'send' : 'run'}:
+                      </Col>
+                      <Col flex="1" alignItems="flex-end">
+                        {nextSend}
+                      </Col>
+                    </Row>
+                  </div>
+                );
+              })}
+            </Show>
+            <Row justifyContent="flex-end">
+              <Action
+                icon={<FaTrashCan />}
+                onClick={() => {
+                  onDelete?.(report);
+                }}
+              />
+            </Row>
+          </Col>
+          {isLoading && (
+            <Col alignContent="center" justifyContent="center">
+              <Spinner />
+            </Col>
+          )}
+        </Row>
+      )}
     </Section>
   );
 };

--- a/app/subscriber/src/features/my-reports/edit/settings/ReportEditSendForm.tsx
+++ b/app/subscriber/src/features/my-reports/edit/settings/ReportEditSendForm.tsx
@@ -1,7 +1,17 @@
 import { Button } from 'components/button';
 import { IToggleOption, Toggle } from 'components/form';
 import { FaInfoCircle } from 'react-icons/fa';
-import { Checkbox, Col, FormikCheckbox, FormikText, ReportKindName, Row, Show } from 'tno-core';
+import { FaClock, FaUser, FaUserClock } from 'react-icons/fa6';
+import {
+  Checkbox,
+  Col,
+  FormikCheckbox,
+  FormikText,
+  getReportKind,
+  ReportKindName,
+  Row,
+  Show,
+} from 'tno-core';
 
 import { useReportEditContext } from '../ReportEditContext';
 import * as styled from './styled';
@@ -18,11 +28,35 @@ export const ReportEditSendForm = ({ onPublish, onGenerate }: IReportEditSendFor
   const { values, setValues, setFieldValue } = useReportEditContext();
 
   const instance = values.instances.length ? values.instances[0] : undefined;
-  const kind = values.events.some((e) => e.isEnabled) ? ReportKindName.Auto : ReportKindName.Manual;
+  const kind = getReportKind(values);
   const reportOptions: IToggleOption<ReportKindName>[] = [
-    { label: 'Manual Report', value: ReportKindName.Manual },
-    { label: 'Auto Report', value: ReportKindName.Auto },
-    { label: 'Auto Send Report', value: ReportKindName.AutoSend },
+    {
+      label: (
+        <Row gap="1rem" alignItems="center">
+          Manual Report
+          <FaUser />
+        </Row>
+      ),
+      value: ReportKindName.Manual,
+    },
+    {
+      label: (
+        <Row gap="1rem" alignItems="center">
+          Auto Report
+          <FaUserClock />
+        </Row>
+      ),
+      value: ReportKindName.Auto,
+    },
+    {
+      label: (
+        <Row gap="1rem" alignItems="center">
+          Auto Send Report
+          <FaClock />
+        </Row>
+      ),
+      value: ReportKindName.AutoSend,
+    },
   ];
   const isAuto = [ReportKindName.Auto, ReportKindName.AutoSend].includes(kind);
 

--- a/app/subscriber/src/features/my-reports/styled/MyReports.tsx
+++ b/app/subscriber/src/features/my-reports/styled/MyReports.tsx
@@ -175,6 +175,10 @@ export const MyReports = styled.div`
         }
       }
 
+      .report-card-schedule {
+        justify-content: space-between;
+      }
+
       .report-schedule-enabled {
         color: ${(props) => props.theme.css.tonePositive};
       }

--- a/db/kafka/docker-compose.yml
+++ b/db/kafka/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
   zookeeper:
     image: tno:kafka-zookeeper

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 ####################### Networks Definition #######################
 networks:
   tno:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
   ####################### Database #######################
   database:

--- a/libs/npm/core/src/components/show/Show.tsx
+++ b/libs/npm/core/src/components/show/Show.tsx
@@ -4,7 +4,7 @@ export interface IShowProps {
   /** Whether the children will be visible. */
   visible?: boolean;
   /** Children nodes to display. */
-  children: React.ReactNode;
+  children: React.ReactNode | ((props: IShowProps) => React.ReactNode);
 }
 
 /**
@@ -14,5 +14,11 @@ export interface IShowProps {
  * @returns A new instance of a Show component.
  */
 export const Show: React.FC<IShowProps> = ({ visible, children }) => {
-  return !!visible ? <>{children}</> : null;
+  return !!visible ? (
+    <>
+      {typeof children === 'function'
+        ? (children as (props: IShowProps) => React.ReactNode)({ visible, children })
+        : children}
+    </>
+  ) : null;
 };

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
   ####################### Ingestion Services #######################
   syndication:


### PR DESCRIPTION
Fix report card schedule to display the next schedule run date and time.

## Summary

- Fixed bug in report type display (Auto Send)
- Updated Section component to only render when needed
- removed warning in docker-compose.yaml files

## My Reports

![image](https://github.com/bcgov/tno/assets/3180256/ba556862-4337-46bf-bb30-d176706bbd96)
