### PR TITLE
Fix reporting

### DIFF
--- a/api/net/Areas/Admin/Controllers/ReportController.cs
+++ b/api/net/Areas/Admin/Controllers/ReportController.cs
@@ -220,9 +220,6 @@ public class ReportController : ControllerBase
         {
             RequestorId = user.Id,
             To = to,
-            // no longer utilized, the caching mechanism
-            // determines whether to update or not
-            // UpdateCache = true,
             GenerateInstance = false
         };
         await _kafkaProducer.SendMessageAsync(_kafkaOptions.ReportingTopic, $"report-{report.Id}-test", request);

--- a/libs/net/core/Extensions/StreamExtensions.cs
+++ b/libs/net/core/Extensions/StreamExtensions.cs
@@ -1,0 +1,26 @@
+namespace TNO.Core.Extensions
+{
+    /// <summary>
+    /// StreamExtensions static class, provides extension methods for Stream objects.
+    /// </summary>
+    public static class StreamExtensions
+    {
+
+        #region Methods
+        /// <summary>
+        /// Copy stream to byte array.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <returns></returns>
+        public static byte[] ReadAllBytes(this Stream stream)
+        {
+            if (stream is MemoryStream)
+                return ((MemoryStream)stream).ToArray();
+
+            using var memoryStream = new MemoryStream();
+            stream.CopyTo(memoryStream);
+            return memoryStream.ToArray();
+        }
+        #endregion
+    }
+}

--- a/libs/net/kafka/KafkaListener`.cs
+++ b/libs/net/kafka/KafkaListener`.cs
@@ -283,7 +283,7 @@ public class KafkaListener<TKey, TValue> : IKafkaListener<TKey, TValue>, IDispos
     /// <param name="partitions"></param>
     public void Resume(IEnumerable<TopicPartition> partitions)
     {
-        if (this.IsPaused)
+        if (this.IsPaused || !this.IsConsuming)
         {
             _logger.LogDebug("Resuming consumption: {topics}", String.Join(", ", partitions.Select(p => p.Topic).Distinct()));
             this.IsPaused = false;

--- a/libs/net/kafka/Models/ReportRequestModel.cs
+++ b/libs/net/kafka/Models/ReportRequestModel.cs
@@ -61,6 +61,7 @@ public class ReportRequestModel
 
     /// <summary>
     /// get/set - Whether this request will generate an instance.
+    /// This can be used to test as it won't result in a change in the database.
     /// </summary>
     public bool GenerateInstance { get; set; } = true;
 

--- a/libs/net/services/Config/ServiceOptions.cs
+++ b/libs/net/services/Config/ServiceOptions.cs
@@ -25,9 +25,19 @@ public class ServiceOptions
     public int RetryDelayMS { get; set; } = 5000;
 
     /// <summary>
-    /// get/set - Default millisecond delay between process cycle.  This stops run-away threads (default: 30 second).
+    /// get/set - Default millisecond delay between process cycle.  This stops run-away threads (default: 30 seconds).
     /// </summary>
     public int DefaultDelayMS { get; set; } = 30000;
+
+    /// <summary>
+    /// get/set - Whether to restart a service after a critical sequence of failures.
+    /// </summary>
+    public bool AutoRestartAfterFailure { get; set; } = true;
+
+    /// <summary>
+    /// get/set - Number of millisecond delay before restarting service after a critical sequence of failures (default: 30 seconds).
+    /// </summary>
+    public int RetryAfterFailedDelayMS { get; set; } = 30000;
 
     /// <summary>
     /// get/set - The URL to the API.

--- a/libs/net/services/ServiceState.cs
+++ b/libs/net/services/ServiceState.cs
@@ -45,7 +45,7 @@ public class ServiceState
     {
         this.Failures++;
 
-        if (this.Failures >= this.MaxFailureLimit) this.Status = ServiceStatus.RequestSleep;
+        if (this.Failures >= this.MaxFailureLimit && this.Status != ServiceStatus.Failed) this.Status = ServiceStatus.RequestFailed;
         return this.Failures;
     }
 
@@ -82,6 +82,8 @@ public class ServiceState
             this.Status = ServiceStatus.Sleeping;
         else if (this.Status == ServiceStatus.RequestPause)
             this.Status = ServiceStatus.Paused;
+        else if (this.Status == ServiceStatus.RequestFailed)
+            this.Status = ServiceStatus.Failed;
         else Sleep();
     }
 

--- a/libs/net/services/ServiceStatus.cs
+++ b/libs/net/services/ServiceStatus.cs
@@ -27,4 +27,12 @@ public enum ServiceStatus
     /// Sleeping can occur if failures have reached their maximum.
     /// </summary>
     Sleeping = 4,
+    /// <summary>
+    /// The service has a failure and must stop.
+    /// </summary>
+    RequestFailed = 5,
+    /// <summary>
+    /// The service has failed.
+    /// </summary>
+    Failed = 6,
 }

