### PR TITLE
TNO-2811: TNO Migration missing Event transcripts

### DIFF
--- a/services/net/contentmigration/migrators/ClipMigrator.cs
+++ b/services/net/contentmigration/migrators/ClipMigrator.cs
@@ -53,9 +53,6 @@ public class ClipMigrator : ContentMigrator<ContentMigrationOptions>, IContentMi
         var sanitizedSummary = TNO.Core.Extensions.StringExtensions.ConvertTextToParagraphs(newsItem.Summary, @"\r\n?|\n|\|");
         var sanitizedBody = TNO.Core.Extensions.StringExtensions.ConvertTextToParagraphs(newsItem.Transcript, @"\r\n?|\n|\|");
 
-        // Scrum/Events place their transcript in the summary.
-        if (String.IsNullOrWhiteSpace(sanitizedBody) && mediaType.Name == "Events") sanitizedBody = sanitizedSummary;
-
         var content = new SourceContent(
             this.Options.DataLocation,
             source.Code,


### PR DESCRIPTION
Keep transcript content in body field during execution of contentmigration service.