### PR TITLE
Fix missing attributes in Press Gallery

### DIFF
--- a/app/subscriber/src/features/press-gallery/PressGallery.tsx
+++ b/app/subscriber/src/features/press-gallery/PressGallery.tsx
@@ -229,6 +229,9 @@ export const PressGallery: React.FC = () => {
       <ContentList
         onContentSelected={handleContentSelected}
         content={content}
+        showDate
+        showTime
+        showSeries
         selected={selected}
       />
     </styled.PressGallery>


### PR DESCRIPTION
Splitting this off as the other PR had some unneeded code. This will ensure Press Gallery list behaves the same as the rest of the application