### PR TITLE
Styling regression fixes

### DIFF
--- a/app/subscriber/src/components/content-list/Attributes.tsx
+++ b/app/subscriber/src/components/content-list/Attributes.tsx
@@ -32,25 +32,21 @@ export const Attributes: React.FC<IAttributesProps> = ({
   const { excludeBylineIds, excludeSourceIds } = useSettings();
   return (
     <Row className={`${mobile && 'mobile add-margin'} attributes`}>
-      {showDate && <div className="date has-divider">{formatDate(item.publishedOn)}</div>}
+      {showDate && <div className="date attr">{formatDate(item.publishedOn)}</div>}
       {showTime && item.contentType !== ContentTypeName.PrintContent && (
-        <div className="time has-divider">{`${moment(item.publishedOn).format('HH:mm')}`}</div>
+        <div className="time attr">{`${moment(item.publishedOn).format('HH:mm')}`}</div>
       )}
       {item.source &&
         !excludeSourceIds?.some((mt) => {
           const mediaTypeObj = mediaTypes.find((m) => m.id === mt);
           return item.mediaTypeId === mediaTypeObj?.id;
-        }) && (
-          <div
-            className={`source ${showSeries && item.series && 'has-divider'}`}
-          >{`${item.source.name}`}</div>
-        )}
+        }) && <div className={`source attr`}>{`${item.source.name}`}</div>}
       {/* do not include byline in talk radio, news radio, or events even if present */}
       {item.byline &&
         !excludeBylineIds?.some((mt) => {
           const mediaTypeObj = mediaTypes.find((m) => m.id === mt);
           return item.mediaTypeId === mediaTypeObj?.id;
-        }) && <div className={`byline`}>{`${item.byline}`}</div>}
+        }) && <div className={`byline attr`}>{`${item.byline}`}</div>}
       {/* show series when source not shown and the show series flag is disabled */}
       {item.series &&
         !showSeries &&
@@ -59,9 +55,7 @@ export const Attributes: React.FC<IAttributesProps> = ({
           return item.mediaTypeId === mediaTypeObj?.id;
         }) && <div className="series">{item.series.name}</div>}
       {/* show series when show series flag is enabled */}
-      {item.series && showSeries && (
-        <div className={`series ${!!item.section && 'has-divider'}`}>{item.series.name}</div>
-      )}
+      {item.series && showSeries && <div className={`series attr`}>{item.series.name}</div>}
       <Show visible={viewOptions?.section}>
         {item.section && <div className="section">{item.section}</div>}
         {item.page && <div className="page-number">{item.page}</div>}

--- a/app/subscriber/src/components/content-list/styled/ContentRow.tsx
+++ b/app/subscriber/src/components/content-list/styled/ContentRow.tsx
@@ -7,6 +7,14 @@ export const ContentRow = styled(Col)`
   padding-bottom: 0.25rem;
   border-bottom: 1px solid ${(props) => props.theme.css.bkStaticGray};
 
+  .attributes {
+    .attr:not(:last-child)::after {
+      content: '|';
+      margin-left: 0.25rem;
+      margin-right: 0.25rem;
+    }
+  }
+
   .icon-row {
     margin-left: 2rem;
     min-width: 75px;
@@ -55,24 +63,6 @@ export const ContentRow = styled(Col)`
     height: 20px;
     margin-left: 0.5rem;
     margin-right: 0.5rem;
-  }
-
-  .section,
-  .series,
-  .source,
-  .byline {
-    margin-left: 5px;
-  }
-
-  .has-divider::after {
-    content: '';
-    position: absolute;
-    right: -5px; /* adjust to control the spacing between text and divider */
-    top: 50%;
-    transform: translateY(-60%);
-    width: 1px;
-    height: 14px;
-    background-color: black;
   }
 
   .parent-row {

--- a/app/subscriber/src/features/home/Home.tsx
+++ b/app/subscriber/src/features/home/Home.tsx
@@ -77,6 +77,8 @@ export const Home: React.FC = () => {
       <ContentList
         onContentSelected={handleContentSelected}
         showDate
+        showSeries
+        showTime
         selected={selected}
         content={content}
       />

--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -177,6 +177,8 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
               content={content}
               selected={selected}
               showDate
+              showTime
+              showSeries
               scrollWithin
               filter={filter}
             />

--- a/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
+++ b/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
@@ -77,6 +77,9 @@ export const TodaysCommentary: React.FC = () => {
       <ContentList
         content={content}
         selected={selected}
+        showSeries
+        showDate
+        showTime
         onContentSelected={handleContentSelected}
       />
     </styled.TodaysCommentary>

--- a/app/subscriber/src/features/top-stories/TopStories.tsx
+++ b/app/subscriber/src/features/top-stories/TopStories.tsx
@@ -75,6 +75,9 @@ export const TopStories: React.FC = () => {
       <ContentList
         content={content}
         onContentSelected={handleContentSelected}
+        showTime
+        showDate
+        showSeries
         selected={selected}
       />
     </styled.TopStories>


### PR DESCRIPTION
Noticed some issues with the content attributes, the dividers had been removed. Re implemented the logic on how they are applied using  `.attr:not(:last-child)::after` so it works everywhere. 

**Before:**
![image](https://github.com/bcgov/tno/assets/15724124/55c3aec6-8667-4aca-9d10-480b039a2c7b)

**After:**
![image](https://github.com/bcgov/tno/assets/15724124/b72ed9b1-60a4-4fea-aff3-b8a71de39b0f)
