### PR TITLE
[READY] TNO-2880: New popout for A/V

### DIFF
--- a/app/subscriber/src/components/content-list/ContentRow.tsx
+++ b/app/subscriber/src/components/content-list/ContentRow.tsx
@@ -111,7 +111,7 @@ export const ContentRow: React.FC<IContentRowProps> = ({
               onClick={(e) => {
                 e.stopPropagation();
                 window.open(
-                  `/view/${item.id}`,
+                  `/view/${item.id}/popout`,
                   '_blank',
                   'toolbar=yes,scrollbars=yes,resizable=yes,top=500,left=600,width=600,height=465',
                 );

--- a/app/subscriber/src/components/layout/DefaultLayout.tsx
+++ b/app/subscriber/src/components/layout/DefaultLayout.tsx
@@ -4,7 +4,7 @@ import { Navbar } from 'components/navbar';
 import { navbarOptions } from 'components/navbar/NavbarItems';
 import { UnauthenticatedHome, UserInfo } from 'features/login';
 import React from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useToastError } from 'store/hooks';
 import { useApiHub } from 'store/hooks/signalr';
@@ -35,6 +35,7 @@ export interface ILayoutProps extends React.HTMLAttributes<HTMLDivElement> {
 export const DefaultLayout: React.FC<ILayoutProps> = ({ children, ...rest }) => {
   const keycloak = useKeycloakWrapper();
   const { setToken } = React.useContext(SummonContext);
+  const { popout } = useParams();
   useToastError();
   const hub = useApiHub();
 
@@ -68,10 +69,13 @@ export const DefaultLayout: React.FC<ILayoutProps> = ({ children, ...rest }) => 
   });
 
   return (
-    <styled.Layout className={!keycloak.authenticated ? 'unauth' : ''} {...rest}>
+    <styled.Layout
+      className={`${!keycloak.authenticated && 'unauth'} ${!!popout && 'popout'}`}
+      {...rest}
+    >
       <UserInfo />
       <Show visible={keycloak.authenticated}>
-        <Show visible={keycloak.hasClaim()}>
+        <Show visible={keycloak.hasClaim() && !popout}>
           <div className="grid-container">
             <div className="nav-bar">
               <Navbar options={navbarOptions} />
@@ -86,6 +90,13 @@ export const DefaultLayout: React.FC<ILayoutProps> = ({ children, ...rest }) => 
               </main>
             </LayoutErrorBoundary>
           </div>
+        </Show>
+        <Show visible={!!popout}>
+          <LayoutErrorBoundary>
+            <main>
+              <Outlet />
+            </main>
+          </LayoutErrorBoundary>
         </Show>
         <Show visible={!keycloak.hasClaim()}>
           <LayoutErrorBoundary>

--- a/app/subscriber/src/components/layout/styled/Layout.tsx
+++ b/app/subscriber/src/components/layout/styled/Layout.tsx
@@ -3,6 +3,18 @@ import styled from 'styled-components';
 import { ILayoutProps } from '..';
 
 export const Layout = styled.div<ILayoutProps>`
+  &.popout {
+    .headline {
+      margin-bottom: 0;
+      padding-left: 0.25em;
+    }
+    .info-bar {
+      margin-left: 0;
+      margin-right: 0;
+      padding-left: 0.5em;
+      padding-right: 0.5em;
+    }
+  }
   &:not(.unauth):not(.popout) {
     main {
       overflow: clip auto;

--- a/app/subscriber/src/components/layout/styled/Layout.tsx
+++ b/app/subscriber/src/components/layout/styled/Layout.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { ILayoutProps } from '..';
 
 export const Layout = styled.div<ILayoutProps>`
-  &:not(.unauth) {
+  &:not(.unauth):not(.popout) {
     main {
       overflow: clip auto;
       height: calc(100dvh - 4.75rem);

--- a/app/subscriber/src/components/tool-bar/styled/ContentActionBar.tsx
+++ b/app/subscriber/src/components/tool-bar/styled/ContentActionBar.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import { Row } from 'tno-core';
 
 export const ContentActionBar = styled(Row)`
-  max-width: fit-content;
   &.search {
     .check-area {
       margin-left: 1em;

--- a/app/subscriber/src/components/tool-bar/styled/ContentActionBar.tsx
+++ b/app/subscriber/src/components/tool-bar/styled/ContentActionBar.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { Row } from 'tno-core';
 
 export const ContentActionBar = styled(Row)`
+  max-width: fit-content;
   &.search {
     .check-area {
       margin-left: 1em;

--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -346,7 +346,7 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent, act
       </Show>
       <Row id="summary" className="summary">
         <Show visible={isAV && !!content?.summary && !isTranscribing && isDifferent && !popout}>
-          <Col>
+          <Col className="summary-container">
             <span>{formattedSummary}</span>
             <Show visible={!!content?.sourceUrl}>
               <a rel="noreferrer" target="_blank" href={content?.sourceUrl}>
@@ -369,7 +369,7 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent, act
             </Show>
           </Col>
         </Show>
-        <Row>
+        <Row className={`${!!popout && 'popout-transcribe-row'}`}>
           <Show
             visible={
               isAV &&
@@ -403,8 +403,8 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent, act
         </Row>
       </Row>
       <Show visible={!!popout}>
-        <hr />
         <div className="copyright-text">
+          <hr />
           <FaCopyright />
           Copyright protected and owned by broadcaster. Your licence is limited to internal,
           non-commercial, government use. All reproduction, broadcast, transmission, or other use of

--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -1,10 +1,13 @@
 import { Bar } from 'components/bar';
 import { Button } from 'components/button';
 import { Sentiment } from 'components/sentiment';
+import { ContentActionBar } from 'components/tool-bar';
 import { formatSearch } from 'features/search-page/utils';
 import { formatDate, showTranscription } from 'features/utils';
 import parse from 'html-react-parser';
 import React from 'react';
+import { FaFeather } from 'react-icons/fa';
+import { FaCopyright } from 'react-icons/fa6';
 import { useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useApiHub, useContent, useWorkOrders } from 'store/hooks';
@@ -42,14 +45,15 @@ export interface IStream {
 export interface IViewContentProps {
   /** set active content */
   setActiveContent?: (content: IContentModel[]) => void;
+  activeContent?: IContentModel[];
 }
 
 /**
  * Component to display content when navigating to it from the landing page list view, responsive and adaptive to screen size
  * @returns ViewContent component
  */
-export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent }) => {
-  const { id } = useParams();
+export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent, activeContent }) => {
+  const { id, popout } = useParams();
   const [
     {
       search: { filter },
@@ -276,7 +280,7 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent }) =
   }, [cleanBody, cleanSummary]);
 
   return (
-    <styled.ViewContent>
+    <styled.ViewContent className={`${!!popout && 'popout'}`}>
       <div className="headline">{formattedHeadline}</div>
       <Bar className="info-bar" vanilla>
         <Show visible={!!content?.byline}>
@@ -341,7 +345,7 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent }) =
         </Row>
       </Show>
       <Row id="summary" className="summary">
-        <Show visible={isAV && !!content?.summary && !isTranscribing && isDifferent}>
+        <Show visible={isAV && !!content?.summary && !isTranscribing && isDifferent && !popout}>
           <Col>
             <span>{formattedSummary}</span>
             <Show visible={!!content?.sourceUrl}>
@@ -353,7 +357,11 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent }) =
         </Show>
         <Show visible={!isAV && !!content}>
           <Col>
-            {!!content?.body?.length ? <div>{formattedBody}</div> : <span>{formattedSummary}</span>}
+            {!!content?.body?.length && !popout ? (
+              <div>{formattedBody}</div>
+            ) : (
+              <span>{formattedSummary}</span>
+            )}
             <Show visible={!!content?.sourceUrl}>
               <a rel="noreferrer" target="_blank" href={content?.sourceUrl}>
                 More...
@@ -361,32 +369,48 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent }) =
             </Show>
           </Col>
         </Show>
-        <Show
-          visible={
-            isAV &&
-            !content?.source?.disableTranscribe &&
-            !content.isApproved &&
-            !isTranscriptRequestor
-          }
-        >
-          <Button
-            onClick={() => handleTranscribe()}
-            variant={isTranscribing ? 'warn' : 'primary'}
-            className="transcribe-button"
-            disabled={
-              (!!content?.fileReferences && !content?.fileReferences.length) ||
-              (!!content?.fileReferences &&
-                content?.fileReferences.length > 0 &&
-                !content?.fileReferences[0].isUploaded)
+        <Row>
+          <Show
+            visible={
+              isAV &&
+              !content?.source?.disableTranscribe &&
+              !content.isApproved &&
+              !isTranscriptRequestor
             }
           >
-            <Show visible={!isTranscribing}>Request Transcript</Show>
-            <Show visible={isTranscribing && !isTranscriptRequestor}>
-              Request Email when Transcript Complete
-            </Show>
-          </Button>
-        </Show>
+            <Button
+              onClick={() => handleTranscribe()}
+              variant={isTranscribing ? 'warn' : 'primary'}
+              className="transcribe-button"
+              disabled={
+                (!!content?.fileReferences && !content?.fileReferences.length) ||
+                (!!content?.fileReferences &&
+                  content?.fileReferences.length > 0 &&
+                  !content?.fileReferences[0].isUploaded)
+              }
+            >
+              <Show visible={!isTranscribing}>
+                <FaFeather /> Request Transcript
+              </Show>
+              <Show visible={isTranscribing && !isTranscriptRequestor}>
+                Request Email when Transcript Complete
+              </Show>
+            </Button>
+            {!!popout && (
+              <ContentActionBar className="actions-popout" content={activeContent ?? []} />
+            )}
+          </Show>
+        </Row>
       </Row>
+      <Show visible={!!popout}>
+        <hr />
+        <div className="copyright-text">
+          <FaCopyright />
+          Copyright protected and owned by broadcaster. Your licence is limited to internal,
+          non-commercial, government use. All reproduction, broadcast, transmission, or other use of
+          this work is prohibited and subject to licence.
+        </div>
+      </Show>
       <Show visible={isAV && isTranscribing}>
         <hr />
         <h3>Transcription:</h3>
@@ -397,7 +421,7 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent }) =
           {isTranscriptRequestor && <p>You will receive an email once available.</p>}
         </Col>
       </Show>
-      <Show visible={isAV && !isTranscribing && !!content.body?.length}>
+      <Show visible={isAV && !isTranscribing && !!content.body?.length && !popout}>
         <hr />
         <Row>
           <img

--- a/app/subscriber/src/features/content/view-content/styled/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/styled/ViewContent.tsx
@@ -6,11 +6,26 @@ export const ViewContent = styled.div`
     margin-left: 0.25em;
   }
 
+  .summary-container {
+    margin-right: auto;
+  }
+  .popout-transcribe-row {
+    width: 100%;
+    .transcribe-button {
+      position: absolute;
+      right: 0;
+    }
+  }
   .actions-popout {
     padding: 0;
+    position: absolute;
+    bottom: 6.5em;
   }
 
   .copyright-text {
+    hr {
+      margin-top: 3em;
+    }
     font-size: 0.8em;
     margin-top: 1em;
     margin-left: 0.5em;

--- a/app/subscriber/src/features/content/view-content/styled/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/styled/ViewContent.tsx
@@ -5,6 +5,20 @@ export const ViewContent = styled.div`
     margin-bottom: 0;
     margin-left: 0.25em;
   }
