### PR TITLE
TNO-2735: Fix calendar being cut off

### DIFF
--- a/app/subscriber/src/features/search-page/components/advanced-search/styled/AdvancedSearch.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/styled/AdvancedSearch.tsx
@@ -4,6 +4,9 @@ import { Row } from 'tno-core';
 export const AdvancedSearch = styled(Row)<{ expanded: boolean }>`
   position: relative;
   max-height: calc(100vh - 10em);
+  .react-datepicker {
+    margin-left: 7em;
+  }
   .page-section {
     width: 100%;
   }


### PR DESCRIPTION
Change margin instead of z-index as z-index posed another of other UI issues.

![image](https://github.com/bcgov/tno/assets/15724124/6027b688-a887-42e3-b71c-ef496a50247a)
