### PR TITLE
TNO-2921: Advanced Search Using Escape Characters Breaking Bolding.

### DIFF
--- a/app/subscriber/src/features/search-page/utils/formatSearch.ts
+++ b/app/subscriber/src/features/search-page/utils/formatSearch.ts
@@ -28,8 +28,8 @@ export const formatSearch = (text: string, filter: IFilterSettingsModel) => {
   }
 
   // Match possible phrases within quotes, prefixed terms with '*',
-  // normal words, and exclude words with '-' and '~'
-  const tokens = cleanedSearch.match(/"[^"]+"|\b\w+\*|\b\w+\b|[-~]\s*\w+/g) || [];
+  // normal words, and exclude words with '~'
+  const tokens = cleanedSearch.match(/"[^"]+"|\b\w+\*|\b\w+\b|[~]\s*\w+/g) || [];
 
   let includePatterns: string[] = [];
   let excludePatterns: string[] = [];
@@ -42,7 +42,7 @@ export const formatSearch = (text: string, filter: IFilterSettingsModel) => {
       // Handle prefix queries, remove the '*' at the end
       let prefix = escapeRegExp(token.slice(0, -1));
       includePatterns.push(`\\b${prefix}\\w*\\b`);
-    } else if (token.startsWith('-') || token.startsWith('~')) {
+    } else if (token.startsWith('~')) {
       // Handle exclude words, remove the '-' at the beginning
       excludePatterns.push(`\\b${escapeRegExp(token.slice(1))}\\b`);
     } else {


### PR DESCRIPTION
In  the modified version of `formatSearch`, we are discarding `[-~]` to be bold, they are added to excludePatterns list. However, jut includePatterns is providing bolding.

This change just remove `-` from excludePatterns to be handled in includePatterns list to be bold.

<img width="872" alt="image" src="https://github.com/user-attachments/assets/6c4a7b2a-638d-4b41-b636-a62c30d2f025">



Story: https://citz-gdx.atlassian.net/browse/TNO-2921