### PR TITLE
TNO-2558: Selecting more than one option minimizes menu

### DIFF
--- a/app/subscriber/src/features/hooks/useSubMediaGroups.ts
+++ b/app/subscriber/src/features/hooks/useSubMediaGroups.ts
@@ -134,14 +134,6 @@ export const useSubMediaGroups = (
       });
     });
 
-    const expandedStates: ISubMediaGroupExpanded = subGroups.reduce(
-      (acc: ISubMediaGroupExpanded, { key }) => {
-        acc[key] = false; // Default all groups to not expanded
-        return acc;
-      },
-      {},
-    );
-
     setSubMediaGroups(subGroups.sort((a, b) => a.sortOrder - b.sortOrder));
   }, [mediaTypeSeriesLookup, mediaTypeSourceLookup, mediaTypes, series, sources]);
 

--- a/app/subscriber/src/features/hooks/useSubMediaGroups.ts
+++ b/app/subscriber/src/features/hooks/useSubMediaGroups.ts
@@ -32,11 +32,8 @@ export const useSubMediaGroups = (
   mediaTypes: IMediaTypeModel[],
 ): {
   subMediaGroups: ISubMediaGroupItem[];
-  mediaGroupExpanded: ISubMediaGroupExpanded;
-  setMediaGroupExpanded: (groupExpanded: ISubMediaGroupExpanded) => void;
 } => {
   const [subMediaGroups, setSubMediaGroups] = useState<ISubMediaGroupItem[]>([]);
-  const [mediaGroupExpanded, setMediaGroupExpanded] = useState<ISubMediaGroupExpanded>({});
 
   // Determine mediaTypeSourceLookup only when sources or mediaTypes change
   const mediaTypeSourceLookup = useMemo(() => {
@@ -146,12 +143,9 @@ export const useSubMediaGroups = (
     );
 
     setSubMediaGroups(subGroups.sort((a, b) => a.sortOrder - b.sortOrder));
-    setMediaGroupExpanded(expandedStates);
   }, [mediaTypeSeriesLookup, mediaTypeSourceLookup, mediaTypes, series, sources]);
 
   return {
     subMediaGroups,
-    mediaGroupExpanded,
-    setMediaGroupExpanded,
   };
 };

--- a/app/subscriber/src/features/hooks/useSubMediaGroups.ts
+++ b/app/subscriber/src/features/hooks/useSubMediaGroups.ts
@@ -1,7 +1,4 @@
-import {
-  ISubMediaGroupExpanded,
-  ISubMediaGroupItem,
-} from 'features/search-page/components/advanced-search/interfaces';
+import { ISubMediaGroupItem } from 'features/search-page/components/advanced-search/interfaces';
 import { IGroupOption } from 'features/search-page/components/advanced-search/interfaces/IGroupOption';
 import { useEffect, useMemo, useState } from 'react';
 import { IMediaTypeModel, ISeriesModel, ISourceModel, ListOptionName } from 'tno-core';

--- a/app/subscriber/src/features/search-page/components/advanced-search/components/sections/MediaSection.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/components/sections/MediaSection.tsx
@@ -15,6 +15,7 @@ import {
   Show,
 } from 'tno-core';
 
+import { ISubMediaGroupExpanded } from '../../interfaces';
 import { IFilterDisplayProps } from './IFilterDisplayProps';
 import { determineSelectedMedia, sortableMediaOptions } from './utils';
 
@@ -31,11 +32,8 @@ export const MediaSection: React.FC<IMediaSectionProps> = ({
   series,
   mediaTypes,
 }) => {
-  const { subMediaGroups, setMediaGroupExpanded, mediaGroupExpanded } = useSubMediaGroups(
-    sources,
-    series,
-    mediaTypes,
-  );
+  const { subMediaGroups } = useSubMediaGroups(sources, series, mediaTypes);
+  const [mediaGroupExpanded, setMediaGroupExpanded] = React.useState<ISubMediaGroupExpanded>({});
 
   const [
     {
@@ -71,12 +69,12 @@ export const MediaSection: React.FC<IMediaSectionProps> = ({
             ) : (
               <IoIosArrowDropdownCircle
                 className="drop-icon"
-                onClick={() =>
+                onClick={() => {
                   setMediaGroupExpanded({
                     ...mediaGroupExpanded,
                     [mediaGroup.key]: false,
-                  })
-                }
+                  });
+                }}
               />
             )}
           </Row>


### PR DESCRIPTION
That was an annoying one to debug.

Bug fix for:

- previously when you clicked "Media source" in the advanced search you could not select more than one option without the menu collapsing
- state was being reset as it was not being maintained properly in a hook
- moved state to the component as it should be