### PR TITLE
Fix ResizeObserver loop bug

### DIFF
--- a/app/subscriber/src/App.tsx
+++ b/app/subscriber/src/App.tsx
@@ -7,6 +7,7 @@ import { ContentListProvider } from 'components/content-list/ContentListContext'
 import { LayoutAnonymous } from 'components/layout';
 import { AppRouter } from 'features/router';
 import { SearchPageProvider } from 'features/search-page';
+import { fixTooltipResizeObserver } from 'features/utils';
 import Keycloak from 'keycloak-js';
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
@@ -16,6 +17,7 @@ import { StyleSheetManager } from 'styled-components';
 import { createKeycloakInstance, Loading, Show, useKeycloakEventHandler } from 'tno-core';
 
 const appName = 'Media Monitoring Insights';
+fixTooltipResizeObserver();
 
 // This implements the default behavior from styled-components v5
 function shouldForwardProp(propName: any, target: any) {

--- a/app/subscriber/src/features/content/view-content/styled/ViewContentToolbar.tsx
+++ b/app/subscriber/src/features/content/view-content/styled/ViewContentToolbar.tsx
@@ -5,7 +5,7 @@ export const ViewContentToolbar = styled(Col)`
   max-height: 10em;
   width: 100%;
   .folder-menu {
-    /* boxs hadow */
+    /* boxshadow */
     box-shadow: 0 0 0.5rem ${(props) => props.theme.css.highlightPrimary};
     opacity: 1;
   }

--- a/app/subscriber/src/features/utils/fixTooltipResizeObserver.ts
+++ b/app/subscriber/src/features/utils/fixTooltipResizeObserver.ts
@@ -1,0 +1,27 @@
+/**
+ * Temporary fix that stops react-tooltip infinite loop error.
+ * This bug occurs when clicking the Add to Folder/Report if there is content on the page.
+ * "ResizeObserver loop completed with undelivered notifications"
+ */
+export const fixTooltipResizeObserver = () => {
+  // Stop error resizeObserver
+  const debounce = (callback: (...args: any[]) => void, delay: number) => {
+    let tid: any;
+    return function (...args: any[]) {
+      // eslint-disable-next-line no-restricted-globals
+      const ctx = self;
+      tid && clearTimeout(tid);
+      tid = setTimeout(() => {
+        callback.apply(ctx, args);
+      }, delay);
+    };
+  };
+
+  const _ = (window as any).ResizeObserver;
+  (window as any).ResizeObserver = class ResizeObserver extends _ {
+    constructor(callback: (...args: any[]) => void) {
+      callback = debounce(callback, 20);
+      super(callback);
+    }
+  };
+};

--- a/app/subscriber/src/features/utils/index.ts
+++ b/app/subscriber/src/features/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './castToSearchResult';
 export * from './createFilterSettings';
 export * from './determinePreview';
+export * from './fixTooltipResizeObserver';
 export * from './formatDate';
 export * from './getBooleanActionValue';
 export * from './handleEnterPressed';


### PR DESCRIPTION
This is a workaround to fix the ResizeObserver infinite loop bug introduced by react-tooltip and content on the page.

![image](https://github.com/bcgov/tno/assets/3180256/eb314fff-f99b-47ce-8e51-2d2516aad6d8)
