### PR TITLE
TNO-2673 Remove headline line breaks to generate configuration

### DIFF
--- a/api/net/Areas/Helpers/WorkOrderHelper.cs
+++ b/api/net/Areas/Helpers/WorkOrderHelper.cs
@@ -162,7 +162,7 @@ public class WorkOrderHelper : IWorkOrderHelper
 
         if (force || !workOrders.Any(o => o.WorkType == Entities.WorkOrderType.Transcription || !WorkLimiterStatus.Contains(o.Status)))
         {
-            var headlineString = $"{{ \"headline\": \"{this.Content.Headline}\" }}";
+            var headlineString = $"{{ \"headline\": \"{this.Content.Headline.Replace("\n", "")}\" }}";
             var configuration = JsonDocument.Parse(headlineString);
             var workOrder = _workOrderService.AddAndSave(
                 new Entities.WorkOrder(

--- a/libs/net/entities/WorkOrder.cs
+++ b/libs/net/entities/WorkOrder.cs
@@ -176,7 +176,7 @@ public class WorkOrder : AuditColumns
     /// <param name="contentId"></param>
     /// <param name="headline"></param>
     public WorkOrder(WorkOrderType type, string description, long contentId, string headline)
-        : this(type, description, $"{{ \"headline\": \"{headline}\" }}")
+        : this(type, description, $"{{ \"headline\": \"{headline.Replace("\n", "")}\" }}")
     {
         this.ContentId = contentId;
     }


### PR DESCRIPTION
When a transcript is requested and there is a line break on headline, the Json parser throws an exception while generating the work order configuration field.
So just to generate the configuration, all line breaks are stripped from the headline.