### PR TITLE
TNO-2710 No reason to display otherSource at this point. confuses the client.

### DIFF
--- a/libs/net/template/ReportExtensions.cs
+++ b/libs/net/template/ReportExtensions.cs
@@ -367,9 +367,13 @@ public static class ReportExtensions
             ? $"{content.Source?.ShortName}"
             : "";
 
-        var source = (context.Settings.Headline.ShowSource
-                ? content?.Source?.Name
-                : "");
+        var source = "";
+        if (context.Settings.Headline.ShowSource)
+        {
+            source = !string.IsNullOrEmpty(content?.Source?.Name)
+                ? content.Source.Name
+                : content?.OtherSource;
+        }
         return $"{source}{(!String.IsNullOrWhiteSpace(name) ? $" - {name}" : "")}";
     }
 

--- a/libs/net/template/ReportExtensions.cs
+++ b/libs/net/template/ReportExtensions.cs
@@ -370,12 +370,6 @@ public static class ReportExtensions
         var source = (context.Settings.Headline.ShowSource
                 ? content?.Source?.Name
                 : "");
-        // source is empty or empty string, use the other source
-        if (String.IsNullOrWhiteSpace(source))
-        {
-            source = content?.OtherSource.ToUpperInvariant();
-        }
-
         return $"{source}{(!String.IsNullOrWhiteSpace(name) ? $" - {name}" : "")}";
     }
 


### PR DESCRIPTION
When the user clicks on the option to turn off the display of the source, the extension looks for the otherSource, which is basically the same code as the source.code. This can be confusing.