### PR TITLE
Add option to toggle title case for byline in ContentForm

### DIFF
--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -118,6 +118,7 @@ const ContentForm: React.FC<IContentFormProps> = ({
   const [cursorStyle, setCursorStyle] = React.useState('text');
   const [savePressed, setSavePressed] = React.useState(false);
   const [parsedTags, setParsedTags] = React.useState<string[]>([]);
+  const [useTitleCase, setUseTitleCase] = React.useState(true);
 
   const [seriesOptions, setSeriesOptions] = React.useState<IOptionItem[]>([]);
   const [seriesOtherOptions, setSeriesOtherOptions] = React.useState<IOptionItem[]>([]);
@@ -274,14 +275,29 @@ const ContentForm: React.FC<IContentFormProps> = ({
                       </Show>
                       <Show visible={props.values.contentType === ContentTypeName.PrintContent}>
                         <Row>
-                          <FormikText
-                            name="byline"
-                            label="Byline"
-                            width="50ch"
-                            onChange={(e) => {
-                              props.setFieldValue('byline', toTitleCase(e.target.value));
-                            }}
-                          />
+                          <Row alignItems="center">
+                            <FormikText
+                              name="byline"
+                              label="Byline"
+                              width="50ch"
+                              onChange={(e) => {
+                                if (useTitleCase) {
+                                  props.setFieldValue('byline', toTitleCase(e.target.value));
+                                } else {
+                                  props.setFieldValue('byline', e.target.value);
+                                }
+                              }}
+                            />
+                            <Checkbox
+                              label="Title Case"
+                              name="useTitleCase"
+                              checked={useTitleCase}
+                              onChange={(e) => {
+                                setUseTitleCase(e.target.checked);
+                              }}
+                              className="checkbox-byline"
+                            />
+                          </Row>
                           <FormikSelect
                             name="contributorId"
                             value={
@@ -305,13 +321,28 @@ const ContentForm: React.FC<IContentFormProps> = ({
                         }
                       >
                         <Row>
-                          <FormikText
-                            name="byline"
-                            label="Byline"
-                            onChange={(e) => {
-                              props.setFieldValue('byline', toTitleCase(e.target.value));
-                            }}
-                          />
+                          <Row alignItems="center">
+                            <FormikText
+                              name="byline"
+                              label="Byline"
+                              onChange={(e) => {
+                                if (useTitleCase) {
+                                  props.setFieldValue('byline', toTitleCase(e.target.value));
+                                } else {
+                                  props.setFieldValue('byline', e.target.value);
+                                }
+                              }}
+                            />
+                            <Checkbox
+                              label="Title Case"
+                              name="useTitleCase"
+                              checked={useTitleCase}
+                              onChange={(e) => {
+                                setUseTitleCase(e.target.checked);
+                              }}
+                              className="checkbox-byline"
+                            />
+                          </Row>
                           <FormikSelect
                             name="contributorId"
                             value={

--- a/app/editor/src/features/content/form/styled/ContentForm.tsx
+++ b/app/editor/src/features/content/form/styled/ContentForm.tsx
@@ -71,6 +71,9 @@ export const ContentForm = styled.div`
       max-height: 12em;
     }
   }
+  .checkbox-byline {
+    padding-right: 0.5em;
+  }
 
   .content-properties {
     flex-grow: 1;


### PR DESCRIPTION
check available next to byline, default is turn on, and able to input all uppercase value.

![image](https://github.com/bcgov/tno/assets/35620699/79e0f611-d1c5-4bea-970f-ab209d2c0019)

![image](https://github.com/bcgov/tno/assets/35620699/5e6006d9-ef63-4457-8c8c-dad4bd5dcd81)
