### PR TITLE
TNO-2623: Wrong number of items being added to reports

### DIFF
--- a/app/subscriber/src/components/content-list/ContentList.tsx
+++ b/app/subscriber/src/components/content-list/ContentList.tsx
@@ -54,9 +54,17 @@ export const ContentList: React.FC<IContentListProps> = ({
   React.useEffect(() => {
     if (!cacheCheck) return;
     const existing = localStorage.getItem('selected');
+    // remove selected items when user navigates away from page or refreshes, etc.
+    const handleBeforeUnload = () => {
+      localStorage.removeItem('selected');
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
     if (existing) {
       onContentSelected(JSON.parse(existing));
     }
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
     // only want to fire once
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
Had trouble reproducing this one but hopped on a call with Bobbi as she was able to.

The issue was:

- selected items were stored in cache even when closing the browser, if it was not visible on the page when the user next loads they will have no idea that other options are selected

Temporary solution: 

- clear cached items on refresh or session end

Eventually Bobbi suggested that we could have a selected items box, so we could keep items selected if the user navigates away but it would be apparent that there are previously selected items.

The `beforeunload` event will get called when the user refreshes or closes the app. 
