### PR TITLE
TNO-2492 Fix corner cases

### DIFF
--- a/services/net/filemonitor/FilemonitorAction.cs
+++ b/services/net/filemonitor/FilemonitorAction.cs
@@ -878,16 +878,31 @@ public class FileMonitorAction : IngestAction<FileMonitorOptions>
     }
 
     /// <summary>
+    /// Remove Special chars from a string.
+    /// </summary>
+    /// <param name="text"></param>
+    /// <returns></returns>
+    private static string RemoveSpecial(string text)
+    {
+        var arr = text.Select(ch => 
+                                ((ch >= 'a' && ch <= 'z') 
+                                    || (ch >= 'A' && ch <= 'Z') 
+                                    || (ch >= '0' && ch <= '9') 
+                                    ) ? ch : ' ').ToArray();
+        return new string(arr);
+    }
+
+    /// <summary>
     /// Convert to Title Case if the text is All Caps.
     /// </summary>
     /// <param name="author"></param>
     /// <returns>bool</returns>
     private static string ToTitleCase(string author)
     {
+        var stringCheck = RemoveSpecial(author.Replace("By", "BY"));
         TextInfo tInfo = new CultureInfo("en-US",false).TextInfo;
-        return IsAllCaps(author) ? tInfo.ToTitleCase(author.ToLower()) : author;
+        return IsAllCaps(stringCheck) ? tInfo.ToTitleCase(author.ToLower()) : author;
     }
-    
 
     /// <summary>
     /// Get the list of labels for this story. Currently only supported for FMS files.

--- a/services/net/filemonitor/FilemonitorAction.cs
+++ b/services/net/filemonitor/FilemonitorAction.cs
@@ -878,7 +878,7 @@ public class FileMonitorAction : IngestAction<FileMonitorOptions>
     }
 
     /// <summary>
-    /// Remove Special chars from a string.
+    /// Remove Special chars from a string replacing with a ' '.
     /// </summary>
     /// <param name="text"></param>
     /// <returns></returns>


### PR DESCRIPTION
Some corner cases were detected and handled.

**By PAN PYLAS**
Since we have on the file By the "y" char is lowercase then the All Caps check does not work.
So before checking we replace the substring "By" with "BY". Then we can keep checking if the rest of the string is uppercase.

**By JOHN CHIDLEY-HILL
By STEVEN CHASE, ROBERT FIFE**
Since we have special chars on these strings, the All Caps check also does not work. So just for the All Caps check, we remove the special chars.
