### PR TITLE
New popout on same page for A/V content

### DIFF
--- a/app/subscriber/src/components/content-list/ContentList.tsx
+++ b/app/subscriber/src/components/content-list/ContentList.tsx
@@ -102,8 +102,6 @@ export const ContentList: React.FC<IContentListProps> = ({
     return settings.find((setting) => setting.name === Settings.SearchPageResultsNewWindow)?.value;
   }, [settings]);
 
-  console.log(popOutIds);
-
   return (
     <styled.ContentList scrollWithin={scrollWithin}>
       <Show visible={!handleDrop}>

--- a/app/subscriber/src/components/content-list/ContentList.tsx
+++ b/app/subscriber/src/components/content-list/ContentList.tsx
@@ -37,7 +37,6 @@ export const ContentList: React.FC<IContentListProps> = ({
   content,
   onContentSelected,
   selected,
-  styleOnSettings = false,
   showDate = false,
   handleDrop,
   scrollWithin = false,
@@ -103,6 +102,8 @@ export const ContentList: React.FC<IContentListProps> = ({
     return settings.find((setting) => setting.name === Settings.SearchPageResultsNewWindow)?.value;
   }, [settings]);
 
+  console.log(popOutIds);
+
   return (
     <styled.ContentList scrollWithin={scrollWithin}>
       <Show visible={!handleDrop}>
@@ -121,7 +122,6 @@ export const ContentList: React.FC<IContentListProps> = ({
                   showSeries={showSeries}
                   showDate={showDate}
                   showTime={showTime}
-                  styleOnSettings={styleOnSettings}
                   item={item}
                   onCheckboxChange={handleCheckboxChange}
                 />
@@ -152,7 +152,6 @@ export const ContentList: React.FC<IContentListProps> = ({
                           }`}
                           popOutIds={popOutIds}
                           showDate={showDate}
-                          styleOnSettings={styleOnSettings}
                           onClick={(e) => {
                             // Ensure the target is an Element and use .closest to check if the click was inside a checkbox (see comment below)
                             if (!(e.target instanceof Element) || !e.target.closest('.checkbox')) {

--- a/app/subscriber/src/components/content-list/ContentRow.tsx
+++ b/app/subscriber/src/components/content-list/ContentRow.tsx
@@ -81,7 +81,11 @@ export const ContentRow: React.FC<IContentRowProps> = ({
             className={`new-tab ${!item.section && 'no-section'}`}
             onClick={(e) => {
               e.stopPropagation();
-              window.open(`/view/${item.id}`, '_blank');
+              window.open(
+                `/view/${item.id}`,
+                '_blank',
+                'toolbar=yes,scrollbars=yes,resizable=yes,top=500,left=600,width=600,height=465',
+              );
             }}
           />
         </Show>

--- a/app/subscriber/src/components/content-list/ContentRow.tsx
+++ b/app/subscriber/src/components/content-list/ContentRow.tsx
@@ -18,7 +18,6 @@ export interface IContentRowProps extends IColProps {
   canDrag?: boolean;
   showDate?: boolean;
   popOutIds?: string;
-  styleOnSettings?: boolean;
   showSeries?: boolean;
   showTime?: boolean;
 }
@@ -27,7 +26,6 @@ export const ContentRow: React.FC<IContentRowProps> = ({
   selected,
   item,
   onCheckboxChange,
-  styleOnSettings,
   canDrag,
   showDate,
   showSeries,
@@ -78,7 +76,7 @@ export const ContentRow: React.FC<IContentRowProps> = ({
         <Show visible={showSeries}>
           {item.series && <div className="series">{item.series.name}</div>}
         </Show>
-        <Show visible={styleOnSettings && popOutIds?.includes(String(item.mediaTypeId))}>
+        <Show visible={popOutIds?.includes(String(item.mediaTypeId))}>
           <FaSquareUpRight
             className={`new-tab ${!item.section && 'no-section'}`}
             onClick={(e) => {

--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -164,7 +164,6 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
               content={content}
               selected={selected}
               showDate
-              styleOnSettings
               scrollWithin
             />
             {isLoading && <Loading />}


### PR DESCRIPTION
Before we only had this semi applied to the search results, but as this is desired across the site, I have removed the prop and made it the default.

In settings the admin may define what pieces of content will have this pop out option.

![image](https://github.com/bcgov/tno/assets/15724124/5d232ef9-9d3b-4926-9479-95007d011828)


