### PR TITLE
TNO-2746 Fix tooltip resize error

### DIFF
--- a/app/editor/src/App.tsx
+++ b/app/editor/src/App.tsx
@@ -14,8 +14,10 @@ import { ToastContainer } from 'react-toastify';
 import { Tooltip } from 'react-tooltip';
 import { StyleSheetManager } from 'styled-components';
 import { createKeycloakInstance, Loading, Show, useKeycloakEventHandler } from 'tno-core';
+import { fixTooltipResizeObserver } from 'utils';
 
 const appName = 'Media Monitoring Insights';
+fixTooltipResizeObserver();
 
 // This implements the default behavior from styled-components v5
 function shouldForwardProp(propName: any, target: any) {

--- a/app/editor/src/utils/fixTooltipResizeObserver.ts
+++ b/app/editor/src/utils/fixTooltipResizeObserver.ts
@@ -1,0 +1,27 @@
+/**
+ * Temporary fix that stops react-tooltip infinite loop error.
+ * This bug occurs when clicking the Add to Folder/Report if there is content on the page.
+ * "ResizeObserver loop completed with undelivered notifications"
+ */
+export const fixTooltipResizeObserver = () => {
+  // Stop error resizeObserver
+  const debounce = (callback: (...args: any[]) => void, delay: number) => {
+    let tid: any;
+    return function (...args: any[]) {
+      // eslint-disable-next-line no-restricted-globals
+      const ctx = self;
+      tid && clearTimeout(tid);
+      tid = setTimeout(() => {
+        callback.apply(ctx, args);
+      }, delay);
+    };
+  };
+
+  const _ = (window as any).ResizeObserver;
+  (window as any).ResizeObserver = class ResizeObserver extends _ {
+    constructor(callback: (...args: any[]) => void) {
+      callback = debounce(callback, 20);
+      super(callback);
+    }
+  };
+};

--- a/app/editor/src/utils/index.ts
+++ b/app/editor/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './fixTooltipResizeObserver';


### PR DESCRIPTION
Fixing same issue in the Editor app.  For some reason the script doesn't work if it's within tno-core.  Which requires duplicating the file in each app.