### PR TITLE
Fix reports

### DIFF
--- a/api/net/Areas/Editor/Controllers/ReportController.cs
+++ b/api/net/Areas/Editor/Controllers/ReportController.cs
@@ -222,9 +222,10 @@ public class ReportController : ControllerBase
 
         var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.Content, report.Id, new { })
         {
-            RequestorId = user.Id
+            RequestorId = user.Id,
+            SendToSubscribers = true,
         };
-        await _kafkaProducer.SendMessageAsync(_kafkaOptions.ReportingTopic, $"report-{report.Id}", request);
+        await _kafkaProducer.SendMessageAsync(_kafkaOptions.ReportingTopic, request);
         return new OkResult();
     }
     #endregion

--- a/api/net/Areas/Services/Controllers/ReportController.cs
+++ b/api/net/Areas/Services/Controllers/ReportController.cs
@@ -105,7 +105,7 @@ public class ReportController : ControllerBase
     /// Get the current instance for the specified report 'id'.
     /// </summary>
     /// <param name="id"></param>
-    /// <param name="requestorId"></param>
+    /// <param name="ownerId"></param>
     /// <returns></returns>
     [HttpGet("{id}/instance")]
     [Produces(MediaTypeNames.Application.Json)]
@@ -113,9 +113,9 @@ public class ReportController : ControllerBase
     [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     [SwaggerOperation(Tags = new[] { "Report" })]
-    public IActionResult GetCurrentInstance(int id, int? requestorId)
+    public IActionResult GetCurrentInstance(int id, int? ownerId)
     {
-        var instance = _service.GetCurrentReportInstance(id, requestorId, true);
+        var instance = _service.GetCurrentReportInstance(id, ownerId, true);
         if (instance == null) return NoContent();
         var report = _service.FindById(id);
         instance.Report = report;

--- a/app/editor/src/features/content/papers/PaperToolbar.tsx
+++ b/app/editor/src/features/content/papers/PaperToolbar.tsx
@@ -63,7 +63,7 @@ export const PaperToolbar: React.FC<IPaperToolbarProps> = ({ onSearch }) => {
       let noContentToastText = 'Report content is empty. Please add content before sending.';
       if (preview.body && preview.body === '\n') {
         toast.error(
-          `Report tempalte is inactive, check the settings ReportID with value ${reportID}.`,
+          `Report template is inactive, check the settings ReportID with value ${reportID}.`,
         );
         return false;
       } else {

--- a/app/subscriber/src/components/action/styled/Action.tsx
+++ b/app/subscriber/src/components/action/styled/Action.tsx
@@ -20,19 +20,23 @@ export const Action = styled.div<IActionProps>`
   &:hover:not([disabled]) * {
     color: ${(props) => props.theme.css.linkPrimaryHoverColor};
     filter: ${(props) => props.theme.css.dropShadow};
+    cursor: pointer;
   }
 
   &:hover:not([disabled]) svg * {
     color: ${(props) => props.theme.css.linkPrimaryHoverColor};
     filter: ${(props) => props.theme.css.dropShadow};
+    cursor: pointer;
   }
 
   &:active:not([disabled]) * {
     color: ${(props) => props.theme.css.linkPrimaryActiveColor};
+    cursor: pointer;
   }
 
   &:active:not([disabled]) svg * {
     color: ${(props) => props.theme.css.linkPrimaryActiveColor};
+    cursor: pointer;
   }
 
   label {

--- a/app/subscriber/src/features/my-reports/edit/view/ReportView.tsx
+++ b/app/subscriber/src/features/my-reports/edit/view/ReportView.tsx
@@ -12,16 +12,17 @@ export const ReportView = () => {
   const [{ requests }] = useApp();
   const [{ reportOutput }, { storeReportOutput }] = useProfileStore();
   const [{ viewReportInstance }] = useReportInstances();
-  const instanceId = values.instances.length ? values.instances[0].id : undefined;
-  const updatedOn = values.instances.length ? values.instances[0].updatedOn : undefined;
+  const instance = values.instances.length ? values.instances[0] : undefined;
+  const instanceId = instance?.id;
+  const updatedOn = instance?.updatedOn;
   const isLoading = requests.some((r) => r.group.includes('view-report'));
 
   const handleViewReport = React.useCallback(
-    async (instanceId: any) => {
+    async (instanceId: any, regenerate: boolean) => {
       if (!instanceId) return;
 
       try {
-        const response = await viewReportInstance(instanceId, true);
+        const response = await viewReportInstance(instanceId, regenerate);
         storeReportOutput({ ...response, instanceId });
       } catch {}
     },
@@ -31,11 +32,11 @@ export const ReportView = () => {
   React.useEffect(() => {
     if (instanceId && updatedOn !== previewLastUpdatedOn) {
       setPreviewLastUpdatedOn(updatedOn);
-      handleViewReport(instanceId);
+      handleViewReport(instanceId, !instance.sentOn);
     }
     // Initialize every time this component is displayed.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [instanceId, updatedOn]);
+  }, [instanceId, updatedOn, instance?.sentOn]);
 
   return (
     <styled.ReportView className="report-edit-section">

--- a/libs/net/dal/Services/ReportInstanceService.cs
+++ b/libs/net/dal/Services/ReportInstanceService.cs
@@ -32,6 +32,7 @@ public class ReportInstanceService : BaseService<ReportInstance, long>, IReportI
             .Include(ri => ri.Report).ThenInclude(r => r!.SubscribersManyToMany).ThenInclude(sm2m => sm2m.User)
             .Include(ri => ri.Report).ThenInclude(r => r!.Sections).ThenInclude(s => s.Filter)
             .Include(ri => ri.Report).ThenInclude(r => r!.Sections).ThenInclude(s => s.ChartTemplatesManyToMany).ThenInclude(ct => ct.ChartTemplate)
+            .AsSplitQuery()
             .FirstOrDefault(ri => ri.Id == id);
     }
 

--- a/libs/net/dal/Services/ReportService.cs
+++ b/libs/net/dal/Services/ReportService.cs
@@ -97,7 +97,7 @@ public class ReportService : BaseService<Report, int>, IReportService
                 .Take(filter.Quantity.Value);
         }
 
-        return query.ToArray();
+        return query.AsSplitQuery().ToArray();
     }
 
     /// <summary>
@@ -116,6 +116,7 @@ public class ReportService : BaseService<Report, int>, IReportService
             .Include(r => r.Sections).ThenInclude(s => s.ChartTemplatesManyToMany).ThenInclude(c => c.ChartTemplate)
             .Include(r => r.SubscribersManyToMany).ThenInclude(s => s.User)
             .Include(r => r.Events).ThenInclude(s => s.Schedule)
+            .AsSplitQuery()
             .FirstOrDefault(r => r.Id == id);
 
         // Reorganize sections.
@@ -593,7 +594,7 @@ public class ReportService : BaseService<Report, int>, IReportService
     {
         var query = this.Context.ReportInstances
             .AsNoTracking()
-            .OrderByDescending(i => i.Id)
+            .AsSplitQuery()
             .Where(i => i.ReportId == id);
 
         if (ownerId.HasValue == true)
@@ -610,7 +611,7 @@ public class ReportService : BaseService<Report, int>, IReportService
         else
             query = query.Include(i => i.ContentManyToMany);
 
-        return query.FirstOrDefault();
+        return query.OrderByDescending(i => i.Id).FirstOrDefault();
     }
 
     /// <summary>

--- a/libs/net/models/Settings/ReportSettingsModel.cs
+++ b/libs/net/models/Settings/ReportSettingsModel.cs
@@ -6,10 +6,29 @@ namespace TNO.API.Models.Settings;
 public class ReportSettingsModel
 {
     #region Properties
+    /// <summary>
+    /// get/set - Subject configuration settings.
+    /// </summary>
     public ReportSubjectSettingsModel Subject { get; set; } = new();
+
+    /// <summary>
+    /// get/set - Headline configuration settings.
+    /// </summary>
     public ReportHeadlineSettingsModel Headline { get; set; } = new();
+
+    /// <summary>
+    /// get/set - Content configuration settings.
+    /// </summary>
     public ReportContentSettingsModel Content { get; set; } = new();
+
+    /// <summary>
+    /// get/set - Section configuration settings.
+    /// </summary>
     public ReportSectionsSettingsModel Sections { get; set; } = new();
+
+    /// <summary>
+    /// get/set - Treat the report as if it was sent, but do not email it out.
+    /// </summary>
     public bool DoNotSendEmail { get; set; } = false;
     #endregion
 


### PR DESCRIPTION
Several minor changes and fixes for reports.

- `ReportInstance.SentOn` will be set even if there is a failure
- Viewing a sent report will no longer require regenerating
- Fixed Action component hover cursor
- Several SQL query changes to test if they are quicker with split queries
- Reports will not keep trying to update the report instance until successful.  This should have a limit added at some point.