### PR TITLE
TNO-2656 fix bold search

### DIFF
--- a/app/subscriber/src/components/content-list/ContentRow.tsx
+++ b/app/subscriber/src/components/content-list/ContentRow.tsx
@@ -41,8 +41,14 @@ export const ContentRow: React.FC<IContentRowProps> = ({
     setActiveFileReference,
     activeStream,
   } = React.useContext(ContentListContext);
-  const body = formatSearch(truncateTeaser(item.body, 250), filter);
-  const headline = formatSearch(item.headline, filter);
+
+  const body = React.useMemo(() => {
+    const truncated = truncateTeaser(item.body, 250);
+    return formatSearch(truncated, filter);
+  }, [filter, item.body]);
+  const headline = React.useMemo(() => {
+    return formatSearch(item.headline, filter);
+  }, [filter, item.headline]);
 
   return (
     <styled.ContentRow {...rest}>

--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -195,15 +195,22 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent }) =
       wo.userNotifications?.some((un) => un.userId === profile?.id),
   );
 
-  const formatedHeadline = formatSearch(content ? content.headline : '', filter);
-  const tempBody = content?.body?.replace(/\n+/g, '<br><br>') ?? '';
-  const tempSummary = content?.summary?.replace(/\n+/g, '<br><br>') ?? '';
-  const formatedBody = formatSearch(tempBody, filter);
-  const formatedSummary = formatSearch(tempSummary, filter);
+  const formattedHeadline = React.useMemo(
+    () => formatSearch(content?.headline ?? '', filter),
+    [content?.headline, filter],
+  );
+  const formattedBody = React.useMemo(
+    () => formatSearch(content?.body?.replace(/\n+/g, '<br><br>') ?? '', filter),
+    [content?.body, filter],
+  );
+  const formattedSummary = React.useMemo(
+    () => formatSearch(content?.summary?.replace(/\n+/g, '<br><br>') ?? '', filter),
+    [content?.summary, filter],
+  );
 
   return (
     <styled.ViewContent>
-      <div className="headline">{formatedHeadline}</div>
+      <div className="headline">{formattedHeadline}</div>
       <Bar className="info-bar" vanilla>
         <Show visible={!!content?.byline}>
           <div className="byline">{`BY ${content?.byline}`}</div>
@@ -260,7 +267,7 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent }) =
       <Row id="summary" className="summary">
         <Show visible={!(isAV && !!content.body && !isTranscribing)}>
           <Col>
-            {!!content?.body?.length ? <div>{formatedBody}</div> : <span>{formatedSummary}</span>}
+            {!!content?.body?.length ? <div>{formattedBody}</div> : <span>{formattedSummary}</span>}
             <Show visible={!!content?.sourceUrl}>
               <a rel="noreferrer" target="_blank" href={content?.sourceUrl}>
                 More...

--- a/app/subscriber/src/features/search-page/utils/formatSearch.ts
+++ b/app/subscriber/src/features/search-page/utils/formatSearch.ts
@@ -1,45 +1,68 @@
 import parse from 'html-react-parser';
 import { IFilterSettingsModel } from 'tno-core';
 
