### PR TITLE
TNO-2652 Retrieve events and schedule on load folders

### DIFF
--- a/app/subscriber/src/features/my-folders/ConfigureFolder.tsx
+++ b/app/subscriber/src/features/my-folders/ConfigureFolder.tsx
@@ -78,7 +78,7 @@ export const ConfigureFolder: React.FC<IConfigureFolderProps> = () => {
   React.useEffect(() => {
     if (init && ((!currentFolder && id) || currentFolder?.id !== Number(id))) {
       setInit(false);
-      getFolder(Number(id), false)
+      getFolder(Number(id), true)
         .then((folder) => {
           setCurrentFolder(folder);
           if (folder.filterId) {

--- a/app/subscriber/src/features/my-folders/ConfigureFolder.tsx
+++ b/app/subscriber/src/features/my-folders/ConfigureFolder.tsx
@@ -180,7 +180,7 @@ export const ConfigureFolder: React.FC<IConfigureFolderProps> = () => {
           <Checkbox
             name="auto-pop"
             label="Auto-populate this folder"
-            checked={currentFolder?.settings.autoPopulate}
+            checked={currentFolder?.settings.autoPopulate ?? false}
             onChange={(e) => {
               setCurrentFolder({
                 ...currentFolder,

--- a/libs/net/dal/Services/FolderService.cs
+++ b/libs/net/dal/Services/FolderService.cs
@@ -51,6 +51,7 @@ public class FolderService : BaseService<Folder, int>, IFolderService
         return this.Context.Folders
             .Include(f => f.Owner)
             .Include(f => f.ContentManyToMany)
+            .Include(f => f.Events).ThenInclude(f => f.Schedule)
             .Where(f => f.OwnerId == userId)
             .OrderBy(a => a.SortOrder).ThenBy(a => a.Name).ToArray();
     }

--- a/libs/net/dal/Services/FolderService.cs
+++ b/libs/net/dal/Services/FolderService.cs
@@ -51,6 +51,7 @@ public class FolderService : BaseService<Folder, int>, IFolderService
         return this.Context.Folders
             .Include(f => f.Owner)
             .Include(f => f.ContentManyToMany)
+            .Include(f => f.Filter)
             .Include(f => f.Events).ThenInclude(f => f.Schedule)
             .Where(f => f.OwnerId == userId)
             .OrderBy(a => a.SortOrder).ThenBy(a => a.Name).ToArray();


### PR DESCRIPTION
At the initial load, events and schedule were not loaded.
Which implied on toggle without saving, that the events were not displayed on screen, leading the user to think that was not being saved at all.
This guarantees that no matter on how it's loaded/saved/added, the UI is always accurate to the data.