### PR TITLE
TNO-2665 Fix Content Service

### DIFF
--- a/openshift/kustomize/services/content-current/base/config-map.yaml
+++ b/openshift/kustomize/services/content-current/base/config-map.yaml
@@ -3,21 +3,21 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: content-service
+  name: content-current-service
   namespace: default
   annotations:
     description: Content TNO service configuration settings
     created-by: jeremy.foster
   labels:
-    name: content-service
+    name: content-current-service
     part-of: tno
     version: 1.0.0
-    component: content-service
+    component: content-current-service
     managed-by: kustomize
 data:
-  KAFKA_CLIENT_ID: Content
+  KAFKA_CLIENT_ID: ContentCurrent-TNO
   MAX_FAIL_LIMIT: "5"
-  CONTENT_TOPICS_EXCLUSIONS: "TNO-HISTORIC,TNO"
+  CONTENT_TOPICS_OVERRIDE: "TNO"
   CHES_EMAIL_ENABLED: "true"
   CHES_EMAIL_AUTHORIZED: "true"
   ALLOW_UPDATE: "true"

--- a/openshift/kustomize/services/content-current/base/deploy.yaml
+++ b/openshift/kustomize/services/content-current/base/deploy.yaml
@@ -1,0 +1,210 @@
+---
+# How the app will be deployed to the pod.
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: content-current-service
+  namespace: default
+  annotations:
+    description: Defines how to deploy content-current-service
+    created-by: jeremy.foster
+  labels:
+    name: content-current-service
+    part-of: tno
+    version: 1.0.0
+    component: content-current-service
+    managed-by: kustomize
+spec:
+  replicas: 1
+  selector:
+    name: content-current-service
+    part-of: tno
+    component: content-current-service
+  strategy:
+    rollingParams:
+      intervalSeconds: 1
+      maxSurge: 25%
+      maxUnavailable: 25%
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+    type: Rolling
+  template:
+    metadata:
+      name: content-current-service
+      labels:
+        name: content-current-service
+        part-of: tno
+        component: content-current-service
+    spec:
+      volumes:
+        - name: ingest-storage
+          persistentVolumeClaim:
+            claimName: ingest-storage
+      containers:
+        - name: content-current-service
+          image: ""
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: ingest-storage
+              mountPath: /data
+          resources:
+            limits:
+              cpu: 125m
+              memory: 350Mi
+            requests:
+              cpu: 25m
+              memory: 100Mi
+          env:
+            # .NET Configuration
+            - name: ASPNETCORE_ENVIRONMENT
+              value: Staging
+            - name: ASPNETCORE_URLS
+              value: http://+:8080
+
+            - name: Logging__LogLevel__TNO
+              value: Information
+
+            # Common Service Configuration
+            - name: Service__ApiUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: API_HOST_URL
+            - name: Service__EmailTo
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: EMAIL_FAILURE_TO
+
+            # Authentication Configuration
+            - name: Auth__Keycloak__Authority
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: KEYCLOAK_AUTHORITY
+            - name: Auth__Keycloak__Audience
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: KEYCLOAK_AUDIENCE
+            - name: Auth__Keycloak__Secret
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak
+                  key: KEYCLOAK_CLIENT_SECRET
+
+            - name: Kafka__Consumer__GroupId
+              valueFrom:
+                configMapKeyRef:
+                  name: content-current-service
+                  key: KAFKA_CLIENT_ID
+            - name: Kafka__Consumer__BootstrapServers
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: KAFKA_BOOTSTRAP_SERVERS
+
+            - name: Kafka__Producer__GroupId
+              valueFrom:
+                configMapKeyRef:
+                  name: content-current-service
+                  key: KAFKA_CLIENT_ID
+            - name: Kafka__Producer__BootstrapServers
+              valueFrom:
+                configMapKeyRef:
+                  name: services
+                  key: KAFKA_BOOTSTRAP_SERVERS
+
+            # Content Service Configuration
+            - name: Service__MaxFailLimit
+              valueFrom:
+                configMapKeyRef:
+                  name: content-current-service
+                  key: MAX_FAIL_LIMIT
+            - name: Service__ContentTopics
+              valueFrom:
+                configMapKeyRef:
+                  name: content-current-service
+                  key: CONTENT_TOPICS_OVERRIDE
+            - name: Service__AllowUpdate
+              valueFrom:
+                configMapKeyRef:
+                  name: content-current-service
+                  key: ALLOW_UPDATE
+
+            # CHES Configuration
+            - name: CHES__From
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_FROM
+            - name: CHES__EmailEnabled
+              valueFrom:
+                configMapKeyRef:
+                  name: content-current-service
+                  key: CHES_EMAIL_ENABLED
+            - name: CHES__EmailAuthorized
+              valueFrom:
+                configMapKeyRef:
+                  name: content-current-service
+                  key: CHES_EMAIL_AUTHORIZED
+
+            - name: CHES__AuthUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_AUTH_URL
+            - name: CHES__HostUri
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_HOST_URI
+            - name: CHES__Username
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: USERNAME
+            - name: CHES__Password
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: PASSWORD
+          livenessProbe:
+            httpGet:
+              path: "/health"
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: "/health"
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 3
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  test: false
+  triggers:
+    - type: ConfigChange
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+          - content-current-service
+        from:
+          kind: ImageStreamTag
+          namespace: 9b301c-tools
+          name: content-service:dev

