### PR TITLE
TNO-2578  Add createUrl function for generating URLs with query param

### DIFF
--- a/app/editor/src/components/tab-control/hooks/useTab.tsx
+++ b/app/editor/src/components/tab-control/hooks/useTab.tsx
@@ -1,49 +1,18 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useApp } from 'store/hooks';
+import { toQueryString } from 'tno-core';
 
 import { NavigateOptions } from '../constants';
 
 /** This is a singleton */
 let _window: Window | null = null;
 
-/**
- * Interface representing URL parameters.
- */
-export interface IUrlParams {
-  [key: string]: string | number | boolean | undefined;
-}
-
 export interface ITabProps {
   /** Override the default open tab option */
   open?: NavigateOptions;
   /** When opening a new tab should the navbar be visible? */
   showNav?: boolean;
-}
-
-/**
- * Creates a URL with query parameters based on the provided path, id, and params.
- * @param path - The base path for the URL.
- * @param id - The ID to append to the path.
- * @param params - An object containing the query parameters.
- * @returns The generated URL with query parameters.
- */
-export function createUrl(path: string, id: number, params: IUrlParams) {
-  let url = `${path}/${id}`;
-  const queryParams = [];
-
-  // Add query parameters to the URL
-  for (const [key, value] of Object.entries(params)) {
-    if (value !== undefined) {
-      queryParams.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`);
-    }
-  }
-
-  if (queryParams.length > 0) {
-    url += `?${queryParams.join('&')}`;
-  }
-
-  return url;
 }
 
 /**
@@ -64,7 +33,13 @@ export const useTab = (props?: ITabProps) => {
 
   const navigateTab = React.useCallback(
     (id: number, path: string = '/contents', open?: NavigateOptions) => {
-      const url = createUrl(path, id, { showNav: values?.showNav });
+      const urlParams = { showNav: values?.showNav };
+      const queryString = toQueryString(urlParams, {
+        includeUndefined: false,
+        includeEmpty: false,
+      });
+
+      const url = `${path}/${id}?${queryString}`;
       const nav = open ?? values?.open ?? NavigateOptions.NewTab;
       if (nav === NavigateOptions.NewTab) {
         window.open(url, '_blank');

--- a/app/editor/src/components/tab-control/hooks/useTab.tsx
+++ b/app/editor/src/components/tab-control/hooks/useTab.tsx
@@ -7,11 +7,43 @@ import { NavigateOptions } from '../constants';
 /** This is a singleton */
 let _window: Window | null = null;
 
+/**
+ * Interface representing URL parameters.
+ */
+export interface IUrlParams {
+  [key: string]: string | number | boolean | undefined;
+}
+
 export interface ITabProps {
   /** Override the default open tab option */
   open?: NavigateOptions;
   /** When opening a new tab should the navbar be visible? */
   showNav?: boolean;
+}
+
+/**
+ * Creates a URL with query parameters based on the provided path, id, and params.
+ * @param path - The base path for the URL.
+ * @param id - The ID to append to the path.
+ * @param params - An object containing the query parameters.
+ * @returns The generated URL with query parameters.
+ */
+export function createUrl(path: string, id: number, params: IUrlParams) {
+  let url = `${path}/${id}`;
+  const queryParams = [];
+
+  // Add query parameters to the URL
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) {
+      queryParams.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`);
+    }
+  }
+
+  if (queryParams.length > 0) {
+    url += `?${queryParams.join('&')}`;
+  }
+
+  return url;
 }
 
 /**
@@ -32,7 +64,7 @@ export const useTab = (props?: ITabProps) => {
 
   const navigateTab = React.useCallback(
     (id: number, path: string = '/contents', open?: NavigateOptions) => {
-      const url = `${path}/${id}${values?.showNav ? `?showNav=${values.showNav}` : ''}`;
+      const url = createUrl(path, id, { showNav: values?.showNav });
       const nav = open ?? values?.open ?? NavigateOptions.NewTab;
       if (nav === NavigateOptions.NewTab) {
         window.open(url, '_blank');


### PR DESCRIPTION
In the old code, 
```
const url = `${path}/${id}${values?.showNav ? `?showNav=${values.showNav}` : ''}`;
```

Because we pass a `false` value to `showNav`, it's best not to rely on concise conditional statements, otherwise, the subsequent logic will never execute as we want, to prevent it, let's use a function in its place.
