### PR TITLE
View Content Header Small Fixes

### DIFF
--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -212,17 +212,17 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent }) =
           {content?.publishedOn && formatDate(content.publishedOn, true)}
         </div>
         <Row className="right-side">
-          <div className="source-name">{content?.source?.name}</div>
-          <span className="divider">|</span>
-          <div className="source-section">{`${content?.section} ${
-            content?.page && `:${content.page}`
-          }`}</div>
-          <Show visible={!!filteredQuotes.length}>
-            <span className="divider">|</span>
-            <a href="#quotes-anchor" title="go to Quotes">
-              [{filteredQuotes.length}] Quotes
-            </a>
-          </Show>
+          <div className="attributes">
+            <div className="source-name attr">{content?.source?.name}</div>
+            <div className="source-section attr">{`${content?.section} ${
+              content?.page && `${content.page}`
+            }`}</div>
+            <Show visible={!!filteredQuotes.length}>
+              <a href="#quotes-anchor" className="attr" title="go to Quotes">
+                [{filteredQuotes.length}] Quotes
+              </a>
+            </Show>
+          </div>
           {content?.tonePools && content?.tonePools.length && (
             <Row className="tone-group">
               <Sentiment value={content?.tonePools[0].value} />

--- a/app/subscriber/src/features/content/view-content/styled/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/styled/ViewContent.tsx
@@ -21,16 +21,28 @@ export const ViewContent = styled.div`
     .right-side {
       margin-left: auto;
     }
+    .right-side {
+      .attributes {
+        display: flex;
+        flex-direction: row;
+        .attr:not(:last-child)::after {
+          content: '|';
+          margin-left: 0.25rem;
+          margin-right: 0.25rem;
+        }
+      }
+    }
     .divider {
       margin: 0 0.5em;
     }
     .numeric-tone {
-      margin-left: 0.5em;
+      margin-left: 0.25em;
+      font-weight: 700;
       align-self: center;
     }
-    .tone-group {
-      margin-left: 0.5em;
-    }
+  }
+  .tone-group {
+    margin-left: 0.5em;
   }
   video {
     margin-top: 1em;


### PR DESCRIPTION
Noticed there were some dividers next to the attributes being placed incorrectly, this should fix that up. 
![image](https://github.com/bcgov/tno/assets/15724124/66c21b87-9919-4f35-9bcb-0380d1c6df98)

(example before it could be like `Vancouver Sun| (nothing) +2`)
