### PR TITLE
TNO-2801: Adding content to folder/reports does not uncheck them

### DIFF
--- a/app/subscriber/src/features/filter-media/FilterMedia.tsx
+++ b/app/subscriber/src/features/filter-media/FilterMedia.tsx
@@ -101,6 +101,7 @@ export const FilterMedia: React.FC<IFilterMediaProps> = ({ loaded }) => {
       <ContentListActionBar
         content={selected}
         onSelectAll={(e) => (e.target.checked ? setSelected(currDateResults) : setSelected([]))}
+        onClear={() => setSelected([])}
       />
       <DateFilter loaded={loaded} filter={filter} storeFilter={storeFilter} />
       <Show visible={isLoading}>

--- a/app/subscriber/src/features/manage-folder/ManageFolder.tsx
+++ b/app/subscriber/src/features/manage-folder/ManageFolder.tsx
@@ -143,6 +143,7 @@ export const ManageFolder: React.FC = () => {
           <ContentListActionBar
             content={selected}
             onSelectAll={(e) => (e.target.checked ? setSelected(items) : setSelected([]))}
+            onClear={() => setSelected([])}
             removeFolderItem={() => removeItems(selected)}
             disableAddToFolder={true}
           />

--- a/app/subscriber/src/features/my-minister/MyMinister.tsx
+++ b/app/subscriber/src/features/my-minister/MyMinister.tsx
@@ -205,6 +205,7 @@ export const MyMinister: React.FC = () => {
     <styled.MyMinister>
       <ContentListActionBar
         content={selected}
+        onClear={() => setSelected([])}
         onSelectAll={(e) => (e.target.checked ? setSelected(content) : setSelected([]))}
       />
       <DateFilter filter={filter} storeFilter={storeFilter} />

--- a/app/subscriber/src/features/press-gallery/PressGallery.tsx
+++ b/app/subscriber/src/features/press-gallery/PressGallery.tsx
@@ -139,6 +139,7 @@ export const PressGallery: React.FC = () => {
     <styled.PressGallery>
       <ContentListActionBar
         content={selected}
+        onClear={() => setSelected([])}
         onSelectAll={(e) => (e.target.checked ? setSelected(content) : setSelected([]))}
       />
       <Row className="tool-bar">

--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -218,6 +218,7 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
           >
             <ContentListActionBar
               content={selected}
+              onClear={() => setSelected([])}
               onSelectAll={(e) =>
                 e.target.checked ? setSelected(currDateResults) : setSelected([])
               }

--- a/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
+++ b/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
@@ -65,6 +65,7 @@ export const TodaysCommentary: React.FC = () => {
     <styled.TodaysCommentary>
       <ContentListActionBar
         content={selected}
+        onClear={() => setSelected([])}
         onSelectAll={(e) => (e.target.checked ? setSelected(content) : setSelected([]))}
       />
       <DateFilter filter={filter} storeFilter={storeFilter} />

--- a/app/subscriber/src/features/top-stories/TopStories.tsx
+++ b/app/subscriber/src/features/top-stories/TopStories.tsx
@@ -63,6 +63,7 @@ export const TopStories: React.FC = () => {
     <styled.TopStories>
       <ContentListActionBar
         content={selected}
+        onClear={() => setSelected([])}
         onSelectAll={(e) => (e.target.checked ? setSelected(content) : setSelected([]))}
       />
       <DateFilter filter={filter} storeFilter={storeFilter} />


### PR DESCRIPTION
Pretty simple bug, the `onClear` was not being passed down to the problematic pages. Home page worked as expected because it had it. 