### PR TITLE
Report preview fix

### DIFF
--- a/app/subscriber/src/features/my-reports/edit/ReportEditActions.tsx
+++ b/app/subscriber/src/features/my-reports/edit/ReportEditActions.tsx
@@ -114,16 +114,22 @@ export const ReportEditActions = ({
           />
         </Col>
       </Show>
-      <Button variant="secondary" onClick={() => navigate('/reports')}>
-        Cancel
-      </Button>
+      <Show
+        visible={
+          !active?.startsWith(ReportMainMenuOption.View) &&
+          !active?.startsWith(ReportMainMenuOption.History)
+        }
+      >
+        <Button variant="secondary" onClick={() => navigate('/reports')}>
+          Cancel
+        </Button>
+      </Show>
       {/* Show save during submitted to handle scenario when email fails */}
       <Show
         visible={
-          !disabled ||
-          !instance?.sentOn ||
-          active?.startsWith(ReportMainMenuOption.Settings) ||
-          active?.startsWith(ReportMainMenuOption.History)
+          (!disabled || !instance?.sentOn || active?.startsWith(ReportMainMenuOption.Settings)) &&
+          !active?.startsWith(ReportMainMenuOption.View) &&
+          !active?.startsWith(ReportMainMenuOption.History)
         }
       >
         <Button
@@ -147,8 +153,7 @@ export const ReportEditActions = ({
       <Show
         visible={
           (active?.startsWith(ReportMainMenuOption.Settings) ||
-            active?.startsWith(ReportMainMenuOption.Content) ||
-            active?.startsWith(ReportMainMenuOption.View)) &&
+            active?.startsWith(ReportMainMenuOption.Content)) &&
           !active?.startsWith(ReportSettingsMenuOption.Subscribers)
         }
       >

--- a/app/subscriber/src/features/my-reports/edit/ReportEditContext.tsx
+++ b/app/subscriber/src/features/my-reports/edit/ReportEditContext.tsx
@@ -55,6 +55,8 @@ export interface IReportEditContext {
   instance?: IReportInstanceModel;
   activeInstance?: IReportInstanceModel;
   setActiveInstance: (instance: IReportInstanceModel) => void;
+  previewLastUpdatedOn?: string;
+  setPreviewLastUpdatedOn: React.Dispatch<React.SetStateAction<string | undefined>>;
 }
 
 /**
@@ -76,6 +78,7 @@ export const ReportEditContext = React.createContext<IReportEditContext>({
   onGenerate: () => Promise.resolve(undefined),
   onRegenerateSection: () => Promise.resolve(undefined),
   setActiveInstance() {},
+  setPreviewLastUpdatedOn: () => {},
 });
 
 /**
@@ -122,6 +125,7 @@ export const ReportEditContextProvider: React.FC<IReportEditContextProviderProps
 
   const instance = values.instances.length ? values.instances[0] : undefined;
   const [activeInstance, setActiveInstance] = React.useState<IReportInstanceModel>();
+  const [previewLastUpdatedOn, setPreviewLastUpdatedOn] = React.useState<string | undefined>();
 
   React.useEffect(() => {
     // Set the active form based on the route.
@@ -247,6 +251,8 @@ export const ReportEditContextProvider: React.FC<IReportEditContextProviderProps
         instance,
         activeInstance,
         setActiveInstance: handleSetActiveInstance,
+        previewLastUpdatedOn,
+        setPreviewLastUpdatedOn,
       }}
     >
       {children}

--- a/app/subscriber/src/features/my-reports/edit/view/ReportView.tsx
+++ b/app/subscriber/src/features/my-reports/edit/view/ReportView.tsx
@@ -1,6 +1,5 @@
-import { Action } from 'components/action/Action';
 import React from 'react';
-import { FaEye, FaX } from 'react-icons/fa6';
+import { FaEye } from 'react-icons/fa6';
 import { useApp, useReportInstances } from 'store/hooks';
 import { useProfileStore } from 'store/slices';
 import { Col, Loading, Row, Show } from 'tno-core';
@@ -9,16 +8,18 @@ import { useReportEditContext } from '../ReportEditContext';
 import * as styled from './styled';
 
 export const ReportView = () => {
-  const { values } = useReportEditContext();
+  const { values, previewLastUpdatedOn, setPreviewLastUpdatedOn } = useReportEditContext();
   const [{ requests }] = useApp();
   const [{ reportOutput }, { storeReportOutput }] = useProfileStore();
   const [{ viewReportInstance }] = useReportInstances();
-
   const instanceId = values.instances.length ? values.instances[0].id : undefined;
+  const updatedOn = values.instances.length ? values.instances[0].updatedOn : undefined;
   const isLoading = requests.some((r) => r.group.includes('view-report'));
 
   const handleViewReport = React.useCallback(
-    async (instanceId: number) => {
+    async (instanceId: any) => {
+      if (!instanceId) return;
+
       try {
         const response = await viewReportInstance(instanceId, true);
         storeReportOutput({ ...response, instanceId });
@@ -28,14 +29,13 @@ export const ReportView = () => {
   );
 
   React.useEffect(() => {
-    if (instanceId) {
+    if (instanceId && updatedOn !== previewLastUpdatedOn) {
+      setPreviewLastUpdatedOn(updatedOn);
       handleViewReport(instanceId);
     }
     // Initialize every time this component is displayed.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  if (!reportOutput) return null;
+  }, [instanceId, updatedOn]);
 
   return (
     <styled.ReportView className="report-edit-section">
@@ -46,14 +46,9 @@ export const ReportView = () => {
         <Row className="report-edit-headline-row" alignItems="first baseline" gap="0.5em">
           <FaEye size={18} />
           <h1>Preview Report</h1>
-          <Action
-            icon={<FaX className="icon-close" />}
-            onClick={() => storeReportOutput(undefined)}
-            id="icon-close"
-          />
+          <div></div>
         </Row>
       </div>
-
       <Col className="preview-report">
         <div
           className="preview-subject"


### PR DESCRIPTION
Summary:

1. Hide some buttons in bottom action bar for 'Preview&Send' and 'History'


![image](https://github.com/bcgov/tno/assets/35620699/1e4f83ff-027b-4975-a107-49d4d9971953)

2. Init Preview Report and always display the Preview Report in the right panel..
3. Considering report updateOn, tracking this data value with hook, so the behavior is regenerate report only when report got update. This could reduce times of request from user, save server resources 