### PR TITLE
TNO-2526, TNO-2542: My folder fixes

### DIFF
--- a/app/subscriber/src/features/my-folders/FolderLanding.tsx
+++ b/app/subscriber/src/features/my-folders/FolderLanding.tsx
@@ -2,33 +2,35 @@ import { PageSection } from 'components/section';
 import { ManageFolder } from 'features/manage-folder';
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { Col, IFolderModel, Show } from 'tno-core';
+import { Col, Show } from 'tno-core';
 
 import { ConfigureFolder } from './ConfigureFolder';
+import { MyFolderContextProvider } from './MyFolderContext';
 import { MyFolders } from './MyFolders';
 import * as styled from './styled';
 
 export const FolderLanding: React.FC<{}> = () => {
-  const [activeFolder, setActiveFolder] = React.useState<IFolderModel>();
   const { action } = useParams();
 
   return (
-    <styled.FolderLanding split={!!action}>
-      <Col className="left-side">
-        <PageSection header="My Folders" includeHeaderIcon>
-          <MyFolders setActive={setActiveFolder} />
-        </PageSection>
-      </Col>
-      <Show visible={!!action}>
-        <Col className="right-side">
-          <Show visible={action === 'view'}>
-            <ManageFolder />
-          </Show>
-          <Show visible={action === 'configure'}>
-            <ConfigureFolder active={activeFolder} />
-          </Show>
+    <MyFolderContextProvider>
+      <styled.FolderLanding split={!!action}>
+        <Col className="left-side">
+          <PageSection header="My Folders" includeHeaderIcon>
+            <MyFolders />
+          </PageSection>
         </Col>
-      </Show>
-    </styled.FolderLanding>
+        <Show visible={!!action}>
+          <Col className="right-side">
+            <Show visible={action === 'view'}>
+              <ManageFolder />
+            </Show>
+            <Show visible={action === 'configure'}>
+              <ConfigureFolder />
+            </Show>
+          </Col>
+        </Show>
+      </styled.FolderLanding>
+    </MyFolderContextProvider>
   );
 };

--- a/app/subscriber/src/features/my-folders/MyFolderContext.tsx
+++ b/app/subscriber/src/features/my-folders/MyFolderContext.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { IFolderModel } from 'tno-core';
+
+export interface IMyFolderContext {
+  activeFolder: IFolderModel;
+  setActiveFolder: (folder: IFolderModel) => void;
+}
+
+export interface IMyFolderContextProviderProps {
+  children: React.ReactNode;
+}
+
+const MyFolderContext = React.createContext<IMyFolderContext | undefined>(undefined);
+
+export const useMyFolderContext = () => {
+  const context = React.useContext(MyFolderContext);
+  if (!context) {
+    throw new Error('useMyFolderContext must be used within a MyFolderContextProvider');
+  }
+  return context;
+};
+
+export const MyFolderContextProvider: React.FC<IMyFolderContextProviderProps> = ({ children }) => {
+  const [activeFolder, setActiveFolder] = React.useState<IFolderModel | undefined>(undefined);
+
+  return (
+    <MyFolderContext.Provider value={{ activeFolder: activeFolder!, setActiveFolder }}>
+      {children}
+    </MyFolderContext.Provider>
+  );
+};

--- a/app/subscriber/src/features/my-folders/MyFolders.tsx
+++ b/app/subscriber/src/features/my-folders/MyFolders.tsx
@@ -5,21 +5,18 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useFolders } from 'store/hooks/subscriber/useFolders';
 import { useProfileStore } from 'store/slices';
-import { FlexboxTable, IFolderModel, Row, Text } from 'tno-core';
+import { FlexboxTable, Row, Text } from 'tno-core';
 
 import { columns } from './constants/columns';
+import { useMyFolderContext } from './MyFolderContext';
 import * as styled from './styled';
 
-export interface IMyFoldersProps {
-  /** function to set the active folder */
-  setActive: React.Dispatch<React.SetStateAction<IFolderModel | undefined>>;
-  /** the active folder */
-  active?: IFolderModel;
-}
+export interface IMyFoldersProps {}
 
 /** contains a list of the user's folders, allows for edit and viewing */
-export const MyFolders: React.FC<IMyFoldersProps> = ({ setActive }) => {
+export const MyFolders: React.FC<IMyFoldersProps> = () => {
   const [{ myFolders }, { findMyFolders, addFolder }] = useFolders();
+  const { setActiveFolder } = useMyFolderContext();
   const navigate = useNavigate();
   const { id } = useParams();
   const [newFolderName, setNewFolderName] = React.useState<string>('');
@@ -78,11 +75,11 @@ export const MyFolders: React.FC<IMyFoldersProps> = ({ setActive }) => {
         <SubscriberTableContainer>
           <FlexboxTable
             pagingEnabled={false}
-            columns={columns(setActive, Number(id), navigate)}
+            columns={columns(setActiveFolder, Number(id), navigate)}
             rowId={'id'}
             disableZebraStriping
             onRowClick={(e) => {
-              setActive(e.original);
+              setActiveFolder(e.original);
               navigate(`/folders/view/${e.original.id}`);
             }}
             data={myFolders}

--- a/app/subscriber/src/features/my-folders/constants/columns.tsx
+++ b/app/subscriber/src/features/my-folders/constants/columns.tsx
@@ -3,7 +3,7 @@ import { FaFolderClosed, FaFolderOpen } from 'react-icons/fa6';
 import { CellEllipsis, IFolderModel, ITableHookColumn, Row } from 'tno-core';
 
 export const columns = (
-  setActive: React.Dispatch<React.SetStateAction<IFolderModel | undefined>>,
+  setActive: (folder: IFolderModel) => void,
   activeId?: number,
   navigate?: (path: string) => void,
 ): ITableHookColumn<IFolderModel>[] => [

--- a/app/subscriber/src/features/my-folders/index.ts
+++ b/app/subscriber/src/features/my-folders/index.ts
@@ -1,3 +1,4 @@
 export * from './ConfigureFolder';
 export * from './FolderLanding';
+export * from './MyFolderContext';
 export * from './MyFolders';


### PR DESCRIPTION
- change to context provider instead of prop drilling
- fix duplicate state issue (had two state variables for the active folder and only one was in sync)
- minor useEffect fixes 

With these updates, it should get rid of all errors when trying to save folders in any combination. Previously emptying the folder / trying to rename the folder would cause an error.