### PR TITLE
TNO-2385 Fix FFmpge Service

### DIFF
--- a/services/net/ffmpeg/appsettings.json
+++ b/services/net/ffmpeg/appsettings.json
@@ -65,7 +65,7 @@
     "Consumer": {
       "GroupId": "FFmpeg",
       "BootstrapServers": "kafka-broker-0.kafka-headless:9092,kafka-broker-1.kafka-headless:9092,kafka-broker-2.kafka-headless:9092",
-      "AutoOffsetReset": "Earliest",
+      "AutoOffsetReset": "Latest",
       "MaxInFlight": 5,
       "EnableAutoCommit": false,
       "MaxThreads": 10


### PR DESCRIPTION
Changing the FFmpeg Service to start at the end of the Kafka queue instead of the beginning.