### PR TITLE
TNO-2575: Add serach bar to /mysearches

### DIFF
--- a/app/subscriber/src/components/header/Header.tsx
+++ b/app/subscriber/src/components/header/Header.tsx
@@ -45,7 +45,7 @@ export const Header: React.FC<IHeaderProps> = ({
         )}
         {children}
       </Row>
-      <Show visible={!window.location.pathname.includes('search') && !!width && width > 900}>
+      <Show visible={!window.location.pathname.includes('/search') && !!width && width > 900}>
         <BasicSearch inHeader />
       </Show>
       {showProfile && <UserProfile />}


### PR DESCRIPTION
Throwing up a small one as I am fighting some state bugs on folders

Small bug that was removing the basic search from the `/mysearches` page.

![image](https://github.com/bcgov/tno/assets/15724124/f19fb601-3d52-421a-b5fa-190c45d3f990)
