### PR TITLE
TNO-2784: [Fix] Stories on Press Gallery landing page are not written by Press Gallery members 

### DIFF
--- a/app/subscriber/src/components/content-list/utils/highlightTerms.tsx
+++ b/app/subscriber/src/components/content-list/utils/highlightTerms.tsx
@@ -2,6 +2,10 @@ export const highlightTerms = (
   body: string,
   highlightedVals: string[],
 ): (string | JSX.Element)[] => {
+  if (typeof body !== 'string') {
+    return [body];
+  }
+
   const regex = new RegExp(
     `(${highlightedVals.map((term) => escapeRegExp(term)).join('|')})`,
     'gi',


### PR DESCRIPTION
`highlightTerms` function splits the body into chunks based on the press members names, so they can be bold, then the function returns an array.

Need to ensure body is string before applying split function. Otherwise, return an array with the body immediately without parsing body.