### PR TITLE
TNO-2665 Fix TNO Migration

### DIFF
--- a/app/editor/src/features/admin/ingests/configurations/DbMigration.tsx
+++ b/app/editor/src/features/admin/ingests/configurations/DbMigration.tsx
@@ -28,42 +28,46 @@ export const DbMigration: React.FC = (props) => {
   return (
     <styled.IngestType>
       <ImportContent />
-      <Col gap="0.5rem">
-        <FormikRadioGroup
-          label="Migration Type"
-          name="importMigrationType"
-          value={values.configuration.importMigrationType ?? ImportMigrationType.Current}
-          onChange={(val) => {
-            const configuration = {
-              ...values.configuration,
-              importMigrationType: val.target.value,
-              offsetHours:
-                val.target.value === ImportMigrationType.Historic ||
-                val.target.value === ImportMigrationType.All
-                  ? undefined
-                  : values.configuration.offsetHours,
-              importDateStart:
-                val.target.value === ImportMigrationType.Current
-                  ? undefined
-                  : values.configuration.importDateStart,
-              importDateEnd:
-                val.target.value === ImportMigrationType.Current
-                  ? undefined
-                  : values.configuration.importDateEnd,
-            };
-            setFieldValue('configuration', configuration);
-          }}
-          options={[
-            ImportMigrationType.Historic,
-            ImportMigrationType.All,
-            ImportMigrationType.Recent,
-            ImportMigrationType.Current,
-          ]}
-          required={true}
-        />
-        <FormikCheckbox name="configuration.publishedOnly" label="Published Content Only" />
-        <FormikCheckbox name="configuration.forceUpdate" label="Force Update" />
-      </Col>
+      <Row gap="1rem">
+        <Col flex="1">
+          <FormikRadioGroup
+            label="Migration Type"
+            name="importMigrationType"
+            value={values.configuration.importMigrationType ?? ImportMigrationType.Current}
+            onChange={(val) => {
+              const configuration = {
+                ...values.configuration,
+                importMigrationType: val.target.value,
+                offsetHours:
+                  val.target.value === ImportMigrationType.Historic ||
+                  val.target.value === ImportMigrationType.All
+                    ? undefined
+                    : values.configuration.offsetHours,
+                importDateStart:
+                  val.target.value === ImportMigrationType.Current
+                    ? undefined
+                    : values.configuration.importDateStart,
+                importDateEnd:
+                  val.target.value === ImportMigrationType.Current
+                    ? undefined
+                    : values.configuration.importDateEnd,
+              };
+              setFieldValue('configuration', configuration);
+            }}
+            options={[
+              ImportMigrationType.Historic,
+              ImportMigrationType.All,
+              ImportMigrationType.Recent,
+              ImportMigrationType.Current,
+            ]}
+            required={true}
+          />
+        </Col>
+        <Col flex="1" gap="0.5rem">
+          <FormikCheckbox name="configuration.publishedOnly" label="Published Content Only" />
+          <FormikCheckbox name="configuration.forceUpdate" label="Force Update" />
+        </Col>
+      </Row>
       <Show visible={values.configuration.importMigrationType !== ImportMigrationType.Current}>
         <Row>
           <Col>
@@ -217,29 +221,50 @@ export const DbMigration: React.FC = (props) => {
           </Col>
         </Row>
       </Show>
-
-      <Show
-        visible={
-          ![ImportMigrationType.Historic, ImportMigrationType.All].includes(
-            values.configuration.importMigrationType,
-          )
-        }
-      >
-        <FormikText
-          label="Migration offset in hours"
-          name="configuration.offsetHours"
-          type="number"
-          min="0"
-          width="10ch"
-          size={5}
-          value={values.configuration.offsetHours ?? ''}
-          onChange={(e) => {
-            const value = e.currentTarget.value;
-            const offset = value && !isNaN(Number(value)) ? Number(value) : undefined;
-            setFieldValue('configuration.offsetHours', offset);
-          }}
-        />
-      </Show>
+      <Row gap="1rem">
+        <Show
+          visible={
+            ![ImportMigrationType.Historic, ImportMigrationType.All].includes(
+              values.configuration.importMigrationType,
+            )
+          }
+        >
+          <Col flex="1">
+            <FormikText
+              label="Migration offset in hours"
+              name="configuration.offsetHours"
+              type="number"
+              min="0"
+              width="10ch"
+              size={5}
+              value={values.configuration.offsetHours ?? ''}
+              onChange={(e) => {
+                const value = e.currentTarget.value;
+                const offset = value && !isNaN(Number(value)) ? Number(value) : undefined;
+                setFieldValue('configuration.offsetHours', offset);
+              }}
+            />
+          </Col>
+        </Show>
+        <Col flex="1">
+          <FormikText
+            label="Import Delay in seconds"
+            name="configuration.importDelayMs"
+            type="number"
+            min="0"
+            width="10ch"
+            size={5}
+            value={
+              values.configuration.importDelayMs ? values.configuration.importDelayMs / 1000 : ''
+            }
+            onChange={(e) => {
+              const value = e.currentTarget.value;
+              const delay = value && !isNaN(Number(value)) ? Number(value) * 1000 : undefined;
+              setFieldValue('configuration.importDelayMs', delay);
+            }}
+          />
+        </Col>
+      </Row>
       <Row>
         <Col flex="1 1 1">
           <FormikText

--- a/libs/net/services/Actions/Managers/IngestActionManager`.cs
+++ b/libs/net/services/Actions/Managers/IngestActionManager`.cs
@@ -69,13 +69,13 @@ public class IngestActionManager<TOptions> : ServiceActionManager<TOptions>, IIn
     {
         if (this.Ingest.IsEnabled && (!this.Ingest.IngestSchedules.Any() || this.Ingest.IngestSchedules.All(s => s.Schedule == null)))
         {
-            this.Logger.LogWarning($"Ingest [{this.Ingest.Name}] is enabled but has NO schedules.  Ingest will be SKIPPED.");
+            this.Logger.LogWarning("Ingest [{name}] is enabled but has NO schedules.  Ingest will be SKIPPED.", this.Ingest.Name);
             return Task.FromResult(false);
         }
 
         if (this.Ingest.IsEnabled && !this.Ingest.IngestSchedules.Any(s => s.Schedule?.IsEnabled == true))
         {
-            this.Logger.LogWarning($"Ingest [{this.Ingest.Name}] is enabled but has NO enabled schedules.  Ingest will be SKIPPED.");
+            this.Logger.LogWarning("Ingest [{name}] is enabled but has NO enabled schedules.  Ingest will be SKIPPED.", this.Ingest.Name);
             return Task.FromResult(false);
         }
 

--- a/openshift/scripts/deploy.sh
+++ b/openshift/scripts/deploy.sh
@@ -30,6 +30,7 @@ podsSubscriber=$(getPods subscriber dc $env)
 
 # podsCapture=$(getPods capture-service dc $env)
 podsContentMigration=$(getPods contentmigration-service dc $env)
+podsContentMigrationRecent=$(getPods contentmigration-recent-service dc $env)
 podsContentMigrationHistoric=$(getPods contentmigration-historic-service dc $env)
 podsFileMonitor=$(getPods filemonitor-service dc $env)
 podsSyndication=$(getPods syndication-service dc $env)
@@ -104,6 +105,7 @@ scale subscriber $podsSubscriber dc $env
 
 # scale capture-service $podsCapture dc $env
 scale contentmigration-service $podsContentMigration dc $env
+scale contentmigration-recent-service $podsContentMigrationRecent dc $env
 scale contentmigration-historic-service $podsContentMigrationHistoric dc $env
 scale filemonitor-service $podsFileMonitor dc $env
 scale syndication-service $podsSyndication dc $env

--- a/services/net/content/ContentManager.cs
+++ b/services/net/content/ContentManager.cs
@@ -105,10 +105,10 @@ public class ContentManager : ServiceManager<ContentOptions>
                     // TODO: Handle e-tag.
                     var ingest = (await this.Api.GetIngestsAsync()).ToArray();
 
-                    // Listen to every enabled data source with a topic that is configured to produce content.
+                    // Listen to every data source with a topic that is configured to produce content.
+                    // Even disabled data sources should continue to import.
                     var topics = this.Options.GetContentTopics(ingest
-                        .Where(i => i.IsEnabled &&
-                            !String.IsNullOrWhiteSpace(i.Topic) &&
+                        .Where(i => !String.IsNullOrWhiteSpace(i.Topic) &&
                             i.ImportContent())
                         .Select(i => i.Topic).ToArray());
 

--- a/services/net/contentmigration/.gitignore
+++ b/services/net/contentmigration/.gitignore
@@ -1,0 +1,1 @@
+./audiovideo-migrated


### PR DESCRIPTION
Adding a way to slow down the import of historical content.

Changing the Content Service to be able to continue importing content even when the ingest has been disabled.