### PR TITLE
TNO-2696: Image layout fixes

### DIFF
--- a/app/editor/src/features/content/form/components/upload/Upload.tsx
+++ b/app/editor/src/features/content/form/components/upload/Upload.tsx
@@ -167,9 +167,9 @@ export const Upload: React.FC<IUploadProps> = ({
       >
         <Col flex="1">
           <img
-            height="300"
-            width="500"
-            alt=""
+            height="350"
+            width="400"
+            alt="media"
             className="image"
             src={stream?.url || fileBlobUrl}
           ></img>
@@ -195,7 +195,8 @@ export const Upload: React.FC<IUploadProps> = ({
       </Show>
       <Show visible={!!file || !!fileName || !!fileReference}>
         <Row justifyContent="flex-end" gap="0.5rem" alignItems="center">
-          {fileName}
+          <span className="file-name">{fileName}</span>
+
           <Row gap="0.25rem">
             <Show visible={values.contentType === ContentTypeName.AudioVideo}>
               <Button
@@ -216,27 +217,29 @@ export const Upload: React.FC<IUploadProps> = ({
                 {processing ? <Spinner size="8px" /> : <FaMobile />}
               </Button>
             </Show>
-            <Button
-              variant={ButtonVariant.link}
-              onClick={() => onDownload?.()}
-              disabled={!onDownload || !file || !downloadable || !fileName || !fileReference}
-              className="file-name"
-              tooltip={`Download ${!!fileName ? fileName : 'not available'}`}
-            >
-              <FaDownload />
-            </Button>
-            <Button
-              disabled={!fileName || (!fileReference && !file)}
-              variant={ButtonVariant.danger}
-              className="delete"
-              onClick={() => {
-                if (verifyDelete) toggle();
-                else handleDelete();
-              }}
-            >
-              <FaTrash />
-            </Button>
           </Row>
+        </Row>
+        <Row className="upload-buttons">
+          <Button
+            variant={ButtonVariant.link}
+            onClick={() => onDownload?.()}
+            disabled={!onDownload || !file || !downloadable || !fileName || !fileReference}
+            className="file-name"
+            tooltip={`Download ${!!fileName ? fileName : 'not available'}`}
+          >
+            <FaDownload />
+          </Button>
+          <Button
+            disabled={!fileName || (!fileReference && !file)}
+            variant={ButtonVariant.danger}
+            className="delete"
+            onClick={() => {
+              if (verifyDelete) toggle();
+              else handleDelete();
+            }}
+          >
+            <FaTrash />
+          </Button>
         </Row>
       </Show>
       {/* Modal to appear when removing a file */}

--- a/app/editor/src/features/content/form/components/upload/styled/Upload.tsx
+++ b/app/editor/src/features/content/form/components/upload/styled/Upload.tsx
@@ -3,6 +3,25 @@ import styled from 'styled-components';
 export const Upload = styled.div`
   display: flex;
   flex-direction: column;
+  margin-top: 2.5rem;
+  padding-bottom: 0.5rem;
+  img,
+  video,
+  audio {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .file-name {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .upload-buttons {
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 0.5em;
+  }
 
   > div:first-child {
     justify-content: center;


### PR DESCRIPTION
In this PR:

- this was a ticket to get images showing properly on the editor site / subscriber site; however, that seems to have been fixed by someone else
- instead i did some css fixes that make the media appear a little cleaner on the editor site
- images are confirmed working on both editor and subscriber 