### PR TITLE
Fix Reporting Service

### DIFF
--- a/api/net/Areas/Services/Controllers/FolderController.cs
+++ b/api/net/Areas/Services/Controllers/FolderController.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Services.Models.Folder;
 using TNO.API.Models;
-using TNO.Core.Exceptions;
 using TNO.DAL.Services;
 using TNO.Keycloak;
 


### PR DESCRIPTION
The hope here is that this will resolve the optimistic concurrency error.  But it may just push the error to the UI when the user attempts to save their next change.