### PR TITLE
TNO-2864 Separate API

### DIFF
--- a/api/net/Config/SIgnalROptions.cs
+++ b/api/net/Config/SIgnalROptions.cs
@@ -7,6 +7,11 @@ public class SignalROptions
 {
     #region Properties
     /// <summary>
+    /// get/set - Whether to enable the Kafka back plane.
+    /// </summary>
+    public bool EnableKafkaBackPlane { get; set; } = true;
+
+    /// <summary>
     /// get/set - Path pattern to SignalR hub.
     /// </summary>
     public string HubPath { get; set; } = "/hub";

--- a/api/net/Program.cs
+++ b/api/net/Program.cs
@@ -148,7 +148,8 @@ builder.Services.AddAuthentication(options =>
         };
     });
 
-builder.Services.AddKafkaHubBackplane(config);
+if (signalROptions.EnableKafkaBackPlane)
+    builder.Services.AddKafkaHubBackPlane(config);
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddTransient<IConfigureOptions<SwaggerGenOptions>, TNO.API.Config.Swagger.ConfigureSwaggerOptions>();

--- a/libs/net/kafka/Extensions/ServiceCollectionExtensions.cs
+++ b/libs/net/kafka/Extensions/ServiceCollectionExtensions.cs
@@ -47,7 +47,7 @@ public static class ServiceCollectionExtensions
     /// <param name="services"></param>
     /// <param name="config"></param>
     /// <returns></returns>
