### PR TITLE
TNO-2597 Verify just audio and video files

### DIFF
--- a/app/subscriber/src/components/content-list/ContentRow.tsx
+++ b/app/subscriber/src/components/content-list/ContentRow.tsx
@@ -91,7 +91,8 @@ export const ContentRow: React.FC<IContentRowProps> = ({
           visible={
             !!item.fileReferences.length &&
             !activeStream?.source &&
-            !item.fileReferences[0].contentType.includes('image')
+            (item.fileReferences[0].contentType.includes('video') ||
+              item.fileReferences[0].contentType.includes('audio'))
           }
         >
           <FaPlayCircle


### PR DESCRIPTION
In the particular case of the bug, the content had a PDF file attached.
Since the previous check was just verifying if there was not an image file, the pdf file was displaying the play button.
Just narrowed the logic to display the button if the type contains audio OR video.

![image](https://github.com/bcgov/tno/assets/26801490/e500e6b8-131c-4d7a-84e1-9065f092f6d9)
