### PR TITLE
TNO-2893 Fix view report instance

### DIFF
--- a/app/subscriber/src/features/my-reports/ReportInstanceView.tsx
+++ b/app/subscriber/src/features/my-reports/ReportInstanceView.tsx
@@ -6,9 +6,14 @@ import { Col, Loading, Show } from 'tno-core';
 export interface IReportInstanceViewProps {
   /** Report instance id. */
   instanceId: number;
+  /** Regenerate report instance */
+  regenerate?: boolean;
 }
 
-export const ReportInstanceView: React.FC<IReportInstanceViewProps> = ({ instanceId }) => {
+export const ReportInstanceView: React.FC<IReportInstanceViewProps> = ({
+  instanceId,
+  regenerate,
+}) => {
   const [{ viewReportInstance }] = useReportInstances();
   const [{ requests }] = useApp();
   const [{ reportOutput }, { storeReportOutput }] = useProfileStore();
@@ -18,11 +23,11 @@ export const ReportInstanceView: React.FC<IReportInstanceViewProps> = ({ instanc
   const handleViewReport = React.useCallback(
     async (instanceId: number) => {
       try {
-        const response = await viewReportInstance(instanceId, true);
+        const response = await viewReportInstance(instanceId, regenerate);
         storeReportOutput({ ...response, instanceId });
       } catch {}
     },
-    [viewReportInstance, storeReportOutput],
+    [viewReportInstance, regenerate, storeReportOutput],
   );
 
   React.useEffect(() => {

--- a/app/subscriber/src/features/my-reports/ReportView.tsx
+++ b/app/subscriber/src/features/my-reports/ReportView.tsx
@@ -5,7 +5,12 @@ import { useReports } from 'store/hooks';
 
 import { ReportInstanceView } from './ReportInstanceView';
 
-export const ReportView = () => {
+export interface IReportViewProps {
+  // Whether to regenerate the report instance.
+  regenerate?: boolean;
+}
+
+export const ReportView: React.FC<IReportViewProps> = ({ regenerate = false }) => {
   const [, { generateReport }] = useReports();
   const { id } = useParams();
 
@@ -36,5 +41,5 @@ export const ReportView = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reportId]);
 
-  return <ReportInstanceView instanceId={instanceId} />;
+  return <ReportInstanceView instanceId={instanceId} regenerate={regenerate} />;
 };

--- a/app/subscriber/src/features/router/AppRouter.tsx
+++ b/app/subscriber/src/features/router/AppRouter.tsx
@@ -154,7 +154,12 @@ export const AppRouter: React.FC<IAppRouter> = () => {
         />
         <Route
           path="report/instances/:id/view"
-          element={<PrivateRoute claims={Claim.subscriber} element={<ReportView />}></PrivateRoute>}
+          element={
+            <PrivateRoute
+              claims={Claim.subscriber}
+              element={<ReportView regenerate={false} />}
+            ></PrivateRoute>
+          }
         />
         <Route
           path="/impersonation"


### PR DESCRIPTION
Fixed issue when viewing a report instance from an email link.  It should now correctly view the instance and not attempt to regenerate the report.