+/**
+ * Escapes special characters in a string to be used in a regular expression.
+ * @param string - The string to escape.
+ * @returns The escaped string.
+ */
+function escapeRegExp(string: string): string {
+  return string.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Formats the search text by applying bold formatting to matched keywords and excluding certain words.
+ * @param text - The text to be formatted.
+ * @param filter - The filter settings to be applied.
+ * @returns The formatted text with matched keywords bolded.
+ */
 export const formatSearch = (text: string, filter: IFilterSettingsModel) => {
-  // Check if filter is undefined or null
-  if (!filter) {
+  if (!filter || filter.boldKeywords === false || !filter.search || !filter.search.trim()) {
     return parse(text);
   }
 
-  let tempText = text;
-  let parseText = () => {
-    if (filter.search) return filter.search;
-    else return '';
-  };
-
-  const searchWords = parseText()
-    .split(' e')
-    .filter((word) => word); // Filter out empty words
-  if (searchWords.length === 0) {
-    // If there are no valid search words, return the original text parsed
+  // Remove parentheses to prevent affecting the construction of the regular expression
+  const cleanedSearch = filter.search.replace(/[()]/g, '');
+  if (!cleanedSearch) {
     return parse(text);
   }
 
-  searchWords.forEach((word) => {
-    const regex = new RegExp(word, 'gi');
-    // remove duplicates found only want unique matches, this will be varying capitalization
-    const matches = text.match(regex)?.filter((v, i, a) => a.indexOf(v) === i) ?? [];
-    // text.match included in replace in order to keep the proper capitalization
-    // When there is more than one match, this indicates there will be varying capitalization. In this case we
-    // have to iterate through the matches and do a more specific replace in order to keep the words capitalization
-    if (matches.length > 1) {
-      matches.forEach((match, i) => {
-        let multiMatch = new RegExp(`${matches[i]}`);
-        tempText = tempText.replace(multiMatch, `<b>${match}</b>`);
-      });
-    } else if (matches.length === 1) {
-      // in this case there will only be one match, so we can just insert the first match
-      tempText = tempText.replace(regex, `<b>${matches[0]}</b>`);
+  // Match possible phrases within quotes, prefixed terms with '*', normal words, and exclude words with '-'
+  const tokens = cleanedSearch.match(/"[^"]+"|\b\w+\*|\b\w+\b|-\s*\w+/g) || [];
+
+  let includePatterns: string[] = [];
+  let excludePatterns: string[] = [];
+
+  tokens.forEach((token) => {
+    if (token.startsWith('"') && token.endsWith('"')) {
+      // Handle phrases within quotes, remove the quotes
+      includePatterns.push(`\\b${escapeRegExp(token.slice(1, -1))}\\b`);
+    } else if (token.endsWith('*')) {
+      // Handle prefix queries, remove the '*' at the end
+      let prefix = escapeRegExp(token.slice(0, -1));
+      includePatterns.push(`\\b${prefix}\\w*\\b`);
+    } else if (token.startsWith('-')) {
+      // Handle exclude words, remove the '-' at the beginning
+      excludePatterns.push(`\\b${escapeRegExp(token.slice(1))}\\b`);
+    } else {
+      // Handle normal keywords
+      includePatterns.push(`\\b${escapeRegExp(token)}\\b`);
     }
   });
 
-  // Check if filter.boldKeywords is undefined or null
-  if (!filter.boldKeywords) return parse(text);
-  return parse(tempText);
+  if (includePatterns.length === 0) {
+    return parse(text);
+  }
+
+  // Build the regular expression and bold the matched words
+  let includeRegex = new RegExp(`(${includePatterns.join('|')})`, 'gi');
+  let boldedText = text.replace(includeRegex, `<b>$&</b>`);
+
+  // Use exclude patterns not bold "-"
+  if (excludePatterns.length > 0) {
+    let excludeRegex = new RegExp(`(${excludePatterns.join('|')})`, 'gi');
+    boldedText = boldedText.replace(excludeRegex, (match) => match);
+  }
+
+  return parse(boldedText);
 };

--- a/app/subscriber/src/features/search-page/utils/formatSearch.ts
+++ b/app/subscriber/src/features/search-page/utils/formatSearch.ts
@@ -27,8 +27,9 @@ export const formatSearch = (text: string, filter: IFilterSettingsModel) => {
     return parse(text);
   }
 
-  // Match possible phrases within quotes, prefixed terms with '*', normal words, and exclude words with '-'
-  const tokens = cleanedSearch.match(/"[^"]+"|\b\w+\*|\b\w+\b|-\s*\w+/g) || [];
+  // Match possible phrases within quotes, prefixed terms with '*',
+  // normal words, and exclude words with '-' and '~'
+  const tokens = cleanedSearch.match(/"[^"]+"|\b\w+\*|\b\w+\b|[-~]\s*\w+/g) || [];
 
   let includePatterns: string[] = [];
   let excludePatterns: string[] = [];
@@ -41,7 +42,7 @@ export const formatSearch = (text: string, filter: IFilterSettingsModel) => {
       // Handle prefix queries, remove the '*' at the end
       let prefix = escapeRegExp(token.slice(0, -1));
       includePatterns.push(`\\b${prefix}\\w*\\b`);
-    } else if (token.startsWith('-')) {
+    } else if (token.startsWith('-') || token.startsWith('~')) {
       // Handle exclude words, remove the '-' at the beginning
       excludePatterns.push(`\\b${escapeRegExp(token.slice(1))}\\b`);
     } else {


### PR DESCRIPTION
Search query `(are +once) | city +mus* -in`

bold: `City`  `are` `once`,  and prex `mus`
exclude: `in`

![image](https://github.com/bcgov/tno/assets/35620699/df3c41ca-e623-45c1-90bd-2376111b7341)

- Change formatSearch to support complex search expression when bolding keywords. 

   Include keywords by `+`  `|` `()` `""` `''` 
   Include prefix by end with `*`
   Exclude keywords by`-` `~`

- Improve performance by usememo 
