### PR TITLE
TNO-2729: Close right side when deleting folder

### DIFF
--- a/app/subscriber/src/features/my-folders/ConfigureFolder.tsx
+++ b/app/subscriber/src/features/my-folders/ConfigureFolder.tsx
@@ -385,6 +385,8 @@ export const ConfigureFolder: React.FC<IConfigureFolderProps> = () => {
             if (currentFolder) {
               deleteFolder(currentFolder)
                 .then(() => {
+                  // delete and close right side menu to avoid errors on non-existing folder
+                  navigate('/folders');
                   toast.success(`${currentFolder.name} deleted successfully`);
                 })
                 .catch(() => {});


### PR DESCRIPTION
Super easy fix, this will close the configuration when a folder is deleted preventing users from performing actions on a non-existent folder.