### PR TITLE
Fix Notification Service

### DIFF
--- a/api/net/Config/ApiOptions.cs
+++ b/api/net/Config/ApiOptions.cs
@@ -15,5 +15,10 @@ public class ApiOptions
     /// get/set - The name of the settings key to identify the notification that will be use to send transcript confirmation emails.
     /// </summary>
     public string TranscriptRequestConfirmationKey { get; set; } = "";
+
+    /// <summary>
+    /// get/set - The service timezone. This is set in appsettings.json as 'Pacific Standard Time'.
+    /// </summary>
+    public string TimeZone { get; set; } = "UTC";
     #endregion
 }

--- a/api/net/appsettings.json
+++ b/api/net/appsettings.json
@@ -51,7 +51,8 @@
   },
   "API": {
     "DataLocation": "Openshift",
-    "TranscriptRequestConfirmationKey": "TranscriptRequestConfirmationId"
+    "TranscriptRequestConfirmationKey": "TranscriptRequestConfirmationId",
+    "TimeZone": "Pacific Standard Time"
   },
   "Storage": {
     "UploadPath": "/data",

--- a/services/net/folder-collection/FolderCollectionManager.cs
+++ b/services/net/folder-collection/FolderCollectionManager.cs
@@ -329,7 +329,7 @@ public class FolderCollectionManager : ServiceManager<FolderCollectionOptions>
             return false;
         }
 
-        var now = DateTime.Now.ToLocalTime();
+        var now = DateTime.Now.ToTimeZone(this.Options.TimeZone);
 
         if (!filter.Settings.SearchUnpublished && content.Status == Entities.ContentStatus.Draft)
         {
@@ -401,16 +401,16 @@ public class FolderCollectionManager : ServiceManager<FolderCollectionOptions>
             return false;
         }
 
-        var publishedOn = content.PublishedOn?.ToLocalTime();
+        var publishedOn = content.PublishedOn?.ToTimeZone(this.Options.TimeZone);
 
-        if (filter.Settings.StartDate != null && publishedOn < filter.Settings.StartDate)
+        if (filter.Settings.StartDate != null && publishedOn < filter.Settings.StartDate.Value.ToTimeZone(this.Options.TimeZone))
         {
             this.Logger.LogDebug("Content ID: {contentId}, Filter ID: {filterId}. Content.PublishedOn is {actual}, but the folder filter StartDate is {target}.",
-                content.Id, filter.Id, content.PublishedOn, filter.Settings.StartDate);
+                content.Id, filter.Id, content.PublishedOn, filter.Settings.StartDate.Value.ToTimeZone(this.Options.TimeZone));
             return false;
         }
 
-        if (filter.Settings.EndDate != null && publishedOn > filter.Settings.EndDate)
+        if (filter.Settings.EndDate != null && publishedOn > filter.Settings.EndDate.Value.ToTimeZone(this.Options.TimeZone))
         {
             this.Logger.LogDebug("Content ID: {contentId}, Filter ID: {filterId}. Content.PublishedOn is {actual}, but the folder filter EndDate is {target}.",
                 content.Id, filter.Id, content.PublishedOn, filter.Settings.EndDate);

--- a/services/net/notification/Validation/NotificationValidator.cs
+++ b/services/net/notification/Validation/NotificationValidator.cs
@@ -226,10 +226,10 @@ public class NotificationValidator : INotificationValidator
 
             ((!filter.StartDate.HasValue && !filter.EndDate.HasValue) ||
              (filter.StartDate.HasValue && filter.EndDate.HasValue &&
-              Content.PublishedOn >= filter.StartDate.Value.ToUniversalTime() &&
-              Content.PublishedOn <= filter.EndDate.Value.ToUniversalTime()) ||
-             (filter.StartDate.HasValue && Content.PublishedOn >= filter.StartDate.Value.ToUniversalTime()) ||
-             (filter.EndDate.HasValue && Content.PublishedOn <= filter.EndDate.Value.ToUniversalTime())) &&
+              Content.PublishedOn?.ToTimeZone(this.Options.TimeZone) >= filter.StartDate.Value.ToTimeZone(this.Options.TimeZone) &&
+              Content.PublishedOn?.ToTimeZone(this.Options.TimeZone) <= filter.EndDate.Value.ToTimeZone(this.Options.TimeZone)) ||
+             (filter.StartDate.HasValue && Content.PublishedOn?.ToTimeZone(this.Options.TimeZone) >= filter.StartDate.Value.ToTimeZone(this.Options.TimeZone)) ||
+             (filter.EndDate.HasValue && Content.PublishedOn?.ToTimeZone(this.Options.TimeZone) <= filter.EndDate.Value.ToTimeZone(this.Options.TimeZone))) &&
 
             (string.IsNullOrWhiteSpace(filter.OtherSource) || Content.OtherSource.ToLower() == filter.OtherSource.ToLower()) &&
             (string.IsNullOrWhiteSpace(filter.Page) || Content.Page.ToLower().Contains(filter.Page.ToLower())) &&


### PR DESCRIPTION
Updated date comparison code to use the same `ToTimeZone(...)` extension function in all services.  This should resolve the date filter issues on notifications.

![image](https://github.com/bcgov/tno/assets/3180256/0efad294-8a3b-4343-9a12-0bacf7b2ad9c)
