### PR TITLE
TNO-2620 Update width fix the year text cut in firefox

### DIFF
--- a/app/subscriber/src/components/date-filter/styled/DateFilter.tsx
+++ b/app/subscriber/src/components/date-filter/styled/DateFilter.tsx
@@ -28,12 +28,12 @@ export const DateFilter = styled(Row)`
       &:focus {
         outline: none;
       }
-      max-width: 6.5em;
+      max-width: 6.8em;
       font-weight: bold;
       background-color: transparent;
       border: none;
     }
-    max-width: 6.5em;
+    max-width: 6.8em;
   }
 
   .react-datepicker__day--keyboard-selected,


### PR DESCRIPTION
<img width="316" alt="image" src="https://github.com/bcgov/tno/assets/35620699/701f3e5a-18ee-429b-9d5e-46d91e66a37d">

quick fix for firfox browser 