### PR TITLE
TNO-2219 Fix image overflow  update

### DIFF
--- a/app/subscriber/src/features/my-reports/edit/styled/ReportEditForm.tsx
+++ b/app/subscriber/src/features/my-reports/edit/styled/ReportEditForm.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 export const ReportEditForm = styled.div`
   display: flex;
   flex-direction: column;
+  overflow-x: auto;
 
   .preview-report {
     border: solid 2px ${(props) => props.theme.css.linePrimaryColor};
@@ -21,6 +22,9 @@ export const ReportEditForm = styled.div`
 
     .preview-body {
       padding: 1rem;
+      img {
+        max-width: 100%;
+      }
     }
   }
 

--- a/app/subscriber/src/features/my-reports/styled/MyReports.tsx
+++ b/app/subscriber/src/features/my-reports/styled/MyReports.tsx
@@ -200,6 +200,9 @@ export const MyReports = styled.div`
       max-width: 100%;
       width: 100%;
       min-width: 100%;
+      img {
+        max-width: 100%;
+      }
     }
 
     .report-title {


### PR DESCRIPTION
![0424(1)](https://github.com/bcgov/tno/assets/35620699/4f7ffdbd-785b-43f1-8337-556d0bcee1b5)

I've noticed that the preview in the subscriber edit view uses a different file, and I've discovered a bug where very high-resolution files can push the top toolbar to the side. so make large images with the same maximum width as their parent.  In GIF changing the screen width will adjust the size of the image, and the toolbar will move accordingly. Additionally, in some cases where the content width is too large, you can scroll horizontally with the scrollbar to locate the toolbar.






