### PR TITLE
TNO-2658: Sort Saved Searches in Alphanumeric Order

### DIFF
--- a/app/subscriber/src/store/hooks/subscriber/useFilters.ts
+++ b/app/subscriber/src/store/hooks/subscriber/useFilters.ts
@@ -40,7 +40,11 @@ export const useFilters = (): [IProfileState, IFilterController] => {
       },
       addFilter: async (model: IFilterModel) => {
         const response = await dispatch<IFilterModel>('add-filter', () => api.addFilter(model));
-        store.storeMyFilters((filters) => [...filters, response.data]);
+        store.storeMyFilters((filters) => {
+          const updatedFilters = [...filters, response.data];
+          updatedFilters.sort((a, b) => a.name.localeCompare(b.name));
+          return updatedFilters;
+        });
         store.storeFilter((state) => (state?.id === model.id ? response.data : state));
         return response.data;
       },

--- a/libs/net/dal/Services/FilterService.cs
+++ b/libs/net/dal/Services/FilterService.cs
@@ -36,6 +36,7 @@ public class FilterService : BaseService<Filter, int>, IFilterService
     {
         return this.Context.Filters
             .Where(f => f.OwnerId == userId)
+            .OrderBy(a => a.Name)
             .ToArray();
     }
     #endregion


### PR DESCRIPTION
Sorting in backend used when loading `MySearches` subscriber for the first time.
Sorting in `useFilters` to sort the filters by name after saving a new search.

![image](https://github.com/bcgov/tno/assets/10526131/6a492f39-0977-415c-be55-63412be94222)




