### PR TITLE
TNO-2720: Impersonation for my minster fix

### DIFF
--- a/app/subscriber/src/features/settings/MyMinisterSettings.tsx
+++ b/app/subscriber/src/features/settings/MyMinisterSettings.tsx
@@ -34,7 +34,6 @@ export const MyMinisterSettings: React.FC = () => {
         return;
       }
       const baseProfile = impersonate ?? profile;
-      console.log('baseProfile', baseProfile);
       const createUser = (): ISubscriberUserModel => {
         // use impersonate if it exists, otherwise use profile
         return {

--- a/app/subscriber/src/features/settings/MyMinisterSettings.tsx
+++ b/app/subscriber/src/features/settings/MyMinisterSettings.tsx
@@ -34,6 +34,7 @@ export const MyMinisterSettings: React.FC = () => {
         return;
       }
       const baseProfile = impersonate ?? profile;
+      console.log('baseProfile', baseProfile);
       const createUser = (): ISubscriberUserModel => {
         // use impersonate if it exists, otherwise use profile
         return {
@@ -48,7 +49,7 @@ export const MyMinisterSettings: React.FC = () => {
       const user = createUser();
 
       try {
-        await updateUser(user);
+        await updateUser(user, !!impersonate);
         toast.success('Your minister(s) have successfully been updated.');
       } catch (error) {
         // Handle the error, if needed

--- a/app/subscriber/src/store/hooks/subscriber/useUsers.ts
+++ b/app/subscriber/src/store/hooks/subscriber/useUsers.ts
@@ -42,7 +42,16 @@ export const useUsers = (): IUserController => {
         return response.data;
       },
     }),
-    [dispatch, getUser, findUsers, storeMyProfile, userInfo, storeUserInfo, updateUser],
+    [
+      dispatch,
+      getUser,
+      findUsers,
+      storeMyProfile,
+      storeImpersonate,
+      userInfo,
+      storeUserInfo,
+      updateUser,
+    ],
   );
 
   return controller;

--- a/app/subscriber/src/store/hooks/subscriber/useUsers.ts
+++ b/app/subscriber/src/store/hooks/subscriber/useUsers.ts
@@ -13,14 +13,14 @@ import {
 interface IUserController {
   getUser: () => Promise<ISubscriberUserModel>;
   findUsers: (filter: IUserFilter) => Promise<IPaged<IUserModel>>;
-  updateUser: (model: ISubscriberUserModel) => Promise<ISubscriberUserModel>;
+  updateUser: (model: ISubscriberUserModel, impersonate?: boolean) => Promise<ISubscriberUserModel>;
 }
 
 export const useUsers = (): IUserController => {
   const { findUsers } = useApiAdminUsers();
   const { getUser, updateUser } = useApiSubscriberUsers();
   const dispatch = useAjaxWrapper();
-  const [, { storeMyProfile }] = useProfileStore();
+  const [, { storeMyProfile, storeImpersonate }] = useProfileStore();
   const [{ userInfo }, { storeUserInfo }] = useAppStore();
 
   const controller = React.useMemo(
@@ -33,11 +33,11 @@ export const useUsers = (): IUserController => {
         const response = await dispatch('find-users', () => findUsers(filter));
         return response.data;
       },
-      updateUser: async (model: ISubscriberUserModel) => {
+      updateUser: async (model: ISubscriberUserModel, impersonate?: boolean) => {
         const response = await dispatch<ISubscriberUserModel>('update-user', () =>
           updateUser(model),
         );
-        storeMyProfile(response.data);
+        impersonate ? storeImpersonate(response.data) : storeMyProfile(response.data);
         if (userInfo) storeUserInfo({ ...userInfo, preferences: response.data.preferences });
         return response.data;
       },


### PR DESCRIPTION
`updateUsers` had a `storeMyProfile` which was overwriting the `profile.preferences.impersonate`, this will fix that allowing the conditionals to be correct in a `useEffect` after updating a user. 

I am not sure why it was working locally before this change...

Key changes:

- update user now takes an optional prop to check if it is being used in an impersonation or not so the user's profile will not get overwritten by the wrong information