### PR TITLE
TNO-2516 Fix missing user information error handling

### DIFF
--- a/app/subscriber/src/features/settings/MyMinisterSettings.tsx
+++ b/app/subscriber/src/features/settings/MyMinisterSettings.tsx
@@ -18,6 +18,11 @@ export const MyMinisterSettings: React.FC = () => {
     .sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name));
 
   const handleSubmit = async (values: number[], userInfo: IUserInfoModel) => {
+    if (!userInfo) {
+      toast.error('User information is missing. Please try again later');
+      return;
+    }
+
     try {
       var user = {
         ...userInfo,
@@ -76,11 +81,7 @@ export const MyMinisterSettings: React.FC = () => {
       </p>
       <div className="option-container">
         <Row justifyContent="flex-end">
-          <Button
-            type="submit"
-            onClick={() => handleSubmit(myMinisters, userInfo!)}
-            disabled={!userInfo}
-          >
+          <Button type="submit" onClick={() => handleSubmit(myMinisters, userInfo!)}>
             Save
           </Button>
         </Row>
@@ -106,11 +107,7 @@ export const MyMinisterSettings: React.FC = () => {
         })}
 
         <Row justifyContent="flex-end">
-          <Button
-            type="submit"
-            onClick={() => handleSubmit(myMinisters, userInfo!)}
-            disabled={!userInfo}
-          >
+          <Button type="submit" onClick={() => handleSubmit(myMinisters, userInfo!)}>
             Save
           </Button>
         </Row>


### PR DESCRIPTION
It's challenging to reproduce the issues, as they might be caused by API responses or other factors. To provide a better user experience, I've removed the 'disable' props on save button and added detection for userinfo in the handleSubmit function. This should help users understand why they cannot submit. 
<img width="364" alt="image" src="https://github.com/bcgov/tno/assets/35620699/11e6b905-1f8f-4c79-8b6d-6878f32c7b6e">
