### PR TITLE
TNO-2907 Add status to disable send

### DIFF
--- a/app/subscriber/src/features/my-reports/edit/view/ReportViewForm.tsx
+++ b/app/subscriber/src/features/my-reports/edit/view/ReportViewForm.tsx
@@ -153,7 +153,10 @@ export const ReportViewForm: React.FC = () => {
           <Row alignItems="flex-start" className="preview-send-details-row">
             <Button
               disabled={
-                isSubmitting || !instance || instance?.status === ReportStatusName.Submitted
+                isSubmitting ||
+                !instance ||
+                instance?.status === ReportStatusName.Submitted ||
+                instance?.status === ReportStatusName.Accepted
               }
               onClick={() => toggleSend()}
               variant="success"

--- a/app/subscriber/src/features/my-reports/edit/view/ReportViewForm.tsx
+++ b/app/subscriber/src/features/my-reports/edit/view/ReportViewForm.tsx
@@ -153,10 +153,7 @@ export const ReportViewForm: React.FC = () => {
           <Row alignItems="flex-start" className="preview-send-details-row">
             <Button
               disabled={
-                isSubmitting ||
-                !instance ||
-                instance?.status === ReportStatusName.Submitted ||
-                instance?.status === ReportStatusName.Accepted
+                isSubmitting || !instance || instance?.status === ReportStatusName.Submitted
               }
               onClick={() => toggleSend()}
               variant="success"

--- a/services/net/reporting/ReportingManager.cs
+++ b/services/net/reporting/ReportingManager.cs
@@ -681,7 +681,7 @@ public class ReportingManager : ServiceManager<ReportingOptions>
                 instance.Response = JsonDocument.Parse(JsonSerializer.Serialize(responseModel, _serializationOptions));
             }
 
-            if (request.GenerateInstance && !resending)
+            if (request.GenerateInstance)
             {
                 instance.Subject = subject;
                 instance.Body = fullTextFormatBody;


### PR DESCRIPTION
I've found out when it was a resend, the this.Api.UpdateReportInstanceAsync method was not called, not generating a new SignalR message, and keeping the status of the instance locked on "Submitted".
As far as I could see, the is no problem on running the update on resend, and having the "Last Sent", and Status up to date.
Testing it locally, it didn't generated multiple instances, and the data integrity seem to be OK.