### PR TITLE
TNO-2667,2690: Update grouped by date display, and fix filter option sync issue

### DIFF
--- a/app/subscriber/src/components/content-list/ContentList.tsx
+++ b/app/subscriber/src/components/content-list/ContentList.tsx
@@ -114,7 +114,7 @@ export const ContentList: React.FC<IContentListProps> = ({
   }, [settings]);
 
   return (
-    <styled.ContentList scrollWithin={scrollWithin}>
+    <styled.ContentList className="content-list" scrollWithin={scrollWithin}>
       <Show visible={!handleDrop}>
         {Object.keys(grouped).map((group) => (
           <div key={group} className="grouped-content">

--- a/app/subscriber/src/components/content-list/utils/groupContent.ts
+++ b/app/subscriber/src/components/content-list/utils/groupContent.ts
@@ -39,38 +39,35 @@ export const groupContent = (groupBy: IGroupByState, content: IContentSearchResu
   const grouped = content
     .sort(sortFunc(firstSort))
     .sort(sortFunc(secondSort))
-    .reduce(
-      (acc, item) => {
-        let key = item.source?.name; // default to source
-        if (!item?.source?.name) {
-          key = item.otherSource;
-        }
-        switch (groupBy) {
-          case 'time':
-            const date = new Date(item.publishedOn);
-            const hours = date.getHours().toString().padStart(2, '0');
-            const minutes = date.getMinutes().toString().padStart(2, '0');
-            key = `${moment(date).format('DD-MMM-YYYY')} ${`(${hours}:${minutes})`}`;
-            break;
-          case 'source':
-            if (!item?.source?.name) {
-              key = item.otherSource;
-            } else {
-              const shortName =
-                item.source.shortName && item.source.shortName !== ''
-                  ? ` (${item.source.shortName})`
-                  : '';
-              key = `${item.source.name}${shortName}`;
-            }
-            break;
-        }
-        if (!acc[key]) {
-          acc[key] = [];
-        }
-        acc[key].push(item);
-        return acc;
-      },
-      {} as Record<string, IContentSearchResult[]>,
-    );
+    .reduce((acc, item) => {
+      let key = item.source?.name; // default to source
+      if (!item?.source?.name) {
+        key = item.otherSource;
+      }
+      switch (groupBy) {
+        case 'time':
+          const date = new Date(item.publishedOn);
+          const hours = date.getHours().toString().padStart(2, '0');
+          const minutes = date.getMinutes().toString().padStart(2, '0');
+          key = `${moment(date).format('DD-MMM-YYYY')} ${`(${hours}:${minutes})`}`;
+          break;
+        case 'source':
+          if (!item?.source?.name) {
+            key = item.otherSource;
+          } else {
+            const shortName =
+              item.source.shortName && item.source.shortName !== ''
+                ? ` (${item.source.shortName})`
+                : '';
+            key = `${item.source.name}${shortName}`;
+          }
+          break;
+      }
+      if (!acc[key]) {
+        acc[key] = [];
+      }
+      acc[key].push(item);
+      return acc;
+    }, {} as Record<string, IContentSearchResult[]>);
   return grouped;
 };

--- a/app/subscriber/src/components/content-list/utils/groupContent.ts
+++ b/app/subscriber/src/components/content-list/utils/groupContent.ts
@@ -1,5 +1,6 @@
 import { IContentSearchResult } from 'features/utils/interfaces';
 import moment from 'moment';
+import { ContentTypeName } from 'tno-core';
 
 import { IGroupByState } from '../interfaces';
 
@@ -49,7 +50,7 @@ export const groupContent = (groupBy: IGroupByState, content: IContentSearchResu
           const date = new Date(item.publishedOn);
           const hours = date.getHours().toString().padStart(2, '0');
           const minutes = date.getMinutes().toString().padStart(2, '0');
-          key = `${moment(date).format('DD/MM/YY')} (${hours}:${minutes})`;
+          key = `${moment(date).format('DD-MMM-YYYY')} ${`(${hours}:${minutes})`}`;
           break;
         case 'source':
           if (!item?.source?.name) {

--- a/app/subscriber/src/components/content-list/utils/groupContent.ts
+++ b/app/subscriber/src/components/content-list/utils/groupContent.ts
@@ -1,6 +1,5 @@
 import { IContentSearchResult } from 'features/utils/interfaces';
 import moment from 'moment';
-import { ContentTypeName } from 'tno-core';
 
 import { IGroupByState } from '../interfaces';
 
@@ -40,35 +39,38 @@ export const groupContent = (groupBy: IGroupByState, content: IContentSearchResu
   const grouped = content
     .sort(sortFunc(firstSort))
     .sort(sortFunc(secondSort))
-    .reduce((acc, item) => {
-      let key = item.source?.name; // default to source
-      if (!item?.source?.name) {
-        key = item.otherSource;
-      }
-      switch (groupBy) {
-        case 'time':
-          const date = new Date(item.publishedOn);
-          const hours = date.getHours().toString().padStart(2, '0');
-          const minutes = date.getMinutes().toString().padStart(2, '0');
-          key = `${moment(date).format('DD-MMM-YYYY')} ${`(${hours}:${minutes})`}`;
-          break;
-        case 'source':
-          if (!item?.source?.name) {
-            key = item.otherSource;
-          } else {
-            const shortName =
-              item.source.shortName && item.source.shortName !== ''
-                ? ` (${item.source.shortName})`
-                : '';
-            key = `${item.source.name}${shortName}`;
-          }
-          break;
-      }
-      if (!acc[key]) {
-        acc[key] = [];
-      }
-      acc[key].push(item);
-      return acc;
-    }, {} as Record<string, IContentSearchResult[]>);
+    .reduce(
+      (acc, item) => {
+        let key = item.source?.name; // default to source
+        if (!item?.source?.name) {
+          key = item.otherSource;
+        }
+        switch (groupBy) {
+          case 'time':
+            const date = new Date(item.publishedOn);
+            const hours = date.getHours().toString().padStart(2, '0');
+            const minutes = date.getMinutes().toString().padStart(2, '0');
+            key = `${moment(date).format('DD-MMM-YYYY')} ${`(${hours}:${minutes})`}`;
+            break;
+          case 'source':
+            if (!item?.source?.name) {
+              key = item.otherSource;
+            } else {
+              const shortName =
+                item.source.shortName && item.source.shortName !== ''
+                  ? ` (${item.source.shortName})`
+                  : '';
+              key = `${item.source.name}${shortName}`;
+            }
+            break;
+        }
+        if (!acc[key]) {
+          acc[key] = [];
+        }
+        acc[key].push(item);
+        return acc;
+      },
+      {} as Record<string, IContentSearchResult[]>,
+    );
   return grouped;
 };

--- a/app/subscriber/src/components/media-type-filters/FilterOptions.tsx
+++ b/app/subscriber/src/components/media-type-filters/FilterOptions.tsx
@@ -19,6 +19,7 @@ import {
 } from 'tno-core';
 
 import { defaultFilter, FilterOptionTypes } from './constants';
+import { useFilterOptionContext } from './FilterOptionsContextProvider';
 import * as styled from './styled';
 import { determineStore } from './utils';
 
@@ -41,10 +42,10 @@ export interface IMediaTypeFiltersProps {
  */
 export const FilterOptions: React.FC<IMediaTypeFiltersProps> = ({ filterStoreName }) => {
   const [{ userInfo }, store] = useAppStore();
-  const [active, setActive] = useState<FilterOptionTypes | undefined>(undefined);
   const filterStoreMethod = determineStore(filterStoreName);
   const api = useUsers();
   const [hasProcessedInitialPreference, setHasProcessedInitialPreference] = useState(false);
+  const { active, setActive } = useFilterOptionContext();
   const savePreferences = async (filterPreference: FilterOptionTypes) => {
     if (userInfo) {
       try {

--- a/app/subscriber/src/components/media-type-filters/FilterOptions.tsx
+++ b/app/subscriber/src/components/media-type-filters/FilterOptions.tsx
@@ -44,8 +44,9 @@ export const FilterOptions: React.FC<IMediaTypeFiltersProps> = ({ filterStoreNam
   const [{ userInfo }, store] = useAppStore();
   const filterStoreMethod = determineStore(filterStoreName);
   const api = useUsers();
-  const [hasProcessedInitialPreference, setHasProcessedInitialPreference] = useState(false);
-  const { active, setActive } = useFilterOptionContext();
+  const { hasProcessedInitialPreferences, setHasProcessedInitialPreferences } =
+    useFilterOptionContext();
+  const [active, setActive] = useState<FilterOptionTypes | undefined>(undefined);
   const savePreferences = async (filterPreference: FilterOptionTypes) => {
     if (userInfo) {
       try {
@@ -63,18 +64,18 @@ export const FilterOptions: React.FC<IMediaTypeFiltersProps> = ({ filterStoreNam
     // if the user has a preference set, set the active filter to that preference
     // otherwise set the active filter to all
     // then set hasProcessedInitialPreference to true which will prevent this from running again
-    if (userInfo && !hasProcessedInitialPreference) {
+    if (userInfo && !hasProcessedInitialPreferences) {
       if (userInfo.preferences && userInfo.preferences.filterPreference) {
         setActive(userInfo.preferences.filterPreference);
         handleFilterClick(userInfo.preferences.filterPreference);
       } else {
         setActive(FilterOptionTypes.All);
       }
-      setHasProcessedInitialPreference(true);
+      setHasProcessedInitialPreferences(true);
     }
     // only fire when userInfo and process complete
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userInfo, hasProcessedInitialPreference]);
+  }, [userInfo, hasProcessedInitialPreferences]);
 
   const [
     {
@@ -146,7 +147,7 @@ export const FilterOptions: React.FC<IMediaTypeFiltersProps> = ({ filterStoreNam
 
   useEffect(() => {
     // Initial Check: Ensure initial preferences have been processed before proceeding
-    if (hasProcessedInitialPreference) {
+    if (hasProcessedInitialPreferences) {
       if (!filter.contentTypes?.length && !filter.mediaTypeIds?.length) {
         setActive(FilterOptionTypes.All);
       } else if (

--- a/app/subscriber/src/components/media-type-filters/FilterOptionsContextProvider.tsx
+++ b/app/subscriber/src/components/media-type-filters/FilterOptionsContextProvider.tsx
@@ -1,10 +1,8 @@
 import React, { createContext, ReactNode, useContext, useState } from 'react';
 
-import { FilterOptionTypes } from './constants';
-
 interface IFilterOptionsContext {
-  active: FilterOptionTypes | undefined;
-  setActive: React.Dispatch<React.SetStateAction<FilterOptionTypes | undefined>>;
+  hasProcessedInitialPreferences: boolean;
+  setHasProcessedInitialPreferences: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const FilterOptionContext = createContext<IFilterOptionsContext | undefined>(undefined);
@@ -22,10 +20,13 @@ interface IFilterOptionsProvider {
 }
 
 export const FilterOptionsProvider: React.FC<IFilterOptionsProvider> = ({ children }) => {
-  const [active, setActive] = useState<FilterOptionTypes | undefined>(undefined);
+  const [hasProcessedInitialPreferences, setHasProcessedInitialPreferences] =
+    useState<boolean>(false);
 
   return (
-    <FilterOptionContext.Provider value={{ active, setActive }}>
+    <FilterOptionContext.Provider
+      value={{ hasProcessedInitialPreferences, setHasProcessedInitialPreferences }}
+    >
       {children}
     </FilterOptionContext.Provider>
   );

--- a/app/subscriber/src/components/media-type-filters/FilterOptionsContextProvider.tsx
+++ b/app/subscriber/src/components/media-type-filters/FilterOptionsContextProvider.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, ReactNode, useContext, useState } from 'react';
+
+import { FilterOptionTypes } from './constants';
+
+interface IFilterOptionsContext {
+  active: FilterOptionTypes | undefined;
+  setActive: React.Dispatch<React.SetStateAction<FilterOptionTypes | undefined>>;
+}
+
+const FilterOptionContext = createContext<IFilterOptionsContext | undefined>(undefined);
+
+export const useFilterOptionContext = (): IFilterOptionsContext => {
+  const context = useContext(FilterOptionContext);
+  if (!context) {
+    throw new Error('FilterOptionsContext must be used within a FilterOptionsProvider');
+  }
+  return context;
+};
+
+interface IFilterOptionsProvider {
+  children: ReactNode;
+}
+
+export const FilterOptionsProvider: React.FC<IFilterOptionsProvider> = ({ children }) => {
+  const [active, setActive] = useState<FilterOptionTypes | undefined>(undefined);
+
+  return (
+    <FilterOptionContext.Provider value={{ active, setActive }}>
+      {children}
+    </FilterOptionContext.Provider>
+  );
+};

--- a/app/subscriber/src/components/media-type-filters/index.ts
+++ b/app/subscriber/src/components/media-type-filters/index.ts
@@ -1,1 +1,2 @@
 export * from './FilterOptions';
+export * from './FilterOptionsContextProvider';

--- a/app/subscriber/src/features/home/Home.tsx
+++ b/app/subscriber/src/features/home/Home.tsx
@@ -23,8 +23,8 @@ export const Home: React.FC = () => {
     },
     { findContentWithElasticsearch, storeHomeFilter: storeFilter },
   ] = useContent();
-  const { active } = useFilterOptionContext();
 
+  const { hasProcessedInitialPreferences } = useFilterOptionContext();
   const [content, setContent] = React.useState<IContentSearchResult[]>([]);
   const [selected, setSelected] = React.useState<IContentModel[]>([]);
   const { featuredStoryActionId } = useSettings(true);
@@ -46,7 +46,7 @@ export const Home: React.FC = () => {
   React.useEffect(() => {
     // stops invalid requests before filter is synced with date
     // wait for userinfo incase applying previously viewed filter
-    if (!!featuredStoryActionId && !!active) {
+    if (!!featuredStoryActionId && hasProcessedInitialPreferences) {
       fetchResults(
         generateQuery(
           filterFormat({
@@ -62,7 +62,7 @@ export const Home: React.FC = () => {
         ),
       );
     }
-  }, [filter, fetchResults, featuredStoryActionId, active]);
+  }, [filter, fetchResults, featuredStoryActionId, hasProcessedInitialPreferences]);
 
   return (
     <styled.Home>

--- a/app/subscriber/src/features/home/Home.tsx
+++ b/app/subscriber/src/features/home/Home.tsx
@@ -1,13 +1,14 @@
 import { MsearchMultisearchBody } from '@elastic/elasticsearch/lib/api/types';
 import { ContentList } from 'components/content-list';
 import { DateFilter } from 'components/date-filter';
+import { useFilterOptionContext } from 'components/media-type-filters';
 import { ContentListActionBar } from 'components/tool-bar';
 import { filterFormat } from 'features/search-page/utils';
 import { createFilterSettings, getBooleanActionValue } from 'features/utils';
 import { IContentSearchResult } from 'features/utils/interfaces';
 import moment from 'moment';
 import React from 'react';
-import { useApp, useContent, useSettings } from 'store/hooks';
+import { useContent, useSettings } from 'store/hooks';
 import { generateQuery, IContentModel, Row } from 'tno-core';
 
 import * as styled from './styled';
@@ -22,7 +23,7 @@ export const Home: React.FC = () => {
     },
     { findContentWithElasticsearch, storeHomeFilter: storeFilter },
   ] = useContent();
-  const [{ userInfo }] = useApp();
+  const { active } = useFilterOptionContext();
 
   const [content, setContent] = React.useState<IContentSearchResult[]>([]);
   const [selected, setSelected] = React.useState<IContentModel[]>([]);
@@ -45,7 +46,7 @@ export const Home: React.FC = () => {
   React.useEffect(() => {
     // stops invalid requests before filter is synced with date
     // wait for userinfo incase applying previously viewed filter
-    if (!!featuredStoryActionId && !!userInfo) {
+    if (!!featuredStoryActionId && !!active) {
       fetchResults(
         generateQuery(
           filterFormat({
@@ -61,7 +62,7 @@ export const Home: React.FC = () => {
         ),
       );
     }
-  }, [filter, fetchResults, featuredStoryActionId, userInfo]);
+  }, [filter, fetchResults, featuredStoryActionId, active]);
 
   return (
     <styled.Home>

--- a/app/subscriber/src/features/landing/Landing.tsx
+++ b/app/subscriber/src/features/landing/Landing.tsx
@@ -1,5 +1,5 @@
 import { ViewOptions } from 'components/content-list';
-import { FilterOptions } from 'components/media-type-filters';
+import { FilterOptions, FilterOptionsProvider } from 'components/media-type-filters';
 import { INavbarOptionItem, NavbarOptions, navbarOptions } from 'components/navbar/NavbarItems';
 import { PageSection } from 'components/section';
 import { TopDomains } from 'components/top-domains';
@@ -40,77 +40,79 @@ export const Landing: React.FC = () => {
 
   return (
     <styled.Landing className="main-container">
-      <Row className="contents-container">
-        <PageSection
-          ignoreMinWidth
-          activeContent={activeContent}
-          header={
-            <>
-              <Show visible={!!activeItem}>
-                {activeItem?.icon && <div className="page-icon">{activeItem?.icon}</div>}
-                {activeItem === NavbarOptions.settings
-                  ? 'Settings | My Minister'
-                  : activeItem?.label}
+      <FilterOptionsProvider>
+        <Row className="contents-container">
+          <PageSection
+            ignoreMinWidth
+            activeContent={activeContent}
+            header={
+              <>
+                <Show visible={!!activeItem}>
+                  {activeItem?.icon && <div className="page-icon">{activeItem?.icon}</div>}
+                  {activeItem === NavbarOptions.settings
+                    ? 'Settings | My Minister'
+                    : activeItem?.label}
+                </Show>
+                {!!activeItem?.reduxFilterStore && (
+                  <>
+                    <FilterOptions filterStoreName={activeItem?.reduxFilterStore} />
+                    <ViewOptions />
+                  </>
+                )}
+              </>
+            }
+            className="main-panel"
+            includeContentActions={!activeItem}
+          >
+            <div className="content">
+              {/* Home is default selected navigation item on login*/}
+              <Show visible={activeItem === NavbarOptions.home}>
+                <Home />
               </Show>
-              {!!activeItem?.reduxFilterStore && (
-                <>
-                  <FilterOptions filterStoreName={activeItem?.reduxFilterStore} />
-                  <ViewOptions />
-                </>
-              )}
-            </>
-          }
-          className="main-panel"
-          includeContentActions={!activeItem}
-        >
-          <div className="content">
-            {/* Home is default selected navigation item on login*/}
-            <Show visible={activeItem === NavbarOptions.home}>
-              <Home />
-            </Show>
-            <Show visible={!activeItem}>
-              <ViewContent setActiveContent={setActiveContent} />
-            </Show>
-            <Show visible={activeItem === NavbarOptions.settings}>
-              <MyMinisterSettings />
-            </Show>
-            <Show visible={activeItem === NavbarOptions.myMinister}>
-              <MyMinister />
-            </Show>
-            <Show visible={activeItem === NavbarOptions.todaysCommentary}>
-              <TodaysCommentary />
-            </Show>
-            <Show visible={activeItem === NavbarOptions.todaysFrontPages}>
-              <TodaysFrontPages />
-            </Show>
-            <Show visible={activeItem === NavbarOptions.topStories}>
-              <TopStories />
-            </Show>
-            <Show visible={activeItem === NavbarOptions.myProducts}>
-              <MyProducts />
-            </Show>
-            <Show visible={activeItem === NavbarOptions.pressGallery}>
-              <PressGallery />
-            </Show>
-            <Show visible={activeItem === NavbarOptions.mySearches}>
-              <MySearches />
+              <Show visible={!activeItem}>
+                <ViewContent setActiveContent={setActiveContent} />
+              </Show>
+              <Show visible={activeItem === NavbarOptions.settings}>
+                <MyMinisterSettings />
+              </Show>
+              <Show visible={activeItem === NavbarOptions.myMinister}>
+                <MyMinister />
+              </Show>
+              <Show visible={activeItem === NavbarOptions.todaysCommentary}>
+                <TodaysCommentary />
+              </Show>
+              <Show visible={activeItem === NavbarOptions.todaysFrontPages}>
+                <TodaysFrontPages />
+              </Show>
+              <Show visible={activeItem === NavbarOptions.topStories}>
+                <TopStories />
+              </Show>
+              <Show visible={activeItem === NavbarOptions.myProducts}>
+                <MyProducts />
+              </Show>
+              <Show visible={activeItem === NavbarOptions.pressGallery}>
+                <PressGallery />
+              </Show>
+              <Show visible={activeItem === NavbarOptions.mySearches}>
+                <MySearches />
+              </Show>
+              <Show visible={activeItem === NavbarOptions.eveningOverview}>
+                <AVOverviewPreview />
+              </Show>
+            </div>
+          </PageSection>
+          {/* unsure of whether these items will change depending on selected item */}
+          <Col className="right-panel">
+            <Show visible={activeItem !== NavbarOptions.eveningOverview}>
+              <Commentary />
+              <TopDomains />
             </Show>
             <Show visible={activeItem === NavbarOptions.eveningOverview}>
-              <AVOverviewPreview />
+              <MediaOverviewIcons />
             </Show>
-          </div>
-        </PageSection>
-        {/* unsure of whether these items will change depending on selected item */}
-        <Col className="right-panel">
-          <Show visible={activeItem !== NavbarOptions.eveningOverview}>
-            <Commentary />
-            <TopDomains />
-          </Show>
-          <Show visible={activeItem === NavbarOptions.eveningOverview}>
-            <MediaOverviewIcons />
-          </Show>
-        </Col>
-      </Row>
+          </Col>
+        </Row>
+      </FilterOptionsProvider>
     </styled.Landing>
   );
 };

--- a/app/subscriber/src/features/search-page/styled/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/styled/SearchPage.tsx
@@ -1,6 +1,9 @@
 import styled from 'styled-components';
 
 export const SearchPage = styled.div<{ expanded: boolean }>`
+  .content-list {
+    padding: 0 1em 0 1em;
+  }
   .divider {
     margin-left: 0.5em;
     margin-right: 0.5em;

--- a/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
+++ b/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
@@ -1,5 +1,6 @@
 import { ContentList } from 'components/content-list';
 import { DateFilter } from 'components/date-filter';
+import { useFilterOptionContext } from 'components/media-type-filters';
 import { ContentListActionBar } from 'components/tool-bar';
 import { useActionFilters } from 'features/search-page/hooks';
 import { filterFormat } from 'features/search-page/utils';
@@ -7,7 +8,7 @@ import { castToSearchResult } from 'features/utils';
 import { IContentSearchResult } from 'features/utils/interfaces';
 import moment from 'moment';
 import React from 'react';
-import { useApp, useContent, useSettings } from 'store/hooks';
+import { useContent, useSettings } from 'store/hooks';
 import { generateQuery, IContentModel } from 'tno-core';
 
 import * as styled from './styled';
@@ -22,8 +23,7 @@ export const TodaysCommentary: React.FC = () => {
   ] = useContent();
   const getActionFilters = useActionFilters();
   const { commentaryActionId } = useSettings();
-  const [{ userInfo }] = useApp();
-
+  const { active } = useFilterOptionContext();
   const [content, setContent] = React.useState<IContentSearchResult[]>([]);
   const [selected, setSelected] = React.useState<IContentModel[]>([]);
 
@@ -32,7 +32,7 @@ export const TodaysCommentary: React.FC = () => {
   }, []);
 
   React.useEffect(() => {
-    if (commentaryActionId && !!userInfo) {
+    if (commentaryActionId && !!active) {
       let actionFilters = getActionFilters();
       const commentaryAction = actionFilters.find((a) => a.id === commentaryActionId);
 
@@ -59,7 +59,7 @@ export const TodaysCommentary: React.FC = () => {
         })
         .catch();
     }
-  }, [commentaryActionId, filter, findContentWithElasticsearch, getActionFilters, userInfo]);
+  }, [commentaryActionId, filter, findContentWithElasticsearch, getActionFilters, active]);
 
   return (
     <styled.TodaysCommentary>

--- a/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
+++ b/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
@@ -23,7 +23,7 @@ export const TodaysCommentary: React.FC = () => {
   ] = useContent();
   const getActionFilters = useActionFilters();
   const { commentaryActionId } = useSettings();
-  const { active } = useFilterOptionContext();
+  const { hasProcessedInitialPreferences } = useFilterOptionContext();
   const [content, setContent] = React.useState<IContentSearchResult[]>([]);
   const [selected, setSelected] = React.useState<IContentModel[]>([]);
 
@@ -32,7 +32,7 @@ export const TodaysCommentary: React.FC = () => {
   }, []);
 
   React.useEffect(() => {
-    if (commentaryActionId && !!active) {
+    if (commentaryActionId && hasProcessedInitialPreferences) {
       let actionFilters = getActionFilters();
       const commentaryAction = actionFilters.find((a) => a.id === commentaryActionId);
 
@@ -59,7 +59,13 @@ export const TodaysCommentary: React.FC = () => {
         })
         .catch();
     }
-  }, [commentaryActionId, filter, findContentWithElasticsearch, getActionFilters, active]);
+  }, [
+    commentaryActionId,
+    filter,
+    findContentWithElasticsearch,
+    getActionFilters,
+    hasProcessedInitialPreferences,
+  ]);
 
   return (
     <styled.TodaysCommentary>

--- a/app/subscriber/src/features/top-stories/TopStories.tsx
+++ b/app/subscriber/src/features/top-stories/TopStories.tsx
@@ -23,14 +23,14 @@ export const TopStories: React.FC = () => {
   ] = useContent();
   const getActionFilters = useActionFilters();
   const { topStoryActionId, isReady } = useSettings();
-  const { active } = useFilterOptionContext();
+  const { hasProcessedInitialPreferences } = useFilterOptionContext();
 
   const [content, setContent] = React.useState<IContentSearchResult[]>([]);
   const [selected, setSelected] = React.useState<IContentModel[]>([]);
 
   React.useEffect(() => {
     // stops invalid requests before filter is synced with date
-    if (isReady && !!active) {
+    if (isReady && hasProcessedInitialPreferences) {
       let actionFilters = getActionFilters();
       const topStoryAction = actionFilters.find((a) => a.id === topStoryActionId);
 
@@ -53,7 +53,14 @@ export const TopStories: React.FC = () => {
         );
       });
     }
-  }, [filter, findContentWithElasticsearch, getActionFilters, isReady, topStoryActionId, active]);
+  }, [
+    filter,
+    findContentWithElasticsearch,
+    getActionFilters,
+    isReady,
+    topStoryActionId,
+    hasProcessedInitialPreferences,
+  ]);
 
   const handleContentSelected = React.useCallback((content: IContentModel[]) => {
     setSelected(content);

--- a/app/subscriber/src/features/top-stories/TopStories.tsx
+++ b/app/subscriber/src/features/top-stories/TopStories.tsx
@@ -1,5 +1,6 @@
 import { ContentList } from 'components/content-list';
 import { DateFilter } from 'components/date-filter';
+import { useFilterOptionContext } from 'components/media-type-filters';
 import { ContentListActionBar } from 'components/tool-bar';
 import { useActionFilters } from 'features/search-page/hooks';
 import { filterFormat } from 'features/search-page/utils';
@@ -7,7 +8,7 @@ import { castToSearchResult } from 'features/utils';
 import { IContentSearchResult } from 'features/utils/interfaces';
 import moment from 'moment';
 import React from 'react';
-import { useApp, useContent, useSettings } from 'store/hooks';
+import { useContent, useSettings } from 'store/hooks';
 import { generateQuery, IContentModel } from 'tno-core';
 
 import * as styled from './styled';
@@ -22,14 +23,14 @@ export const TopStories: React.FC = () => {
   ] = useContent();
   const getActionFilters = useActionFilters();
   const { topStoryActionId, isReady } = useSettings();
-  const [{ userInfo }] = useApp();
+  const { active } = useFilterOptionContext();
 
   const [content, setContent] = React.useState<IContentSearchResult[]>([]);
   const [selected, setSelected] = React.useState<IContentModel[]>([]);
 
   React.useEffect(() => {
     // stops invalid requests before filter is synced with date
-    if (isReady && !!userInfo) {
+    if (isReady && !!active) {
       let actionFilters = getActionFilters();
       const topStoryAction = actionFilters.find((a) => a.id === topStoryActionId);
 
@@ -52,7 +53,7 @@ export const TopStories: React.FC = () => {
         );
       });
     }
-  }, [filter, findContentWithElasticsearch, getActionFilters, isReady, topStoryActionId, userInfo]);
+  }, [filter, findContentWithElasticsearch, getActionFilters, isReady, topStoryActionId, active]);
 
   const handleContentSelected = React.useCallback((content: IContentModel[]) => {
     setSelected(content);


### PR DESCRIPTION
Small changes to update the grouped by date display, and additionally fix a bug that causes the api to fetch before the user's filter preference is grabbed. 

I added the active filter to a context provider for the landing page to use, this way it will not fetch until the active filter is set based on the userPrefs, which should eliminate the race condition that was present when using `userInfo` as the ready state.

Also some padding fixes for the search page.

![image](https://github.com/bcgov/tno/assets/15724124/a61ddbfd-293a-4a71-8fa4-08b865d8e7a7)
