### PR TITLE
TNO-2865 Add reverse-proxy

### DIFF
--- a/network/reverse-proxy/editor/Dockerfile
+++ b/network/reverse-proxy/editor/Dockerfile
@@ -1,0 +1,5 @@
+FROM image-registry.openshift-image-registry.svc:5000/9b301c-tools/nginx-unprivileged:1.20
+
+COPY ./config /etc/nginx/conf.d
+
+EXPOSE 8080

--- a/network/reverse-proxy/editor/config/default.conf
+++ b/network/reverse-proxy/editor/config/default.conf
@@ -1,0 +1,42 @@
+server {
+  listen 8080;
+  listen [::]:8080;
+  server_name localhost;
+
+  location /nginx-status {
+    access_log off;
+    default_type text/plain;
+    return 200 "healthy\n";
+  }
+
+  location /api {
+    client_max_body_size 5120M;
+    rewrite /api(.*) $1 break;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Host $server_name;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header X-NginX-Proxy true;
+    proxy_ssl_session_reuse off;
+    proxy_set_header Host $http_host;
+    proxy_cache_bypass $http_upgrade;
+    proxy_pass http://api:8080;
+    proxy_redirect off;
+  }
+
+  location / {
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-NginX-Proxy true;
+    proxy_ssl_session_reuse off;
+    proxy_set_header Host $http_host;
+    proxy_cache_bypass $http_upgrade;
+    proxy_pass http://editor:8080;
+    proxy_redirect off;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
+}

--- a/network/reverse-proxy/subscriber/Dockerfile
+++ b/network/reverse-proxy/subscriber/Dockerfile
@@ -1,0 +1,5 @@
+FROM image-registry.openshift-image-registry.svc:5000/9b301c-tools/nginx-unprivileged:1.20
+
+COPY ./config /etc/nginx/conf.d
+
+EXPOSE 8080

--- a/network/reverse-proxy/subscriber/config/default.conf
+++ b/network/reverse-proxy/subscriber/config/default.conf
@@ -1,0 +1,42 @@
+server {
+  listen 8080;
+  listen [::]:8080;
+  server_name localhost;
+
+  location /nginx-status {
+    access_log off;
+    default_type text/plain;
+    return 200 "healthy\n";
+  }
+
+  location /api {
+    client_max_body_size 5120M;
+    rewrite /api(.*) $1 break;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Host $server_name;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header X-NginX-Proxy true;
+    proxy_ssl_session_reuse off;
+    proxy_set_header Host $http_host;
+    proxy_cache_bypass $http_upgrade;
+    proxy_pass http://api:8080;
+    proxy_redirect off;
+  }
+
+  location / {
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-NginX-Proxy true;
+    proxy_ssl_session_reuse off;
+    proxy_set_header Host $http_host;
+    proxy_cache_bypass $http_upgrade;
+    proxy_pass http://subscriber:8080;
+    proxy_redirect off;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
+}

--- a/openshift/kustomize/nginx-reverse-proxy/base/deploy.yaml
+++ b/openshift/kustomize/nginx-reverse-proxy/base/deploy.yaml
@@ -1,0 +1,175 @@
+# How the app will be deployed to the pod.
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: nginx-editor
+  namespace: default
+  annotations:
+    description: Defines how to deploy nginx
+  labels:
+    name: nginx-editor
+    part-of: tno
+    version: 1.0.0
+    component: nginx-editor
+    managed-by: kustomize
+    created-by: jeremy.foster
+spec:
+  replicas: 1
+  selector:
+    name: nginx-editor
+    part-of: tno
+    component: nginx-editor
+  strategy:
+    rollingParams:
+      intervalSeconds: 1
+      maxSurge: 25%
+      maxUnavailable: 25%
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+    type: Rolling
+  template:
+    metadata:
+      name: nginx-editor
+      labels:
+        name: nginx-editor
+        part-of: tno
+        component: nginx-editor
+    spec:
+      containers:
+        - name: nginx-editor
+          image: ""
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 20m
+              memory: 50Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          # livenessProbe:
+          #   httpGet:
+          #     path: '/nginx-status'
+          #     port: 8080
+          #     scheme: HTTP
+          #   initialDelaySeconds: 120
+          #   timeoutSeconds: 60
+          #   periodSeconds: 30
+          #   successThreshold: 1
+          #   failureThreshold: 3
+          # readinessProbe:
+          #   httpGet:
+          #     path: '/nginx-status'
+          #     port: 8080
+          #     scheme: HTTP
+          #   initialDelaySeconds: 120
+          #   timeoutSeconds: 60
+          #   periodSeconds: 30
+          #   successThreshold: 1
+          #   failureThreshold: 3
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  test: false
+  triggers:
+    - type: ConfigChange
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+          - nginx-editor
+        from:
+          kind: ImageStreamTag
+          namespace: 9b301c-tools
+          name: nginx-editor:dev
+---
+# How the app will be deployed to the pod.
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: nginx-subscriber
+  namespace: default
+  annotations:
+    description: Defines how to deploy nginx
+  labels:
+    name: nginx-subscriber
+    part-of: tno
+    version: 1.0.0
+    component: nginx-subscriber
+    managed-by: kustomize
+    created-by: jeremy.foster
+spec:
+  replicas: 1
+  selector:
+    name: nginx-subscriber
+    part-of: tno
+    component: nginx-subscriber
+  strategy:
+    rollingParams:
+      intervalSeconds: 1
+      maxSurge: 25%
+      maxUnavailable: 25%
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+    type: Rolling
+  template:
+    metadata:
+      name: nginx-subscriber
+      labels:
+        name: nginx-subscriber
+        part-of: tno
+        component: nginx-subscriber
+    spec:
+      containers:
+        - name: nginx-subscriber
+          image: ""
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 20m
+              memory: 50Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          # livenessProbe:
+          #   httpGet:
+          #     path: '/nginx-status'
+          #     port: 8080
+          #     scheme: HTTP
+          #   initialDelaySeconds: 120
+          #   timeoutSeconds: 60
+          #   periodSeconds: 30
+          #   successThreshold: 1
+          #   failureThreshold: 3
+          # readinessProbe:
+          #   httpGet:
+          #     path: '/nginx-status'
+          #     port: 8080
+          #     scheme: HTTP
+          #   initialDelaySeconds: 120
+          #   timeoutSeconds: 60
+          #   periodSeconds: 30
+          #   successThreshold: 1
+          #   failureThreshold: 3
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  test: false
+  triggers:
+    - type: ConfigChange
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+          - nginx-subscriber
+        from:
+          kind: ImageStreamTag
+          namespace: 9b301c-tools
+          name: nginx-subscriber:dev

--- a/openshift/kustomize/nginx-reverse-proxy/base/kustomization.yaml
+++ b/openshift/kustomize/nginx-reverse-proxy/base/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deploy.yaml
+  - service.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/openshift/kustomize/nginx-reverse-proxy/base/service.yaml
+++ b/openshift/kustomize/nginx-reverse-proxy/base/service.yaml
@@ -1,0 +1,51 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx-editor
+  namespace: default
+  annotations:
+    description: Exposes and load balances the application pods.
+  labels:
+    name: nginx-editor
+    part-of: tno
+    version: 1.0.0
+    component: nginx-editor
+    managed-by: kustomize
+    created-by: jeremy.foster
+spec:
+  ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    part-of: tno
+    component: nginx-editor
+  sessionAffinity: None
+  type: ClusterIP
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx-subscriber
+  namespace: default
+  annotations:
+    description: Exposes and load balances the application pods.
+  labels:
+    name: nginx-subscriber
+    part-of: tno
+    version: 1.0.0
+    component: nginx-editor
+    managed-by: kustomize
+    created-by: jeremy.foster
+spec:
+  ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    part-of: tno
+    component: nginx-subscriber
+  sessionAffinity: None
+  type: ClusterIP

--- a/openshift/kustomize/nginx-reverse-proxy/build/base/build.yaml
+++ b/openshift/kustomize/nginx-reverse-proxy/build/base/build.yaml
@@ -1,0 +1,120 @@
+---
+# The final build image.
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: nginx-editor
+  annotations:
+    description: Destination for built images.
+  labels:
+    name: nginx-editor
+    part-of: tno
+    version: 1.0.0
+    component: nginx-editor
+    managed-by: kustomize
+    created-by: jeremy.foster
+
+---
+# The build config that will be created will be named for the branch you created it for.
+kind: BuildConfig
+apiVersion: build.openshift.io/v1
+metadata:
+  name: nginx-editor.dev
+  annotations:
+    description: Build image from Dockerfile in git repo.
+  labels:
+    name: nginx-editor
+    part-of: tno
+    version: 1.0.0
+    component: nginx-editor
+    managed-by: kustomize
+    created-by: jeremy.foster
+    branch: dev
+spec:
+  completionDeadlineSeconds: 1800
+  triggers:
+    - type: ImageChange
+    - type: ConfigChange
+  runPolicy: Serial
+  source:
+    git:
+      uri: https://github.com/bcgov/tno.git
+      ref: dev
+    contextDir: network/reverse-proxy/editor
+  strategy:
+    type: Docker
+    dockerStrategy:
+      imageOptimizationPolicy: SkipLayers
+      dockerfilePath: Dockerfile
+  output:
+    to:
+      kind: ImageStreamTag
+      name: nginx-editor:latest
+  resources:
+    requests:
+      cpu: 20m
+      memory: 100Mi
+    limits:
+      cpu: 100m
+      memory: 1Gi
+---
+
+---
+# The final build image.
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: nginx-subscriber
+  annotations:
+    description: Destination for built images.
+  labels:
+    name: nginx-subscriber
+    part-of: tno
+    version: 1.0.0
+    component: nginx-subscriber
+    managed-by: kustomize
+    created-by: jeremy.foster
+
+---
+# The build config that will be created will be named for the branch you created it for.
+kind: BuildConfig
+apiVersion: build.openshift.io/v1
+metadata:
+  name: nginx-subscriber.dev
+  annotations:
+    description: Build image from Dockerfile in git repo.
+  labels:
+    name: nginx-subscriber
+    part-of: tno
+    version: 1.0.0
+    component: nginx-subscriber
+    managed-by: kustomize
+    created-by: jeremy.foster
+    branch: dev
+spec:
+  completionDeadlineSeconds: 1800
+  triggers:
+    - type: ImageChange
+    - type: ConfigChange
+  runPolicy: Serial
+  source:
+    git:
+      uri: https://github.com/bcgov/tno.git
+      ref: dev
+    contextDir: network/reverse-proxy/subscriber
+  strategy:
+    type: Docker
+    dockerStrategy:
+      imageOptimizationPolicy: SkipLayers
+      dockerfilePath: Dockerfile
+  output:
+    to:
+      kind: ImageStreamTag
+      name: nginx-subscriber:latest
+  resources:
+    requests:
+      cpu: 20m
+      memory: 100Mi
+    limits:
+      cpu: 100m
+      memory: 1Gi

--- a/openshift/kustomize/nginx-reverse-proxy/build/base/kustomization.yaml
+++ b/openshift/kustomize/nginx-reverse-proxy/build/base/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - build.yaml

--- a/openshift/kustomize/nginx-reverse-proxy/build/overlays/dev/kustomization.yaml
+++ b/openshift/kustomize/nginx-reverse-proxy/build/overlays/dev/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-tools
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: BuildConfig
+      name: nginx-editor.dev
+    patch: |-
+      - op: replace
+        path: /spec/source/git/uri
+        value: https://github.com/bcgov/tno.git
+      - op: replace
+        path: /spec/source/git/ref
+        value: dev
+  - target:
+      kind: BuildConfig
+      name: nginx-subscriber.dev
+    patch: |-
+      - op: replace
+        path: /spec/source/git/uri
+        value: https://github.com/bcgov/tno.git
+      - op: replace
+        path: /spec/source/git/ref
+        value: dev

--- a/openshift/kustomize/nginx-reverse-proxy/overlays/dev/kustomization.yaml
+++ b/openshift/kustomize/nginx-reverse-proxy/overlays/dev/kustomization.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-dev
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: DeploymentConfig
+      name: nginx-editor
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: replace
+        path: /spec/triggers/1/imageChangeParams/from/name
+        value: nginx-editor:dev
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 20m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 35Mi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 50m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 100Mi
+  - target:
+      kind: DeploymentConfig
+      name: nginx-subscriber
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: replace
+        path: /spec/triggers/1/imageChangeParams/from/name
+        value: nginx-subscriber:dev
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 20m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 35Mi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 50m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 100Mi

--- a/openshift/kustomize/nginx-reverse-proxy/overlays/prod/kustomization.yaml
+++ b/openshift/kustomize/nginx-reverse-proxy/overlays/prod/kustomization.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-prod
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: DeploymentConfig
+      name: nginx-editor
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: replace
+        path: /spec/triggers/1/imageChangeParams/from/name
+        value: nginx-editor:prod
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 20m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 35Mi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 50m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 100Mi
+  - target:
+      kind: DeploymentConfig
+      name: nginx-subscriber
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: replace
+        path: /spec/triggers/1/imageChangeParams/from/name
+        value: nginx-subscriber:prod
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 20m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 35Mi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 50m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 100Mi

--- a/openshift/kustomize/nginx-reverse-proxy/overlays/test/kustomization.yaml
+++ b/openshift/kustomize/nginx-reverse-proxy/overlays/test/kustomization.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-test
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: DeploymentConfig
+      name: nginx-editor
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: replace
+        path: /spec/triggers/1/imageChangeParams/from/name
+        value: nginx-editor:test
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 20m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 35Mi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 50m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 100Mi
+  - target:
+      kind: DeploymentConfig
+      name: nginx-subscriber
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: replace
+        path: /spec/triggers/1/imageChangeParams/from/name
+        value: nginx-subscriber:test
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 20m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 35Mi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 50m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 100Mi


### PR DESCRIPTION
Provide an Nginx reverse-proxy for the Editor, Subscriber applications and the API.  This will allow us to remove the Openshift path router which appears to not be working reliably.  This may still not resolve various issues we're seeing, but the hope is it will be enough for us to keep using Openshift for our release.

I've created two Nginx services as it will take longer to figure out the configuration to support a single Nginx service for everything.  