### PR TITLE
TNO-2623: Selected filter and results are not correlated when refreshing  

### DIFF
--- a/app/subscriber/src/components/media-type-filters/FilterOptions.tsx
+++ b/app/subscriber/src/components/media-type-filters/FilterOptions.tsx
@@ -65,6 +65,7 @@ export const FilterOptions: React.FC<IMediaTypeFiltersProps> = ({ filterStoreNam
     if (userInfo && !hasProcessedInitialPreference) {
       if (userInfo.preferences && userInfo.preferences.filterPreference) {
         setActive(userInfo.preferences.filterPreference);
+        handleFilterClick(userInfo.preferences.filterPreference);
       } else {
         setActive(FilterOptionTypes.All);
       }

--- a/app/subscriber/src/components/media-type-filters/FilterOptions.tsx
+++ b/app/subscriber/src/components/media-type-filters/FilterOptions.tsx
@@ -71,6 +71,8 @@ export const FilterOptions: React.FC<IMediaTypeFiltersProps> = ({ filterStoreNam
       }
       setHasProcessedInitialPreference(true);
     }
+    // only fire when userInfo and process complete
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userInfo, hasProcessedInitialPreference]);
 
   const [

--- a/app/subscriber/src/features/home/Home.tsx
+++ b/app/subscriber/src/features/home/Home.tsx
@@ -61,7 +61,7 @@ export const Home: React.FC = () => {
         ),
       );
     }
-  }, [filter, fetchResults, featuredStoryActionId]);
+  }, [filter, fetchResults, featuredStoryActionId, userInfo]);
 
   return (
     <styled.Home>

--- a/app/subscriber/src/features/home/Home.tsx
+++ b/app/subscriber/src/features/home/Home.tsx
@@ -7,7 +7,7 @@ import { createFilterSettings, getBooleanActionValue } from 'features/utils';
 import { IContentSearchResult } from 'features/utils/interfaces';
 import moment from 'moment';
 import React from 'react';
-import { useContent, useSettings } from 'store/hooks';
+import { useApp, useContent, useSettings } from 'store/hooks';
 import { generateQuery, IContentModel, Row } from 'tno-core';
 
 import * as styled from './styled';
@@ -22,6 +22,7 @@ export const Home: React.FC = () => {
     },
     { findContentWithElasticsearch, storeHomeFilter: storeFilter },
   ] = useContent();
+  const [{ userInfo }] = useApp();
 
   const [content, setContent] = React.useState<IContentSearchResult[]>([]);
   const [selected, setSelected] = React.useState<IContentModel[]>([]);
@@ -43,7 +44,8 @@ export const Home: React.FC = () => {
 
   React.useEffect(() => {
     // stops invalid requests before filter is synced with date
-    if (!!featuredStoryActionId) {
+    // wait for userinfo incase applying previously viewed filter
+    if (!!featuredStoryActionId && !!userInfo) {
       fetchResults(
         generateQuery(
           filterFormat({

--- a/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
+++ b/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
@@ -7,7 +7,7 @@ import { castToSearchResult } from 'features/utils';
 import { IContentSearchResult } from 'features/utils/interfaces';
 import moment from 'moment';
 import React from 'react';
-import { useContent, useSettings } from 'store/hooks';
+import { useApp, useContent, useSettings } from 'store/hooks';
 import { generateQuery, IContentModel } from 'tno-core';
 
 import * as styled from './styled';
@@ -22,6 +22,7 @@ export const TodaysCommentary: React.FC = () => {
   ] = useContent();
   const getActionFilters = useActionFilters();
   const { commentaryActionId } = useSettings();
+  const [{ userInfo }] = useApp();
 
   const [content, setContent] = React.useState<IContentSearchResult[]>([]);
   const [selected, setSelected] = React.useState<IContentModel[]>([]);
@@ -31,7 +32,7 @@ export const TodaysCommentary: React.FC = () => {
   }, []);
 
   React.useEffect(() => {
-    if (commentaryActionId) {
+    if (commentaryActionId && !!userInfo) {
       let actionFilters = getActionFilters();
       const commentaryAction = actionFilters.find((a) => a.id === commentaryActionId);
 

--- a/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
+++ b/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
@@ -59,7 +59,7 @@ export const TodaysCommentary: React.FC = () => {
         })
         .catch();
     }
-  }, [commentaryActionId, filter, findContentWithElasticsearch, getActionFilters]);
+  }, [commentaryActionId, filter, findContentWithElasticsearch, getActionFilters, userInfo]);
 
   return (
     <styled.TodaysCommentary>

--- a/app/subscriber/src/features/top-stories/TopStories.tsx
+++ b/app/subscriber/src/features/top-stories/TopStories.tsx
@@ -7,7 +7,7 @@ import { castToSearchResult } from 'features/utils';
 import { IContentSearchResult } from 'features/utils/interfaces';
 import moment from 'moment';
 import React from 'react';
-import { useContent, useSettings } from 'store/hooks';
+import { useApp, useContent, useSettings } from 'store/hooks';
 import { generateQuery, IContentModel } from 'tno-core';
 
 import * as styled from './styled';
@@ -22,13 +22,14 @@ export const TopStories: React.FC = () => {
   ] = useContent();
   const getActionFilters = useActionFilters();
   const { topStoryActionId, isReady } = useSettings();
+  const [{ userInfo }] = useApp();
 
   const [content, setContent] = React.useState<IContentSearchResult[]>([]);
   const [selected, setSelected] = React.useState<IContentModel[]>([]);
 
   React.useEffect(() => {
     // stops invalid requests before filter is synced with date
-    if (isReady) {
+    if (isReady && !!userInfo) {
       let actionFilters = getActionFilters();
       const topStoryAction = actionFilters.find((a) => a.id === topStoryActionId);
 

--- a/app/subscriber/src/features/top-stories/TopStories.tsx
+++ b/app/subscriber/src/features/top-stories/TopStories.tsx
@@ -52,7 +52,7 @@ export const TopStories: React.FC = () => {
         );
       });
     }
-  }, [filter, findContentWithElasticsearch, getActionFilters, isReady, topStoryActionId]);
+  }, [filter, findContentWithElasticsearch, getActionFilters, isReady, topStoryActionId, userInfo]);
 
   const handleContentSelected = React.useCallback((content: IContentModel[]) => {
     setSelected(content);


### PR DESCRIPTION
We were properly applying the `activeFilter` that controlled the active buttons, but not actually applying it to the filter. This would only be noticeable on refreshing the page.

This is now fixed, also ensured not to fetch the data until `userInfo` is present in order to avoid the screen briefly having the wrong results before being overridden.