--- a/openshift/kustomize/services/content-current/base/kustomization.yaml
+++ b/openshift/kustomize/services/content-current/base/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - config-map.yaml
+  - deploy.yaml
+  - service.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/openshift/kustomize/services/content-current/base/service.yaml
+++ b/openshift/kustomize/services/content-current/base/service.yaml
@@ -1,0 +1,27 @@
+---
+# Open up ports to communicate with the app.
+kind: Service
+apiVersion: v1
+metadata:
+  name: content-current-service
+  namespace: default
+  annotations:
+    description: Exposes and load balances the application pods.
+    created-by: jeremy.foster
+  labels:
+    name: content-current-service
+    part-of: tno
+    version: 1.0.0
+    component: content-current-service
+    managed-by: kustomize
+spec:
+  ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    part-of: tno
+    component: content-current-service
+  sessionAffinity: None
+  type: ClusterIP

--- a/openshift/kustomize/services/content-current/overlays/dev/kustomization.yaml
+++ b/openshift/kustomize/services/content-current/overlays/dev/kustomization.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-dev
+
+resources:
+  - ../../base
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+patches:
+  - target:
+      kind: DeploymentConfig
+      name: content-current-service
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 50m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 100Mi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 125m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 350Mi
+      - op: replace
+        path: /spec/triggers/1/imageChangeParams/from/name
+        value: content-service:dev

--- a/openshift/kustomize/services/content-current/overlays/prod/kustomization.yaml
+++ b/openshift/kustomize/services/content-current/overlays/prod/kustomization.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-prod
+
+resources:
+  - ../../base
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+patches:
+  - target:
+      kind: DeploymentConfig
+      name: content-current-service
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 2
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 50m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 100Mi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 125m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 350Mi
+      - op: replace
+        path: /spec/triggers/1/imageChangeParams/from/name
+        value: content-service:prod

--- a/openshift/kustomize/services/content-current/overlays/test/kustomization.yaml
+++ b/openshift/kustomize/services/content-current/overlays/test/kustomization.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-test
+
+resources:
+  - ../../base
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+patches:
+  - target:
+      kind: DeploymentConfig
+      name: content-current-service
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 50m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 100Mi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 125m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 350Mi
+      - op: replace
+        path: /spec/triggers/1/imageChangeParams/from/name
+        value: content-service:test

--- a/openshift/scripts/deploy.sh
+++ b/openshift/scripts/deploy.sh
@@ -38,7 +38,8 @@ podsImage=$(getPods image-service dc $env)
 
 podsIndexing=$(getPods indexing-service dc $env)
 podsContent=$(getPods content-service dc $env)
-podsContentTNO=$(getPods content-historic-service dc $env)
+podsContentTNOCurrent=$(getPods content-current-service dc $env)
+podsContentTNOHistoric=$(getPods content-historic-service dc $env)
 
 podsFileCopy=$(getPods filecopy-service dc $env)
 podsFolderCollection=$(getPods folder-collection-service dc $env)
@@ -113,7 +114,8 @@ scale image-service $podsImage dc $env
 
 scale indexing-service $podsIndexing dc $env
 scale content-service $podsContent dc $env
-scale content-historic-service $podsContentTNO dc $env
+scale content-current-service $podsContentTNOCurrent dc $env
+scale content-historic-service $podsContentTNOHistoric dc $env
 
 scale filecopy-service $podsFileCopy dc $env
 scale folder-collection-service $podsFolderCollection dc $env

--- a/services/net/content/ContentManager.cs
+++ b/services/net/content/ContentManager.cs
@@ -107,7 +107,7 @@ public class ContentManager : ServiceManager<ContentOptions>
 
                     // Get settings to find any overrides.
                     var settings = await this.Api.GetSettings();
-                    var topicOverride = settings.FirstOrDefault(s => s.Name == "ContentImportTopicOverride")?.Value.Split(",", StringSplitOptions.TrimEntries) ?? Array.Empty<string>();
+                    var topicOverride = settings.FirstOrDefault(s => s.Name == "ContentImportTopicOverride")?.Value.Split(",", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
                     var ingestTopics = ingest
                         .Where(i => !String.IsNullOrWhiteSpace(i.Topic) && i.ImportContent())
                         .Select(i => i.Topic).ToArray();


### PR DESCRIPTION
Need to handle the empty string in the Content Service configuration.

Added new deployment dedicated to the TNO topic.  This should ensure all other content is coming in, no matter how much is migrated.