### PR TITLE
Fix- Userinfo Bad Request

### DIFF
--- a/api/net/Models/Auth/LocationModel.cs
+++ b/api/net/Models/Auth/LocationModel.cs
@@ -37,17 +37,17 @@ public class LocationModel
     /// <summary>
     /// get/set -
     /// </summary>
-    public string City { get; set; } = "";
+    public string? City { get; set; } = "";
 
     /// <summary>
     /// get/set -
     /// </summary>
-    public string State { get; set; } = "";
+    public string? State { get; set; } = "";
 
     /// <summary>
     /// get/set -
     /// </summary>
-    public string Postal { get; set; } = "";
+    public string? Postal { get; set; } = "";
 
     /// <summary>
     /// get/set -


### PR DESCRIPTION
Error occurs when city, postal and state fields are null, getting `400 - Bad Request` error:
<img width="890" alt="image" src="https://github.com/bcgov/tno/assets/10526131/03e9736c-9257-4cb2-adcc-0a75f99c02e5">

The location is obtained from `https://geolocation-db.com/json/` with null values for the mentioned fields.

The endpoint `auth/userinfo` is defining the location as optional. However, if the location object exists, all fields are required. With this change we are modifying the fields with null value as optional.


