### PR TITLE
TNO-2671 [Fix]:  Saved changes in search && Create new search

### DIFF
--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -54,9 +54,11 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
   const { expanded } = useSearchPageContext();
   const [init, setInit] = React.useState(true); // React hooks are horrible...
 
-  const filterId = id ? parseInt(id) : 0;
+  const [filterId, setFilterId] = React.useState(0);
 
   React.useEffect(() => {
+    const parsedId = id ? parseInt(id) : 0;
+    setFilterId(parsedId);
     // Fetch the active filter if required.
     if (filterId && init && activeFilter?.id !== filterId) {
       setInit(false);
@@ -69,7 +71,7 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
     } else if (!filterId) {
       storeFilter(undefined);
     }
-  }, [activeFilter, getFilter, filterId, init, storeFilter, storeSearchFilter]);
+  }, [activeFilter, getFilter, filterId, init, storeFilter, storeSearchFilter, id]);
 
   const fetchResults = React.useCallback(
     async (filter: MsearchMultisearchBody, searchUnpublished: boolean) => {

--- a/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
@@ -158,12 +158,13 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ onSearch }) => 
       await updateFilter(filter)
         .then((data) => {
           toast.success(`${data.name} has successfully been updated.`);
+          storeFilter(data);
           storeSearchFilter(data.settings);
           setInitialState(data.settings);
         })
         .catch(() => {});
     }
-  }, [search, genQuery, activeFilter, searchName, storeSearchFilter, updateFilter]);
+  }, [search, genQuery, activeFilter, searchName, updateFilter, storeFilter, storeSearchFilter]);
 
   const saveSearch = React.useCallback(async () => {
     const settings = filterFormat(search);


### PR DESCRIPTION
**Issue**
After saving a new record, subscriber is showing the previous content. However, the URL is correct (including the new id).

**Fix**
When saving a new record, the navigation goes to `/search/advanced/${data.id}` which finds an existing route which redirects to `SearchPage` component.  Because the `SearchPage` is already mounted React is not mounting again, so it is not updating the `id` param obtained by react-router-dom. As a result, the user is redirected to `/subscriber/filters/${id}` using `useApiSubscriberFilters` in order to obtain the last well-known value for _id_  embedded in the URL and because it is not updated then it is replacing the new content with the old one.

This change is to update the id before comparing its value.

