### PR TITLE
TNO-2728=MMI-Advanced Search Problems

### DIFF
--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -195,11 +195,30 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent }) =
       wo.userNotifications?.some((un) => un.userId === profile?.id),
   );
 
+  //Remove HTML tags, square brackets and line breaks before comparison.
+  const cleanString = (str: string | undefined) => str?.replace(/<[^>]*>?|\[|\]|\n/gm, '').trim();
+
+  //Difference ratio
+  const threshold = 0.1;
+
+  //Return true if difference between length of str1 & str2 is greater than 10%
+  const isDifferent = (str1: string | undefined, str2: string | undefined) => {
+    if (str1 === undefined || str2 === undefined) {
+      return false; // If either str1 or str2 is undefined, return false
+    }
+
+    const difference = Math.abs((str1.length ?? 0) - (str2.length ?? 0));
+    const maxLength = Math.max(str1.length ?? 0, str2.length ?? 0);
+    return difference > maxLength * threshold;
+  };
+
   const formatedHeadline = formatSearch(content ? content.headline : '', filter);
   const tempBody = content?.body?.replace(/\n+/g, '<br><br>') ?? '';
   const tempSummary = content?.summary?.replace(/\n+/g, '<br><br>') ?? '';
   const formatedBody = formatSearch(tempBody, filter);
   const formatedSummary = formatSearch(tempSummary, filter);
+  const cleanBody = cleanString(content?.body);
+  const cleanSummary = cleanString(content?.summary);
 
   return (
     <styled.ViewContent>
@@ -260,7 +279,28 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent }) =
       <Row id="summary" className="summary">
         <Show visible={!(isAV && !!content.body && !isTranscribing)}>
           <Col>
-            {!!content?.body?.length ? <div>{formatedBody}</div> : <span>{formatedSummary}</span>}
+            {!!content?.summary?.length ? (
+              <div>{formatedSummary}</div>
+            ) : (
+              <span>{formatedBody}</span>
+            )}
+            <Show visible={!!content?.sourceUrl}>
+              <a rel="noreferrer" target="_blank" href={content?.sourceUrl}>
+                More...
+              </a>
+            </Show>
+          </Col>
+        </Show>
+        <Show
+          visible={
+            isAV &&
+            cleanBody !== cleanSummary &&
+            isDifferent(cleanBody, cleanSummary) &&
+            !isTranscribing
+          }
+        >
+          <Col>
+            {content?.summary?.length && <div>{formatedSummary}</div>}
             <Show visible={!!content?.sourceUrl}>
               <a rel="noreferrer" target="_blank" href={content?.sourceUrl}>
                 More...

--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -201,17 +201,6 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent }) =
   //Difference ratio
   const threshold = 0.1;
 
-  //Return true if difference between length of str1 & str2 is greater than 10%
-  const isDifferent = (str1: string | undefined, str2: string | undefined) => {
-    if (str1 === undefined || str2 === undefined) {
-      return false; // If either str1 or str2 is undefined, return false
-    }
-
-    const difference = Math.abs((str1.length ?? 0) - (str2.length ?? 0));
-    const maxLength = Math.max(str1.length ?? 0, str2.length ?? 0);
-    return difference > maxLength * threshold;
-  };
-
   const formatedHeadline = formatSearch(content ? content.headline : '', filter);
   const tempBody = content?.body?.replace(/\n+/g, '<br><br>') ?? '';
   const tempSummary = content?.summary?.replace(/\n+/g, '<br><br>') ?? '';
@@ -219,6 +208,17 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent }) =
   const formatedSummary = formatSearch(tempSummary, filter);
   const cleanBody = cleanString(content?.body);
   const cleanSummary = cleanString(content?.summary);
+
+  //Return true if difference between length of cleanBody & cleanSummary is greater than 10%
+  const isDifferent = React.useMemo(() => {
+    if (cleanBody === undefined || cleanSummary === undefined) {
+      return false; // If either cleanBody or cleanSummary is undefined, return false
+    }
+
+    const difference = Math.abs((cleanBody.length ?? 0) - (cleanSummary.length ?? 0));
+    const maxLength = Math.max(cleanBody.length ?? 0, cleanSummary.length ?? 0);
+    return difference > maxLength * threshold;
+  }, [cleanBody, cleanSummary]);
 
   return (
     <styled.ViewContent>
@@ -291,14 +291,7 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent }) =
             </Show>
           </Col>
         </Show>
-        <Show
-          visible={
-            isAV &&
-            cleanBody !== cleanSummary &&
-            isDifferent(cleanBody, cleanSummary) &&
-            !isTranscribing
-          }
-        >
+        <Show visible={isAV && cleanBody !== cleanSummary && isDifferent && !isTranscribing}>
           <Col>
             {content?.summary?.length && <div>{formatedSummary}</div>}
             <Show visible={!!content?.sourceUrl}>


### PR DESCRIPTION
Summary stores the transcription for Content Type Audio/Video and sometimes summary is different to body. We need to show the summary and body when they are different.

- Remove HTML tags, square brackets and brake lines before comparison
- Check if the difference in length is greater than 10%
- If summary and body are different then show both of them:

<img width="500" alt="image" src="https://github.com/bcgov/tno/assets/10526131/56e35552-bb70-43ac-be37-dd7b18d8c8f5">


Story: https://apps.itsm.gov.bc.ca/jira/browse/TNO-2728