### PR TITLE
TNO-2361: Transcription / Body Duplication Fix

### DIFF
--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -246,18 +246,20 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent }) =
         </Row>
       </Show>
       <Row id="summary" className="summary">
-        <Col>
-          {!!content?.body?.length ? (
-            <div>{parse(content?.body?.replace(/\n+/g, '<br><br>') ?? '')}</div>
-          ) : (
-            <span>{parse(content?.summary?.replace(/\n+/g, '<br><br>') ?? '')}</span>
-          )}
-          <Show visible={!!content?.sourceUrl}>
-            <a rel="noreferrer" target="_blank" href={content?.sourceUrl}>
-              More...
-            </a>
-          </Show>
-        </Col>
+        <Show visible={!(isAV && !!content.body && !isTranscribing)}>
+          <Col>
+            {!!content?.body?.length ? (
+              <div>{parse(content?.body?.replace(/\n+/g, '<br><br>') ?? '')}</div>
+            ) : (
+              <span>{parse(content?.summary?.replace(/\n+/g, '<br><br>') ?? '')}</span>
+            )}
+            <Show visible={!!content?.sourceUrl}>
+              <a rel="noreferrer" target="_blank" href={content?.sourceUrl}>
+                More...
+              </a>
+            </Show>
+          </Col>
+        </Show>
         <Show
           visible={
             isAV &&


### PR DESCRIPTION
Previously we would display identical text twice when a transcription was present.

Added simple logic to check if there is a transcription available, and if there is, skip the default summary section.

 See issue below.

![image](https://github.com/bcgov/tno/assets/15724124/155c0b83-fe56-40c9-a312-47601eb4b91b)

Now:
![image](https://github.com/bcgov/tno/assets/15724124/f5d2e8c5-2af8-4b3a-9b29-8d97c0140b43)

