### PR TITLE
TNO-2666: Search results move when clicking search

### DIFF
--- a/app/subscriber/src/components/content-list/ContentList.tsx
+++ b/app/subscriber/src/components/content-list/ContentList.tsx
@@ -106,7 +106,7 @@ export const ContentList: React.FC<IContentListProps> = ({
     <styled.ContentList scrollWithin={scrollWithin}>
       <Show visible={!handleDrop}>
         {Object.keys(grouped).map((group) => (
-          <div key={group}>
+          <div key={group} className="page-content">
             <h2 className="group-title">{group}</h2>
             <div>
               {grouped[group].map((item) => (

--- a/app/subscriber/src/components/section/styled/PageSection.tsx
+++ b/app/subscriber/src/components/section/styled/PageSection.tsx
@@ -33,14 +33,18 @@ export const PageSection = styled.div<{ $ignoreMinWidth?: boolean; $ignoreLastCh
     max-height: 26px;
   }
 
-  ${(props) =>
-    !props.$ignoreLastChildGap &&
-    `
-  > div:last-child {
+  .page-content {
     display: flex;
     flex-direction: column;
     padding: 1rem;
     gap: 0.25rem;
+  }
+
+  ${(props) =>
+    !props.$ignoreLastChildGap &&
+    `
+  > div:last-child {
+    @extend .page-content;
   }
 
   `}


### PR DESCRIPTION
When user clicks the search results are missing 1rem padding in Page Content:
https://github.com/bcgov/tno/assets/10526131/29c35911-c825-4d61-80d0-e2cb6ad61011

Applied padding for all children:
https://github.com/bcgov/tno/assets/10526131/757b033a-25f3-424d-aed8-eca49983814c


Story: https://apps.itsm.gov.bc.ca/jira/browse/TNO-2664


