### PR TITLE
TNO-2571 setting to prevet ininite loop of creating new lines 

### DIFF
--- a/libs/npm/core/src/components/form/wysiwyg/Wysiwyg.tsx
+++ b/libs/npm/core/src/components/form/wysiwyg/Wysiwyg.tsx
@@ -133,9 +133,18 @@ export const Wysiwyg: React.FC<IWysiwygProps> = ({
   };
 
   const modules = React.useMemo(() => {
+    // toolbar configuration
+    // https://quilljs.com/docs/modules/toolbar/
+    // why we have matchVisual: false:
+    // it will prevent the editor reate clicked bullet list button in full screen modal.
+    // There is a bug in quilljs 2.0, in this situation, it will create a new line after refresh,
+    // and it will inpact useEffect related to value change, and it causes infinite loop to create a new line.
     const config = {
       toolbar: {
         container: toolBarNode,
+      },
+      clipboard: {
+        matchVisual: false,
       },
     };
 


### PR DESCRIPTION
This is a known [bug](https://github.com/zenoamaro/react-quill/issues/935), and although the official documentation says that this setting has been REMOVED, apparently It helps us in v2.0.2
<img width="695" alt="image" src="https://github.com/bcgov/tno/assets/35620699/12bbe0ac-5be3-445e-bfed-1694a9da5cb7">
https://quilljs.com/docs/upgrading-to-2-0#configuration

Test like this: in the editor, select one of the contents to go to the rich text editor,  click the pop-out button, and select a row that is not the first row, then click the bullet-list button. On the dev server, the editor will keep creating new lines. If you pack tno-core locally, this should be avoided.