+
+  .actions-popout {
+    padding: 0;
+  }
+
+  .copyright-text {
+    font-size: 0.8em;
+    margin-top: 1em;
+    margin-left: 0.5em;
+    svg {
+      margin-right: 0.5em;
+    }
+  }
+
   .summary {
     font-family: ${(props) => props.theme.css.fPrimary};
     p {
@@ -74,6 +88,19 @@ export const ViewContent = styled.div`
 
   .transcribe-button {
     margin-left: auto;
+    padding: 0.5em;
+    color: ${(props) => props.theme.css.fPrimaryColor};
+    background-color: ${(props) => props.theme.css.btnEditColor};
+    border: solid 2px ${(props) => props.theme.css.btnEditBorderColor};
+    svg {
+      color: ${(props) => props.theme.css.btnEditBorderColor};
+    }
+    height: 2em;
+    border-radius: 0.85em;
+    &:hover {
+      background-color: ${(props) => props.theme.css.btnEditHoverColor};
+      cursor: pointer;
+    }
   }
 
   img {

--- a/app/subscriber/src/features/landing/Landing.tsx
+++ b/app/subscriber/src/features/landing/Landing.tsx
@@ -28,7 +28,7 @@ import * as styled from './styled';
  * @returns Component containing the main "box" that will correspond to the selected item in the left navigation bar. Secondary column displaying commentary and front pages.
  */
 export const Landing: React.FC = () => {
-  const { id } = useParams();
+  const { id, popout } = useParams();
   const [activeItem, setActiveItem] = React.useState<INavbarOptionItem | undefined>(
     NavbarOptions.home,
   );
@@ -42,79 +42,84 @@ export const Landing: React.FC = () => {
   return (
     <styled.Landing className="main-container">
       <FilterOptionsProvider>
+        <Show visible={!!popout}>
+          <ViewContent activeContent={activeContent} setActiveContent={setActiveContent} />
+        </Show>
         <Row className="contents-container">
-          <PageSection
-            ignoreMinWidth
-            activeContent={activeContent}
-            header={
-              <>
-                <Show visible={!!activeItem}>
-                  {activeItem?.icon && <div className="page-icon">{activeItem?.icon}</div>}
-                  {activeItem === NavbarOptions.settings
-                    ? 'Settings | My Minister'
-                    : activeItem?.label}
+          <Show visible={!popout}>
+            <PageSection
+              ignoreMinWidth
+              activeContent={activeContent}
+              header={
+                <>
+                  <Show visible={!!activeItem}>
+                    {activeItem?.icon && <div className="page-icon">{activeItem?.icon}</div>}
+                    {activeItem === NavbarOptions.settings
+                      ? 'Settings | My Minister'
+                      : activeItem?.label}
+                  </Show>
+                  {!!activeItem?.reduxFilterStore && (
+                    <>
+                      <FilterOptions filterStoreName={activeItem?.reduxFilterStore} />
+                      <ViewOptions />
+                    </>
+                  )}
+                </>
+              }
+              className="main-panel"
+              includeContentActions={!activeItem && !popout}
+            >
+              <div className="content">
+                {/* Home is default selected navigation item on login*/}
+                <Show visible={activeItem === NavbarOptions.home}>
+                  <Home />
                 </Show>
-                {!!activeItem?.reduxFilterStore && (
-                  <>
-                    <FilterOptions filterStoreName={activeItem?.reduxFilterStore} />
-                    <ViewOptions />
-                  </>
-                )}
-              </>
-            }
-            className="main-panel"
-            includeContentActions={!activeItem}
-          >
-            <div className="content">
-              {/* Home is default selected navigation item on login*/}
-              <Show visible={activeItem === NavbarOptions.home}>
-                <Home />
-              </Show>
-              <Show visible={!activeItem}>
-                <ViewContent setActiveContent={setActiveContent} />
-              </Show>
-              <Show visible={activeItem === NavbarOptions.settings}>
-                <MyMinisterSettings />
-              </Show>
-              <Show visible={activeItem === NavbarOptions.myMinister}>
-                <MyMinister />
-              </Show>
-              <Show visible={activeItem === NavbarOptions.todaysCommentary}>
-                <TodaysCommentary />
-              </Show>
-              <Show visible={activeItem === NavbarOptions.todaysFrontPages}>
-                <TodaysFrontPages />
-              </Show>
-              <Show visible={activeItem === NavbarOptions.topStories}>
-                <TopStories />
-              </Show>
-              <Show visible={activeItem === NavbarOptions.myProducts}>
-                <MyProducts />
-              </Show>
-              <Show visible={activeItem === NavbarOptions.pressGallery}>
-                <PressGallery />
-              </Show>
-              <Show visible={activeItem === NavbarOptions.mySearches}>
-                <MySearches />
-              </Show>
-              <Show visible={activeItem === NavbarOptions.eventOfTheDay}>
-                <EventOfTheDayPreview />
+                <Show visible={!activeItem}>
+                  <ViewContent setActiveContent={setActiveContent} />
+                </Show>
+                <Show visible={activeItem === NavbarOptions.settings}>
+                  <MyMinisterSettings />
+                </Show>
+                <Show visible={activeItem === NavbarOptions.myMinister}>
+                  <MyMinister />
+                </Show>
+                <Show visible={activeItem === NavbarOptions.todaysCommentary}>
+                  <TodaysCommentary />
+                </Show>
+                <Show visible={activeItem === NavbarOptions.todaysFrontPages}>
+                  <TodaysFrontPages />
+                </Show>
+                <Show visible={activeItem === NavbarOptions.topStories}>
+                  <TopStories />
+                </Show>
+                <Show visible={activeItem === NavbarOptions.myProducts}>
+                  <MyProducts />
+                </Show>
+                <Show visible={activeItem === NavbarOptions.pressGallery}>
+                  <PressGallery />
+                </Show>
+                <Show visible={activeItem === NavbarOptions.mySearches}>
+                  <MySearches />
+                </Show>
+                <Show visible={activeItem === NavbarOptions.eventOfTheDay}>
+                  <EventOfTheDayPreview />
+                </Show>
+                <Show visible={activeItem === NavbarOptions.eveningOverview}>
+                  <AVOverviewPreview />
+                </Show>
+              </div>
+            </PageSection>
+            {/* unsure of whether these items will change depending on selected item */}
+            <Col className="right-panel">
+              <Show visible={activeItem !== NavbarOptions.eveningOverview && !popout}>
+                <Commentary />
+                <TopDomains />
               </Show>
               <Show visible={activeItem === NavbarOptions.eveningOverview}>
-                <AVOverviewPreview />
+                <MediaOverviewIcons />
               </Show>
-            </div>
-          </PageSection>
-          {/* unsure of whether these items will change depending on selected item */}
-          <Col className="right-panel">
-            <Show visible={activeItem !== NavbarOptions.eveningOverview}>
-              <Commentary />
-              <TopDomains />
-            </Show>
-            <Show visible={activeItem === NavbarOptions.eveningOverview}>
-              <MediaOverviewIcons />
-            </Show>
-          </Col>
+            </Col>
+          </Show>
         </Row>
       </FilterOptionsProvider>
     </styled.Landing>

--- a/app/subscriber/src/features/router/AppRouter.tsx
+++ b/app/subscriber/src/features/router/AppRouter.tsx
@@ -147,7 +147,7 @@ export const AppRouter: React.FC = () => {
           }
         />
         <Route
-          path="/view/:id"
+          path="/view/:id/:popout?"
           element={<PrivateRoute claims={Claim.subscriber} element={<Landing />}></PrivateRoute>}
         />
         <Route


### PR DESCRIPTION
When clicking the pop out button on the content list view, we now have a new simplified screen to show the a/v content.

New styling for A/V popout:
![image](https://github.com/user-attachments/assets/2b3eeef1-5335-46a8-9c0d-b9e7397fd645)