-    public static IServiceCollection AddKafkaHubBackplane(this IServiceCollection services, IConfiguration config)
+    public static IServiceCollection AddKafkaHubBackPlane(this IServiceCollection services, IConfiguration config)
     {
         return services
             .Configure<KafkaHubConfig>(config.GetSection("Kafka"))

--- a/openshift/kustomize/api-services/base/deploy.yaml
+++ b/openshift/kustomize/api-services/base/deploy.yaml
@@ -1,0 +1,261 @@
+---
+# How the app will be deployed to the pod.
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: api-services
+  namespace: default
+  annotations:
+    description: Defines how to deploy api
+  labels:
+    name: api-services
+    part-of: tno
+    version: 1.0.0
+    component: api-services
+    managed-by: kustomize
+    created-by: jeremy.foster
+spec:
+  replicas: 1
+  test: false
+  selector:
+    part-of: tno
+    component: api-services
+  strategy:
+    rollingParams:
+      intervalSeconds: 1
+      maxSurge: 25%
+      maxUnavailable: 25%
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+    type: Rolling
+  triggers:
+    - type: ConfigChange
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+          - api-services
+        from:
+          kind: ImageStreamTag
+          namespace: 9b301c-tools
+          name: api:dev
+  template:
+    metadata:
+      name: api-services
+      labels:
+        part-of: tno
+        component: api-services
+    spec:
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: api-storage
+          persistentVolumeClaim:
+            claimName: api-storage
+        - name: ingest-storage
+          persistentVolumeClaim:
+            claimName: ingest-storage
+      containers:
+        - name: api-services
+          image: ""
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: api-storage
+              mountPath: /mnt/data
+            - name: ingest-storage
+              mountPath: /mnt/ingest
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1536Mi
+            requests:
+              cpu: 100m
+              memory: 350Mi
+          env:
+            - name: ASPNETCORE_URLS
+              value: http://+:8080
+            - name: HubPath
+              value: /hub
+            - name: Charts__Url
+              value: "http://charts-api:8080"
+
+            - name: Logging__LogLevel__TNO
+              value: Information
+
+            - name: Storage__UploadPath
+              value: /mnt/data
+            - name: Storage__CapturePath
+              value: /mnt/ingest
+
+            - name: SignalR__EnableKafkaBackPlane
+              value: false
+
+            - name: Keycloak__Authority
+              valueFrom:
+                configMapKeyRef:
+                  name: keycloak
+                  key: KEYCLOAK_AUTHORITY
+            - name: Keycloak__Audience
+              valueFrom:
+                configMapKeyRef:
+                  name: keycloak
+                  key: KEYCLOAK_AUDIENCE
+            - name: Keycloak__Issuer
+              valueFrom:
+                configMapKeyRef:
+                  name: keycloak
+                  key: KEYCLOAK_ISSUER
+            - name: Keycloak__Secret
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak
+                  key: KEYCLOAK_CLIENT_SECRET
+
+            - name: CSS__IntegrationId
+              valueFrom:
+                configMapKeyRef:
+                  name: keycloak
+                  key: CSS_INTEGRATION_ID
+            - name: CSS__Environment
+              valueFrom:
+                configMapKeyRef:
+                  name: keycloak
+                  key: CSS_ENVIRONMENT
+            - name: CSS__ApiUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: keycloak
+                  key: CSS_API_URL
+            - name: CSS__Authority
+              valueFrom:
+                configMapKeyRef:
+                  name: keycloak
+                  key: CSS_AUTHORITY
+            - name: CSS__ClientId
+              valueFrom:
+                configMapKeyRef:
+                  name: keycloak
+                  key: CSS_CLIENT_ID
+            - name: CSS__Secret
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak
+                  key: CSS_SECRET
+
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              valueFrom:
+                configMapKeyRef:
+                  name: api
+                  key: KAFKA_BOOTSTRAP_SERVERS
+
+            - name: ConnectionStrings__TNO
+              valueFrom:
+                configMapKeyRef:
+                  name: api
+                  key: CONNECTION_STRING
+            - name: DB_POSTGRES_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: crunchy-pguser-admin
+                  key: user
+            - name: DB_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: crunchy-pguser-admin
+                  key: password
+
+            - name: Elastic__Url
+              valueFrom:
+                configMapKeyRef:
+                  name: api
+                  key: ELASTIC_URIS
+            - name: ELASTIC_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: elastic
+                  key: USERNAME
+            - name: ELASTIC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: elastic
+                  key: PASSWORD
+
+            - name: Reporting__SubscriberAppUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: reporting-shared
+                  key: REPORTING_BASE_URL
+            - name: Reporting__ViewContentUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: reporting-shared
+                  key: REPORTING_VIEW_CONTENT_URL
+            - name: Reporting__RequestTranscriptUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: reporting-shared
+                  key: REPORTING_REQUEST_TRANSCRIPT_URL
+
+            # CHES Configuration
+            - name: CHES__From
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_FROM
+            - name: CHES__EmailEnabled
+              valueFrom:
+                configMapKeyRef:
+                  name: api
+                  key: CHES_EMAIL_ENABLED
+            - name: CHES__EmailAuthorized
+              valueFrom:
+                configMapKeyRef:
+                  name: api
+                  key: CHES_EMAIL_AUTHORIZED
+
+            - name: CHES__AuthUrl
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_AUTH_URL
+            - name: CHES__HostUri
+              valueFrom:
+                configMapKeyRef:
+                  name: ches
+                  key: CHES_HOST_URI
+            - name: CHES__Username
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: USERNAME
+            - name: CHES__Password
+              valueFrom:
+                secretKeyRef:
+                  name: ches
+                  key: PASSWORD
+
+          livenessProbe:
+            httpGet:
+              path: "/health"
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: "/health"
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 30
+            timeoutSeconds: 60
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 3

--- a/openshift/kustomize/api-services/base/kustomization.yaml
+++ b/openshift/kustomize/api-services/base/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deploy.yaml
+  - service.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/openshift/kustomize/api-services/base/service.yaml
+++ b/openshift/kustomize/api-services/base/service.yaml
@@ -1,0 +1,26 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: api-services
+  namespace: default
+  annotations:
+    description: Exposes and load balances the api pods.
+  labels:
+    name: api-services
+    part-of: tno
+    version: 1.0.0
+    component: api-services
+    managed-by: kustomize
+    created-by: jeremy.foster
+spec:
+  ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    part-of: tno
+    component: api-services
+  sessionAffinity: None
+  type: ClusterIP

--- a/openshift/kustomize/api-services/overlays/dev/kustomization.yaml
+++ b/openshift/kustomize/api-services/overlays/dev/kustomization.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-dev
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: DeploymentConfig
+      name: api
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 3
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 100m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 350Mi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 500m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 1536Mi
+      - op: replace
+        path: /spec/triggers/1/imageChangeParams/from/name
+        value: image-registry.openshift-image-registry.svc:5000/9b301c-tools/api:dev

--- a/openshift/kustomize/api-services/overlays/prod/kustomization.yaml
+++ b/openshift/kustomize/api-services/overlays/prod/kustomization.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-prod
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: DeploymentConfig
+      name: api
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 3
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 100m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 350Mi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 500m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 1536Mi
+      - op: replace
+        path: /spec/triggers/1/imageChangeParams/from/name
+        value: image-registry.openshift-image-registry.svc:5000/9b301c-tools/api:prod

--- a/openshift/kustomize/api-services/overlays/test/kustomization.yaml
+++ b/openshift/kustomize/api-services/overlays/test/kustomization.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-test
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: DeploymentConfig
+      name: api
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 3
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 100m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 350Mi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 500m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 1536Mi
+      - op: replace
+        path: /spec/triggers/1/imageChangeParams/from/name
+        value: image-registry.openshift-image-registry.svc:5000/9b301c-tools/api:prod

--- a/openshift/kustomize/api/base/route-editor.yaml
+++ b/openshift/kustomize/api/base/route-editor.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   annotations:
     haproxy.router.openshift.io/rewrite-target: /
+    haproxy.router.openshift.io/timeout: 2m
   labels:
     name: api-editor
     part-of: tno
@@ -32,100 +33,11 @@ spec:
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  name: api-editor-0
-  namespace: default
-  annotations:
-    haproxy.router.openshift.io/rewrite-target: /
-  labels:
-    name: api-editor-0
-    part-of: tno
-    version: 1.0.0
-    component: api
-    managed-by: kustomize
-    created-by: jeremy.foster
-spec:
-  host: tno-dev-0.apps.silver.devops.gov.bc.ca
-  path: /api
-  port:
-    targetPort: 8080-tcp
-  tls:
-    insecureEdgeTerminationPolicy: Redirect
-    termination: edge
-    # caCertificate: ""
-    # certificate: ""
-    # key: ""
-  to:
-    kind: Service
-    name: api-0
-    weight: 100
----
-kind: Route
-apiVersion: route.openshift.io/v1
-metadata:
-  name: api-editor-1
-  namespace: default
-  annotations:
-    haproxy.router.openshift.io/rewrite-target: /
-  labels:
-    name: api-editor-1
-    part-of: tno
-    version: 1.0.0
-    component: api
-    managed-by: kustomize
-    created-by: jeremy.foster
-spec:
-  host: tno-dev-1.apps.silver.devops.gov.bc.ca
-  path: /api
-  port:
-    targetPort: 8080-tcp
-  tls:
-    insecureEdgeTerminationPolicy: Redirect
-    termination: edge
-    # caCertificate: ""
-    # certificate: ""
-    # key: ""
-  to:
-    kind: Service
-    name: api-1
-    weight: 100
----
-kind: Route
-apiVersion: route.openshift.io/v1
-metadata:
-  name: api-editor-2
-  namespace: default
-  annotations:
-    haproxy.router.openshift.io/rewrite-target: /
-  labels:
-    name: api-editor-2
-    part-of: tno
-    version: 1.0.0
-    component: api
-    managed-by: kustomize
-    created-by: jeremy.foster
-spec:
-  host: tno-dev-2.apps.silver.devops.gov.bc.ca
-  path: /api
-  port:
-    targetPort: 8080-tcp
-  tls:
-    insecureEdgeTerminationPolicy: Redirect
-    termination: edge
-    # caCertificate: ""
-    # certificate: ""
-    # key: ""
-  to:
-    kind: Service
-    name: api-2
-    weight: 100
----
-kind: Route
-apiVersion: route.openshift.io/v1
-metadata:
   name: api-editor-tls
   namespace: default
   annotations:
     haproxy.router.openshift.io/rewrite-target: /
+    haproxy.router.openshift.io/timeout: 2m
   labels:
     name: api-editor-tls
     part-of: tno
@@ -148,3 +60,93 @@ spec:
     kind: Service
     name: api
     weight: 100
+# ---
+# kind: Route
+# apiVersion: route.openshift.io/v1
+# metadata:
+#   name: api-editor-0
+#   namespace: default
+#   annotations:
+#     haproxy.router.openshift.io/rewrite-target: /
+#   labels:
+#     name: api-editor-0
+#     part-of: tno
+#     version: 1.0.0
+#     component: api
+#     managed-by: kustomize
+#     created-by: jeremy.foster
+# spec:
+#   host: tno-dev-0.apps.silver.devops.gov.bc.ca
+#   path: /api
+#   port:
+#     targetPort: 8080-tcp
+#   tls:
+#     insecureEdgeTerminationPolicy: Redirect
+#     termination: edge
+#     # caCertificate: ""
+#     # certificate: ""
+#     # key: ""
+#   to:
+#     kind: Service
+#     name: api-0
+#     weight: 100
+# ---
+# kind: Route
+# apiVersion: route.openshift.io/v1
+# metadata:
+#   name: api-editor-1
+#   namespace: default
+#   annotations:
+#     haproxy.router.openshift.io/rewrite-target: /
+#   labels:
+#     name: api-editor-1
+#     part-of: tno
+#     version: 1.0.0
+#     component: api
+#     managed-by: kustomize
+#     created-by: jeremy.foster
+# spec:
+#   host: tno-dev-1.apps.silver.devops.gov.bc.ca
+#   path: /api
+#   port:
+#     targetPort: 8080-tcp
+#   tls:
+#     insecureEdgeTerminationPolicy: Redirect
+#     termination: edge
+#     # caCertificate: ""
+#     # certificate: ""
+#     # key: ""
+#   to:
+#     kind: Service
+#     name: api-1
+#     weight: 100
+# ---
+# kind: Route
+# apiVersion: route.openshift.io/v1
+# metadata:
+#   name: api-editor-2
+#   namespace: default
+#   annotations:
+#     haproxy.router.openshift.io/rewrite-target: /
+#   labels:
+#     name: api-editor-2
+#     part-of: tno
+#     version: 1.0.0
+#     component: api
+#     managed-by: kustomize
+#     created-by: jeremy.foster
+# spec:
+#   host: tno-dev-2.apps.silver.devops.gov.bc.ca
+#   path: /api
+#   port:
+#     targetPort: 8080-tcp
+#   tls:
+#     insecureEdgeTerminationPolicy: Redirect
+#     termination: edge
+#     # caCertificate: ""
+#     # certificate: ""
+#     # key: ""
+#   to:
+#     kind: Service
+#     name: api-2
+#     weight: 100

--- a/openshift/kustomize/api/base/route-subscriber.yaml
+++ b/openshift/kustomize/api/base/route-subscriber.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: default
   annotations:
     haproxy.router.openshift.io/rewrite-target: /
+    haproxy.router.openshift.io/timeout: 2m
   labels:
     name: api-subscriber
     part-of: tno
@@ -32,100 +33,11 @@ spec:
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  name: api-subscriber-0
-  namespace: default
-  annotations:
-    haproxy.router.openshift.io/rewrite-target: /
-  labels:
-    name: api-subscriber-0
-    part-of: tno
-    version: 1.0.0
-    component: api
-    managed-by: kustomize
-    created-by: jeremy.foster
-spec:
-  host: mmi-dev-0.apps.silver.devops.gov.bc.ca
-  path: /api
-  port:
-    targetPort: 8080-tcp
-  tls:
-    insecureEdgeTerminationPolicy: Redirect
-    termination: edge
-    # caCertificate: ""
-    # certificate: ""
-    # key: ""
-  to:
-    kind: Service
-    name: api-0
-    weight: 100
----
-kind: Route
-apiVersion: route.openshift.io/v1
-metadata:
-  name: api-subscriber-1
-  namespace: default
-  annotations:
-    haproxy.router.openshift.io/rewrite-target: /
-  labels:
-    name: api-subscriber-1
-    part-of: tno
-    version: 1.0.0
-    component: api
-    managed-by: kustomize
-    created-by: jeremy.foster
-spec:
-  host: mmi-dev-1.apps.silver.devops.gov.bc.ca
-  path: /api
-  port:
-    targetPort: 8080-tcp
-  tls:
-    insecureEdgeTerminationPolicy: Redirect
-    termination: edge
-    # caCertificate: ""
-    # certificate: ""
-    # key: ""
-  to:
-    kind: Service
-    name: api-1
-    weight: 100
----
-kind: Route
-apiVersion: route.openshift.io/v1
-metadata:
-  name: api-subscriber-2
-  namespace: default
-  annotations:
-    haproxy.router.openshift.io/rewrite-target: /
-  labels:
-    name: api-subscriber-2
-    part-of: tno
-    version: 1.0.0
-    component: api
-    managed-by: kustomize
-    created-by: jeremy.foster
-spec:
-  host: mmi-dev-2.apps.silver.devops.gov.bc.ca
-  path: /api
-  port:
-    targetPort: 8080-tcp
-  tls:
-    insecureEdgeTerminationPolicy: Redirect
-    termination: edge
-    # caCertificate: ""
-    # certificate: ""
-    # key: ""
-  to:
-    kind: Service
-    name: api-2
-    weight: 100
----
-kind: Route
-apiVersion: route.openshift.io/v1
-metadata:
   name: api-subscriber-tls
   namespace: default
   annotations:
     haproxy.router.openshift.io/rewrite-target: /
+    haproxy.router.openshift.io/timeout: 2m
   labels:
     name: api-subscriber-tls
     part-of: tno
@@ -148,3 +60,93 @@ spec:
     kind: Service
     name: api
     weight: 100
+# ---
+# kind: Route
+# apiVersion: route.openshift.io/v1
+# metadata:
+#   name: api-subscriber-0
+#   namespace: default
+#   annotations:
+#     haproxy.router.openshift.io/rewrite-target: /
+#   labels:
+#     name: api-subscriber-0
+#     part-of: tno
+#     version: 1.0.0
+#     component: api
+#     managed-by: kustomize
+#     created-by: jeremy.foster
+# spec:
+#   host: mmi-dev-0.apps.silver.devops.gov.bc.ca
+#   path: /api
+#   port:
+#     targetPort: 8080-tcp
+#   tls:
+#     insecureEdgeTerminationPolicy: Redirect
+#     termination: edge
+#     # caCertificate: ""
+#     # certificate: ""
+#     # key: ""
+#   to:
+#     kind: Service
+#     name: api-0
+#     weight: 100
+# ---
+# kind: Route
+# apiVersion: route.openshift.io/v1
+# metadata:
+#   name: api-subscriber-1
+#   namespace: default
+#   annotations:
+#     haproxy.router.openshift.io/rewrite-target: /
+#   labels:
+#     name: api-subscriber-1
+#     part-of: tno
+#     version: 1.0.0
+#     component: api
+#     managed-by: kustomize
+#     created-by: jeremy.foster
+# spec:
+#   host: mmi-dev-1.apps.silver.devops.gov.bc.ca
+#   path: /api
+#   port:
+#     targetPort: 8080-tcp
+#   tls:
+#     insecureEdgeTerminationPolicy: Redirect
+#     termination: edge
+#     # caCertificate: ""
+#     # certificate: ""
+#     # key: ""
+#   to:
+#     kind: Service
+#     name: api-1
+#     weight: 100
+# ---
+# kind: Route
+# apiVersion: route.openshift.io/v1
+# metadata:
+#   name: api-subscriber-2
+#   namespace: default
+#   annotations:
+#     haproxy.router.openshift.io/rewrite-target: /
+#   labels:
+#     name: api-subscriber-2
+#     part-of: tno
+#     version: 1.0.0
+#     component: api
+#     managed-by: kustomize
+#     created-by: jeremy.foster
+# spec:
+#   host: mmi-dev-2.apps.silver.devops.gov.bc.ca
+#   path: /api
+#   port:
+#     targetPort: 8080-tcp
+#   tls:
+#     insecureEdgeTerminationPolicy: Redirect
+#     termination: edge
+#     # caCertificate: ""
+#     # certificate: ""
+#     # key: ""
+#   to:
+#     kind: Service
+#     name: api-2
+#     weight: 100

--- a/openshift/kustomize/api/overlays/prod/kustomization.yaml
+++ b/openshift/kustomize/api/overlays/prod/kustomization.yaml
@@ -125,6 +125,3 @@ patches:
       - op: replace
         path: /spec/template/spec/containers/0/image
         value: image-registry.openshift-image-registry.svc:5000/9b301c-tools/api:prod
-      - op: replace
-        path: /spec/template/spec/containers/0/image
-        value: image-registry.openshift-image-registry.svc:5000/9b301c-tools/api:prod

--- a/openshift/kustomize/api/overlays/test/kustomization.yaml
+++ b/openshift/kustomize/api/overlays/test/kustomization.yaml
@@ -125,6 +125,3 @@ patches:
       - op: replace
         path: /spec/template/spec/containers/0/image
         value: image-registry.openshift-image-registry.svc:5000/9b301c-tools/api:test
-      - op: replace
-        path: /spec/template/spec/containers/0/image
-        value: image-registry.openshift-image-registry.svc:5000/9b301c-tools/api:test

--- a/openshift/kustomize/shared_resources/base/services-config-map.yaml
+++ b/openshift/kustomize/shared_resources/base/services-config-map.yaml
@@ -14,7 +14,7 @@ metadata:
     component: services
     managed-by: kustomize
 data:
-  API_HOST_URL: http://api:8080
+  API_HOST_URL: http://api-services:8080
 
   KEYCLOAK_AUTHORITY: https://dev.loginproxy.gov.bc.ca/auth
   KEYCLOAK_AUDIENCE: mmia-service-account-3994


### PR DESCRIPTION
Standing up separate API for the backend services.  This will allow us to dedicate the standard API for the frontend Editor and Subscriber applications.  This will also allow us to turn on debug logging to help us narrow down the network issues we're seeing.