--- a/libs/net/tests/services/ServiceStateTest.cs
+++ b/libs/net/tests/services/ServiceStateTest.cs
@@ -48,7 +48,7 @@ public class ServiceStateTest
 
         // Assert
         Assert.Equal(state.MaxFailureLimit, state.Failures);
-        Assert.Equal(ServiceStatus.RequestSleep, state.Status);
+        Assert.Equal(ServiceStatus.RequestFailed, state.Status);
     }
 
     [Fact]

--- a/services/net/content/ContentManager.cs
+++ b/services/net/content/ContentManager.cs
@@ -87,7 +87,7 @@ public class ContentManager : ServiceManager<ContentOptions>
         // Always keep looping until an unexpected failure occurs.
         while (true)
         {
-            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause)
+            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause || this.State.Status == ServiceStatus.RequestFailed)
             {
                 // An API request or failures have requested the service to stop.
                 this.Logger.LogInformation("The service is stopping: '{Status}'", this.State.Status);
@@ -352,11 +352,14 @@ public class ContentManager : ServiceManager<ContentOptions>
             content.PublishedOn = model.PublishedOn;
             content.Section = model.Section;
             content.Byline = string.Join(",", model.Authors.Select(a => a.Name[0..Math.Min(a.Name.Length, 200)])); // TODO: Temporary workaround to deal with regression issue in Syndication Service.
-            if (!string.IsNullOrEmpty(content.Byline)) {
+            if (!string.IsNullOrEmpty(content.Byline))
+            {
                 var contributors = lookups?.Contributors;
-                if (contributors != null && contributors.Any()) {
+                if (contributors != null && contributors.Any())
+                {
                     var contributor = FindMatchedContributor(contributors, content.Byline);
-                    if (contributor != null) {
+                    if (contributor != null)
+                    {
                         content.Contributor = new ContributorModel((Contributor)contributor);
                         content.ContributorId = content.Contributor.Id;
                     }
@@ -591,7 +594,7 @@ public class ContentManager : ServiceManager<ContentOptions>
         }
         else
         {
-            var index = nameString.LastIndexOf(" ", nameString.Length-1, nameString.Length, StringComparison.OrdinalIgnoreCase);
+            var index = nameString.LastIndexOf(" ", nameString.Length - 1, nameString.Length, StringComparison.OrdinalIgnoreCase);
             if (index == -1)
             {
                 return nameString;

--- a/services/net/contentmigration/migrators/ClipMigrator.cs
+++ b/services/net/contentmigration/migrators/ClipMigrator.cs
@@ -55,7 +55,10 @@ public class ClipMigrator : ContentMigrator<ContentMigrationOptions>, IContentMi
 
         // Scrum/Events place their transcript in the summary.
         if (!String.IsNullOrWhiteSpace(newsItem.Text) && mediaType.Name == "Events")
+        {
+            sanitizedSummary = string.Empty;
             sanitizedBody = TNO.Core.Extensions.StringExtensions.ConvertTextToParagraphs(newsItem.Text, @"\r\n?|\n|\|");
+        }
 
         var content = new SourceContent(
             this.Options.DataLocation,

--- a/services/net/event-handler/EventHandlerManager.cs
+++ b/services/net/event-handler/EventHandlerManager.cs
@@ -73,7 +73,7 @@ public class EventHandlerManager : ServiceManager<EventHandlerOptions>
         // Always keep looping until an unexpected failure occurs.
         while (true)
         {
-            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause)
+            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause || this.State.Status == ServiceStatus.RequestFailed)
             {
                 // An API request or failures have requested the service to stop.
                 this.Logger.LogInformation("The service is stopping: '{Status}'", this.State.Status);

--- a/services/net/ffmpeg/FFmpegManager.cs
+++ b/services/net/ffmpeg/FFmpegManager.cs
@@ -71,7 +71,7 @@ public class FFmpegManager : ServiceManager<FFmpegOptions>
         // Always keep looping until an unexpected failure occurs.
         while (true)
         {
-            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause)
+            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause || this.State.Status == ServiceStatus.RequestFailed)
             {
                 // An API request or failures have requested the service to stop.
                 this.Logger.LogInformation("The service is stopping: '{Status}'", this.State.Status);

--- a/services/net/filecopy/FileCopyManager.cs
+++ b/services/net/filecopy/FileCopyManager.cs
@@ -1,17 +1,17 @@
+using System.Web;
+using Confluent.Kafka;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using TNO.Services.Managers;
-using TNO.Services.FileCopy.Config;
-using TNO.Kafka.Models;
-using Confluent.Kafka;
-using TNO.Kafka;
-using TNO.Core.Extensions;
-using TNO.Core.Exceptions;
-using TNO.Entities;
-using TNO.Models.Extensions;
-using System.Web;
 using TNO.Ches;
 using TNO.Ches.Configuration;
+using TNO.Core.Exceptions;
+using TNO.Core.Extensions;
+using TNO.Entities;
+using TNO.Kafka;
+using TNO.Kafka.Models;
+using TNO.Models.Extensions;
+using TNO.Services.FileCopy.Config;
+using TNO.Services.Managers;
 
 namespace TNO.Services.FileCopy;
 
@@ -73,7 +73,7 @@ public class FileCopyManager : ServiceManager<FileCopyOptions>
         // Always keep looping until an unexpected failure occurs.
         while (true)
         {
-            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause)
+            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause || this.State.Status == ServiceStatus.RequestFailed)
             {
                 // An API request or failures have requested the service to stop.
                 this.Logger.LogInformation("The service is stopping: '{Status}'", this.State.Status);

--- a/services/net/folder-collection/FolderCollectionManager.cs
+++ b/services/net/folder-collection/FolderCollectionManager.cs
@@ -96,7 +96,7 @@ public class FolderCollectionManager : ServiceManager<FolderCollectionOptions>
         // Always keep looping until an unexpected failure occurs.
         while (true)
         {
-            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause)
+            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause || this.State.Status == ServiceStatus.RequestFailed)
             {
                 // An API request or failures have requested the service to stop.
                 this.Logger.LogInformation("The service is stopping: '{Status}'", this.State.Status);

--- a/services/net/indexing/IndexingManager.cs
+++ b/services/net/indexing/IndexingManager.cs
@@ -91,7 +91,7 @@ public class IndexingManager : ServiceManager<IndexingOptions>
         // Always keep looping until an unexpected failure occurs.
         while (true)
         {
-            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause)
+            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause || this.State.Status == ServiceStatus.RequestFailed)
             {
                 // An API request or failures have requested the service to stop.
                 this.Logger.LogInformation("The service is stopping: '{Status}'", this.State.Status);

--- a/services/net/nlp/NLPManager.cs
+++ b/services/net/nlp/NLPManager.cs
@@ -83,7 +83,7 @@ public class NlpManager : ServiceManager<NLPOptions>
         // Always keep looping until an unexpected failure occurs.
         while (true)
         {
-            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause)
+            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause || this.State.Status == ServiceStatus.RequestFailed)
             {
                 // An API request or failures have requested the service to stop.
                 this.Logger.LogInformation("The service is stopping: '{Status}'", this.State.Status);

--- a/services/net/notification/NotificationManager.cs
+++ b/services/net/notification/NotificationManager.cs
@@ -107,7 +107,7 @@ public class NotificationManager : ServiceManager<NotificationOptions>
         // Always keep looping until an unexpected failure occurs.
         while (true)
         {
-            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause)
+            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause || this.State.Status == ServiceStatus.RequestFailed)
             {
                 // An API request or failures have requested the service to stop.
                 this.Logger.LogInformation("The service is stopping: '{Status}'", this.State.Status);

--- a/services/net/reporting/ReportingErrors.cs
+++ b/services/net/reporting/ReportingErrors.cs
@@ -1,0 +1,11 @@
+namespace TNO.Services.Reporting;
+
+public enum ReportingErrors
+{
+    FailedToGetInstance = 0,
+    FailedToGetContent = 1,
+    FailedToAddInstance = 2,
+    FailedToUpdateInstance = 3,
+    FailedToGenerateOutput = 4,
+    FailedToEmail = 4,
+}

--- a/services/net/reporting/ReportingException.cs
+++ b/services/net/reporting/ReportingException.cs
@@ -1,0 +1,19 @@
+namespace TNO.Services.Reporting;
+
+public class ReportingException : Exception
+{
+    #region Properties
+    public ReportingErrors Error { get; }
+    #endregion
+
+    #region Constructors
+    public ReportingException(ReportingErrors error, string? message, Exception? innerException)
+        : base(message, innerException)
+    {
+        this.Error = error;
+    }
+    #endregion
+
+    #region Methods
+    #endregion
+}

--- a/services/net/scheduler/SchedulerManager.cs
+++ b/services/net/scheduler/SchedulerManager.cs
@@ -53,7 +53,7 @@ public class SchedulerManager : ServiceManager<SchedulerOptions>
         // Always keep looping until an unexpected failure occurs.
         while (true)
         {
-            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause)
+            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause || this.State.Status == ServiceStatus.RequestFailed)
             {
                 // An API request or failures have requested the service to stop.
                 this.Logger.LogInformation("The service is stopping: '{Status}'", this.State.Status);

--- a/services/net/transcription/TranscriptionManager.cs
+++ b/services/net/transcription/TranscriptionManager.cs
@@ -76,7 +76,7 @@ public class TranscriptionManager : ServiceManager<TranscriptionOptions>
         // Always keep looping until an unexpected failure occurs.
         while (true)
         {
-            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause)
+            if (this.State.Status == ServiceStatus.RequestSleep || this.State.Status == ServiceStatus.RequestPause || this.State.Status == ServiceStatus.RequestFailed)
             {
                 // An API request or failures have requested the service to stop.
                 this.Logger.LogInformation("The service is stopping: '{Status}'", this.State.Status);

--- a/tools/elastic/migration/TNOMigration.cs
+++ b/tools/elastic/migration/TNOMigration.cs
@@ -4,8 +4,8 @@ using Elastic.Transport;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using TNO.API.Areas.Services.Models.Content;
-using TNO.Models.Filters;
 using TNO.DAL.Services;
+using TNO.Models.Filters;
 
 namespace TNO.Elastic.Migration;
 
@@ -73,7 +73,7 @@ public abstract class TNOMigration : Migration
                         {
                             if (response.TryGetOriginalException(out Exception? ex))
                                 throw ex!;
-                            throw new Exception($"Failed to index. Error {response.ElasticsearchServerError.Error.Reason}");
+                            throw new Exception($"Failed to index. Error {response.ElasticsearchServerError?.Error.Reason}");
                         }
 
                         if (item.Status == Entities.ContentStatus.Published)
@@ -84,7 +84,7 @@ public abstract class TNOMigration : Migration
                             {
                                 if (response.TryGetOriginalException(out Exception? ex))
                                     throw ex!;
-                                throw new Exception($"Failed to index. Error {response.ElasticsearchServerError.Error.Reason}");
+                                throw new Exception($"Failed to index. Error {response.ElasticsearchServerError?.Error.Reason}");
                             }
                         }
 


### PR DESCRIPTION
Failed reports will now keep trying over and over by sending a message to Kafka.  I will need to put a limiter on this at some point, but want to test before doing this.

A failed report which is partially successful will pick up where it left off, by publishing a message to Kafka for the report instance instead.

I also discovered that the prior implementation to restart services after failures was not implemented correctly, as such only a few services actually do this.  The new code added for the reports will need to be applied to other services later.