### PR TITLE
TNO-2535 Fix save media analytics

### DIFF
--- a/app/subscriber/src/features/my-reports/edit/content/stories/ReportSectionMediaAnalytics.tsx
+++ b/app/subscriber/src/features/my-reports/edit/content/stories/ReportSectionMediaAnalytics.tsx
@@ -122,10 +122,8 @@ export const ReportSectionMediaAnalytics: React.FC<IReportSectionMediaAnalyticsP
         />
       </Show>
       {!!section.id &&
-        !section.linkedReportId &&
         !disabled &&
-        !section.reportId &&
-        (section.filterId || section.folderId) && (
+        (section.filterId || section.folderId || section.linkedReportId) && (
           <Col flex="1">
             <Action
               icon={<FaArrowsSpin />}

--- a/libs/net/models/Areas/Admin/Report/ReportModel.cs
+++ b/libs/net/models/Areas/Admin/Report/ReportModel.cs
@@ -174,6 +174,7 @@ public class ReportModel : BaseTypeWithAuditColumnsModel<int>
                     SortOrder = modelSection.Folder.SortOrder,
                     Settings = JsonDocument.Parse(JsonSerializer.Serialize(modelSection.Folder.Settings))
                 } : null,
+                LinkedReportId = modelSection.LinkedReportId,
                 Settings = JsonDocument.Parse(JsonSerializer.Serialize(modelSection.Settings)),
                 Version = modelSection.Version ?? 0
             };

--- a/libs/net/models/Areas/Editor/Models/ReportInstance/ReportSectionModel.cs
+++ b/libs/net/models/Areas/Editor/Models/ReportInstance/ReportSectionModel.cs
@@ -36,6 +36,16 @@ public class ReportSectionModel : BaseTypeModel<int>
     public FolderModel? Folder { get; set; }
 
     /// <summary>
+    /// get/set - Foreign key to the report this section pulls content from.
+    /// </summary>
+    public int? LinkedReportId { get; set; }
+
+    /// <summary>
+    /// get/set - The linked report for this section.
+    /// </summary>
+    public ReportModel? LinkedReport { get; set; }
+
+    /// <summary>
     /// get/set - The settings for this report section.
     /// </summary>
     public ReportSectionSettingsModel Settings { get; set; } = new();
@@ -64,6 +74,7 @@ public class ReportSectionModel : BaseTypeModel<int>
         this.Folder = entity.Folder != null ? new FolderModel(entity.Folder) : null;
         this.FilterId = entity.FilterId;
         this.Filter = entity.Filter != null ? new FilterModel(entity.Filter) : null;
+        this.LinkedReportId = entity.LinkedReportId;
         this.Settings = new ReportSectionSettingsModel(JsonSerializer.Deserialize<Dictionary<string, object>>(entity.Settings, options) ?? new Dictionary<string, object>(), options);
         this.ChartTemplates = entity.ChartTemplatesManyToMany
             .OrderBy(c => c.SortOrder)


### PR DESCRIPTION
Fixing issue when saving a report with a Media Analytic section that pulls data from another report.

## Editor Report Admin

![image](https://github.com/bcgov/tno/assets/3180256/a412986f-f4c9-4250-a783-72988376b9dc)

## Subscriber Edit Report

![image](https://github.com/bcgov/tno/assets/3180256/b13523fe-91d0-49e4-ae87-769121bbc66d)
