### PR TITLE
[Fix] TNO-2922: Advanced Search Very Slow

### DIFF
--- a/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
@@ -111,7 +111,7 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ onSearch }) => 
   const [{ sources, series, mediaTypes }] = useLookup();
   const [initialState, setInitialState] = React.useState<IFilterSettingsModel | null>(null);
   const [isFirstLoad, setIsFirstLoad] = React.useState<boolean>(false);
-  const [controlled, setController] = React.useState('');
+  const [controlled, setController] = React.useState<string>(search?.search ?? '');
 
   const isDiff = React.useMemo(
     () => JSON.stringify(initialState) !== JSON.stringify(search),
@@ -215,7 +215,7 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ onSearch }) => 
     () =>
       debounce((value) => {
         memoizedStoreSearchFilter({ ...search, search: value });
-      }, 1000),
+      }, 150),
     [search, memoizedStoreSearchFilter],
   );
 


### PR DESCRIPTION
Not showing saved filter when user is in Advanced Search:
<img width="254" alt="image" src="https://github.com/user-attachments/assets/05a324e5-849c-4723-8c4b-0bf36818671f">

The fix is adding search filter as default value if it exists, else the value is empty:
<img width="866" alt="image" src="https://github.com/user-attachments/assets/d08c4b38-da08-4a1c-ae36-8e0b29063d12">
