### PR TITLE
TNO-2867 Avoid undefined of publishedOn, tno-core update

### DIFF
--- a/libs/npm/core/src/hooks/api/subscriber/useApiSubscriberReportInstances.ts
+++ b/libs/npm/core/src/hooks/api/subscriber/useApiSubscriberReportInstances.ts
@@ -29,10 +29,15 @@ export const useApiSubscriberReportInstances = (
   return React.useRef({
     getReportInstance: (id: number, includeContent?: boolean, publishedOn?: Date | string) => {
       const query = { publishedOn };
+
+      let queryString = `includeContent=${!!includeContent}`;
+
+      if (publishedOn !== undefined && publishedOn !== null) {
+        queryString += `&${toQueryString(query)}`;
+      }
+
       return api.get<never, AxiosResponse<IReportInstanceModel | undefined>, any>(
-        `/subscriber/report/instances/${id}?includeContent=${!!includeContent}${
-          publishedOn && `&${toQueryString(query)}`
-        }`,
+        `/subscriber/report/instances/${id}?${queryString}`,
       );
     },
     addReportInstance: (instance: IReportInstanceModel) => {


### PR DESCRIPTION
This change requires to bump tno-core 

Modify the logic of URL generation, if `publishedOn` is null or undefined, we shouldn't append any query string, and the old way gives an undefined follow by ` includeContent=true`

![image](https://github.com/bcgov/tno/assets/35620699/64b2abee-584b-45da-9362-bf066ab3be37)
