### PR TITLE
Update Reports to support failures

### DIFF
--- a/api/net/Areas/Admin/Controllers/ReportInstanceController.cs
+++ b/api/net/Areas/Admin/Controllers/ReportInstanceController.cs
@@ -146,7 +146,7 @@ public class ReportInstanceController : ControllerBase
         var username = User.GetUsername() ?? throw new NotAuthorizedException("Username is missing");
         var user = _userService.FindByUsername(username) ?? throw new NotAuthorizedException($"User [{username}] does not exist");
 
-        instance.Status = ReportStatus.Submitted;
+        instance.Status = instance.Status == Entities.ReportStatus.Pending ? Entities.ReportStatus.Submitted : instance.Status;
         instance = _reportInstanceService.UpdateAndSave(instance);
 
         var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.Content, instance.ReportId, instance.Id, new { })

--- a/api/net/Areas/Editor/Controllers/AVOverviewController.cs
+++ b/api/net/Areas/Editor/Controllers/AVOverviewController.cs
@@ -80,7 +80,7 @@ public class AVOverviewController : ControllerBase
     [ProducesResponseType(typeof(AVOverviewInstanceModel), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
     [SwaggerOperation(Tags = new[] { "Evening Overview" })]
-    public IActionResult FindByDate([FromQuery]DateTime? publishedOn = null)
+    public IActionResult FindByDate([FromQuery] DateTime? publishedOn = null)
     {
         Entities.AVOverviewInstance? instance;
         if (publishedOn != null)
@@ -113,7 +113,7 @@ public class AVOverviewController : ControllerBase
     [ProducesResponseType(typeof(AVOverviewInstanceModel), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
     [SwaggerOperation(Tags = new[] { "Evening Overview" })]
-    public IActionResult FindById(int instanceId)
+    public IActionResult FindById(long instanceId)
     {
         var result = _overviewInstanceService.FindById(instanceId) ?? throw new NoContentException();
         return new JsonResult(new AVOverviewInstanceModel(result));
@@ -178,8 +178,8 @@ public class AVOverviewController : ControllerBase
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType(typeof(TemplateEngine.Models.Reports.ReportResultModel), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
-    [SwaggerOperation(Tags = new[] { "Report" })]
-    public async Task<IActionResult> View(int instanceId)
+    [SwaggerOperation(Tags = new[] { "Evening Overview" })]
+    public async Task<IActionResult> View(long instanceId)
     {
         var instance = _overviewInstanceService.FindById(instanceId) ?? throw new NoContentException($"AV overview instance '{instanceId}' not found");
         var model = new TemplateEngine.Models.Reports.AVOverviewInstanceModel(instance);
@@ -196,18 +196,18 @@ public class AVOverviewController : ControllerBase
     [Produces(MediaTypeNames.Application.Json)]
     [ProducesResponseType((int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
-    [SwaggerOperation(Tags = new[] { "Report" })]
-    public async Task<IActionResult> Publish(int instanceId)
+    [SwaggerOperation(Tags = new[] { "Evening Overview" })]
+    public async Task<IActionResult> Publish(long instanceId)
     {
         var instance = _overviewInstanceService.FindById(instanceId) ?? throw new NoContentException($"AV overview instance '{instanceId}' not found");
         var username = User.GetUsername() ?? throw new NotAuthorizedException("Username is missing");
         var user = _userService.FindByUsername(username) ?? throw new NotAuthorizedException($"User [{username}] does not exist");
 
-        var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.AVOverview, instance.Id, new { })
+        var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.AVOverview, 0, instance.Id, new { })
         {
             RequestorId = user.Id
         };
-        await _kafkaProducer.SendMessageAsync(_kafkaOptions.ReportingTopic, $"report-{instance.Id}", request);
+        await _kafkaProducer.SendMessageAsync(_kafkaOptions.ReportingTopic, request);
         return new OkResult();
     }
     #endregion

--- a/api/net/Areas/Services/Controllers/AVOverviewController.cs
+++ b/api/net/Areas/Services/Controllers/AVOverviewController.cs
@@ -90,5 +90,56 @@ public class AVOverviewController : ControllerBase
         var instance = _overviewInstanceService.FindById(result.Id) ?? throw new NoContentException("Overview Section does not exist");
         return new JsonResult(new AVOverviewInstanceModel(instance, _serializerOptions));
     }
+
+    /// <summary>
+    /// Get all user report instances for the specified instance 'id'.
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    [HttpGet("{id}/responses")]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(typeof(IEnumerable<UserAVOverviewInstanceModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
+    [SwaggerOperation(Tags = new[] { "Report" })]
+    public IActionResult GetUserAVOverviewInstancesAsync(long id)
+    {
+        var content = _overviewInstanceService.GetUserAVOverviewInstances(id);
+        return new JsonResult(content.Select(c => new UserAVOverviewInstanceModel(c)));
+    }
+
+    /// <summary>
+    /// Add or update an array of user report instances.
+    /// These keep track of who a report was sent to and the status.
+    /// </summary>
+    /// <param name="model"></param>
+    /// <returns></returns>
+    [HttpPost("response")]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(typeof(UserAVOverviewInstanceModel), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
+    [SwaggerOperation(Tags = new[] { "ReportInstance" })]
+    public IActionResult AddOrUpdate(UserAVOverviewInstanceModel model)
+    {
+        var result = _overviewInstanceService.UpdateAndSave((Entities.UserAVOverviewInstance)model);
+        return new JsonResult(new UserAVOverviewInstanceModel(result));
+    }
+
+    /// <summary>
+    /// Add or update an array of user report instances.
+    /// These keep track of who a report was sent to and the status.
+    /// </summary>
+    /// <param name="models"></param>
+    /// <returns></returns>
+    [HttpPost("responses")]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(typeof(IEnumerable<UserAVOverviewInstanceModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
+    [SwaggerOperation(Tags = new[] { "ReportInstance" })]
+    public IActionResult AddOrUpdate(IEnumerable<UserAVOverviewInstanceModel> models)
+    {
+        var entities = models.Select(m => (Entities.UserAVOverviewInstance)m);
+        var result = _overviewInstanceService.UpdateAndSave(entities);
+        return new JsonResult(result.Select(r => new UserAVOverviewInstanceModel(r)));
+    }
     #endregion
 }

--- a/api/net/Areas/Services/Controllers/UserController.cs
+++ b/api/net/Areas/Services/Controllers/UserController.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TNO.API.Areas.Services.Models.User;
 using TNO.API.Models;
-using TNO.Core.Exceptions;
 using TNO.DAL.Services;
 using TNO.Keycloak;
 
@@ -42,7 +41,7 @@ public class UserController : ControllerBase
 
     #region Endpoints
     /// <summary>
-    /// Find the work order for the specified 'id'.
+    /// Find the user for the specified 'id'.
     /// </summary>
     /// <param name="id"></param>
     /// <returns></returns>
@@ -57,6 +56,22 @@ public class UserController : ControllerBase
         var result = _service.FindById(id);
         if (result == null) return NoContent();
         return new JsonResult(new UserModel(result));
+    }
+
+    /// <summary>
+    /// Find all the users in the distribution list for the specified 'id'.
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    [HttpGet("{id}/distribution")]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(typeof(IEnumerable<UserModel>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
+    [SwaggerOperation(Tags = new[] { "User" })]
+    public IActionResult FindDistributionListById(int id)
+    {
+        var result = _service.GetDistributionList(id);
+        return new JsonResult(result.Select(r => new UserModel(r)));
     }
     #endregion
 }

--- a/api/net/Areas/Subscriber/Controllers/ReportInstanceController.cs
+++ b/api/net/Areas/Subscriber/Controllers/ReportInstanceController.cs
@@ -243,7 +243,7 @@ public class ReportInstanceController : ControllerBase
         var instance = _reportInstanceService.FindById(id) ?? throw new NoContentException("Report does not exist");
         if (instance.OwnerId != user.Id) throw new NotAuthorizedException("Not authorized to publish this report"); // User does not own the report
 
-        instance.Status = Entities.ReportStatus.Submitted;
+        instance.Status = instance.Status == Entities.ReportStatus.Pending ? Entities.ReportStatus.Submitted : instance.Status;
         instance = _reportInstanceService.UpdateAndSave(instance);
 
         var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.Content, instance.ReportId, instance.Id, new { })

--- a/app/editor/src/features/admin/users/UserFormDistribution.tsx
+++ b/app/editor/src/features/admin/users/UserFormDistribution.tsx
@@ -77,6 +77,10 @@ export const UserFormDistribution: React.FC = () => {
     <div className="form-container">
       <Section className="frm-in">
         <label>Account Information</label>
+        <p className="info">
+          DO NOT ADD/EDIT DISTRIBUTION LISTS UNTIL I COMPLETE THE MOST RECENT CHANGES TO REPORTS.
+        </p>
+        <p className="info">THEY DO NO CURRENTLY WORK BECAUSE OF CHES ISSUES.</p>
         <Row gap="1rem">
           <Col>
             <FormikSelect

--- a/app/editor/src/features/admin/users/styled/UserForm.tsx
+++ b/app/editor/src/features/admin/users/styled/UserForm.tsx
@@ -6,6 +6,12 @@ export const UserForm = styled(FormPage)`
   flex-direction: column;
   align-items: center;
 
+  .info {
+    padding: 2rem;
+    background-color: red;
+    color: white;
+  }
+
   .back-button {
     align-self: start;
   }

--- a/libs/net/dal/Configuration/UserAVOverviewInstanceConfiguration.cs
+++ b/libs/net/dal/Configuration/UserAVOverviewInstanceConfiguration.cs
@@ -1,0 +1,23 @@
+namespace TNO.DAL.Configuration;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TNO.Entities;
+
+public class UserAVOverviewInstanceConfiguration : AuditColumnsConfiguration<UserAVOverviewInstance>
+{
+    public override void Configure(EntityTypeBuilder<UserAVOverviewInstance> builder)
+    {
+        builder.HasKey(m => new { m.UserId, m.InstanceId });
+        builder.Property(m => m.UserId).IsRequired().ValueGeneratedNever();
+        builder.Property(m => m.InstanceId).IsRequired().ValueGeneratedNever();
+        builder.Property(m => m.SentOn);
+        builder.Property(m => m.Status).IsRequired();
+        builder.Property(m => m.Response).IsRequired().HasColumnType("jsonb").HasDefaultValueSql("'{}'::jsonb");
+
+        builder.HasOne(m => m.User).WithMany().HasForeignKey(m => m.UserId).OnDelete(DeleteBehavior.Cascade);
+        builder.HasOne(m => m.Instance).WithMany(m => m.UserInstances).HasForeignKey(m => m.InstanceId).OnDelete(DeleteBehavior.Cascade);
+
+        base.Configure(builder);
+    }
+}

--- a/libs/net/dal/Configuration/UserDistributionConfiguration.cs
+++ b/libs/net/dal/Configuration/UserDistributionConfiguration.cs
@@ -1,0 +1,20 @@
+namespace TNO.DAL.Configuration;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TNO.Entities;
+
+public class UserDistributionConfiguration : AuditColumnsConfiguration<UserDistribution>
+{
+    public override void Configure(EntityTypeBuilder<UserDistribution> builder)
+    {
+        builder.HasKey(m => new { m.UserId, m.LinkedUserId });
+        builder.Property(m => m.UserId).IsRequired().ValueGeneratedNever();
+        builder.Property(m => m.LinkedUserId).IsRequired().ValueGeneratedNever();
+
+        builder.HasOne(m => m.User).WithMany(m => m.Distribution).HasForeignKey(m => m.UserId).OnDelete(DeleteBehavior.Cascade);
+        builder.HasOne(m => m.LinkedUser).WithMany().HasForeignKey(m => m.LinkedUserId).OnDelete(DeleteBehavior.Cascade);
+
+        base.Configure(builder);
+    }
+}

--- a/libs/net/dal/Configuration/UserReportInstanceConfiguration.cs
+++ b/libs/net/dal/Configuration/UserReportInstanceConfiguration.cs
@@ -1,0 +1,26 @@
+namespace TNO.DAL.Configuration;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TNO.Entities;
+
+public class UserReportInstanceConfiguration : AuditColumnsConfiguration<UserReportInstance>
+{
+    public override void Configure(EntityTypeBuilder<UserReportInstance> builder)
+    {
+        builder.HasKey(m => new { m.UserId, m.InstanceId });
+        builder.Property(m => m.UserId).IsRequired().ValueGeneratedNever();
+        builder.Property(m => m.InstanceId).IsRequired().ValueGeneratedNever();
+        builder.Property(m => m.LinkSentOn);
+        builder.Property(m => m.LinkStatus).IsRequired();
+        builder.Property(m => m.LinkResponse).IsRequired().HasColumnType("jsonb").HasDefaultValueSql("'{}'::jsonb");
+        builder.Property(m => m.TextSentOn);
+        builder.Property(m => m.TextStatus).IsRequired();
+        builder.Property(m => m.TextResponse).IsRequired().HasColumnType("jsonb").HasDefaultValueSql("'{}'::jsonb");
+
+        builder.HasOne(m => m.User).WithMany().HasForeignKey(m => m.UserId).OnDelete(DeleteBehavior.Cascade);
+        builder.HasOne(m => m.Instance).WithMany(m => m.UserInstances).HasForeignKey(m => m.InstanceId).OnDelete(DeleteBehavior.Cascade);
+
+        base.Configure(builder);
+    }
+}

--- a/libs/net/dal/Migrations/1.2.0/Up/PostUp/00-Users.sql
+++ b/libs/net/dal/Migrations/1.2.0/Up/PostUp/00-Users.sql
@@ -1,0 +1,34 @@
+DO
+$BODY$
+
+DECLARE
+	tempRow record;
+	tempItem json;
+
+BEGIN
+
+	FOR tempRow IN
+	    SELECT "id", "preferences", "preferences" -> 'addresses' as "addresses" FROM public."user" WHERE "account_type" = 2
+	LOOP
+		FOR tempItem IN SELECT * FROM json_array_elements(to_json(tempRow.addresses))
+		LOOP
+
+			RAISE NOTICE 'output from space %', tempItem ->> 'userId';
+
+      INSERT INTO public."user_distribution" (
+        "user_id"
+        , "linked_user_id"
+        , "created_by"
+        , "updated_by"
+      ) VALUES (
+        tempRow."id"
+        , (tempItem ->> 'userId')::int
+        , ''
+        , ''
+      ) ON CONFLICT DO NOTHING;
+		END LOOP;
+	END LOOP;
+
+END;
+
+$BODY$ LANGUAGE plpgsql

--- a/libs/net/dal/Migrations/20240731064252_1.2.0.Designer.cs
+++ b/libs/net/dal/Migrations/20240731064252_1.2.0.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TNO.DAL;
@@ -14,9 +15,11 @@ using TNO.Entities.Models;
 namespace TNO.DAL.Migrations
 {
     [DbContext(typeof(TNOContext))]
-    partial class TNOContextModelSnapshot : ModelSnapshot
+    [Migration("20240731064252_1.2.0")]
+    partial class _120
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/libs/net/dal/Migrations/20240731064252_1.2.0.cs
+++ b/libs/net/dal/Migrations/20240731064252_1.2.0.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using TNO.DAL;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace TNO.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class _120 : SeedMigration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            PreUp(migrationBuilder);
+            migrationBuilder.AlterColumn<long>(
+                name: "av_overview_instance_id",
+                table: "av_overview_section",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "id",
+                table: "av_overview_instance",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer")
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
+                .OldAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.CreateTable(
+                name: "user_av_overview_instance",
+                columns: table => new
+                {
+                    user_id = table.Column<int>(type: "integer", nullable: false),
+                    report_instance_id = table.Column<long>(type: "bigint", nullable: false),
+                    sent_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    status = table.Column<int>(type: "integer", nullable: false),
+                    response = table.Column<JsonDocument>(type: "jsonb", nullable: false, defaultValueSql: "'{}'::jsonb"),
+                    created_by = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
+                    created_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    updated_by = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
+                    updated_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    version = table.Column<long>(type: "bigint", nullable: false, defaultValueSql: "0")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_user_av_overview_instance", x => new { x.user_id, x.report_instance_id });
+                    table.ForeignKey(
+                        name: "FK_user_av_overview_instance_av_overview_instance_report_insta~",
+                        column: x => x.report_instance_id,
+                        principalTable: "av_overview_instance",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_user_av_overview_instance_user_user_id",
+                        column: x => x.user_id,
+                        principalTable: "user",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "user_distribution",
+                columns: table => new
+                {
+                    user_id = table.Column<int>(type: "integer", nullable: false),
+                    linked_user_id = table.Column<int>(type: "integer", nullable: false),
+                    created_by = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
+                    created_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    updated_by = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
+                    updated_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    version = table.Column<long>(type: "bigint", nullable: false, defaultValueSql: "0")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_user_distribution", x => new { x.user_id, x.linked_user_id });
+                    table.ForeignKey(
+                        name: "FK_user_distribution_user_linked_user_id",
+                        column: x => x.linked_user_id,
+                        principalTable: "user",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_user_distribution_user_user_id",
+                        column: x => x.user_id,
+                        principalTable: "user",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "user_report_instance",
+                columns: table => new
+                {
+                    user_id = table.Column<int>(type: "integer", nullable: false),
+                    report_instance_id = table.Column<long>(type: "bigint", nullable: false),
+                    link_status = table.Column<int>(type: "integer", nullable: false),
+                    link_sent_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    link_response = table.Column<JsonDocument>(type: "jsonb", nullable: false, defaultValueSql: "'{}'::jsonb"),
+                    text_status = table.Column<int>(type: "integer", nullable: false),
+                    text_sent_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    text_response = table.Column<JsonDocument>(type: "jsonb", nullable: false, defaultValueSql: "'{}'::jsonb"),
+                    created_by = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
+                    created_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    updated_by = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
+                    updated_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    version = table.Column<long>(type: "bigint", nullable: false, defaultValueSql: "0")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_user_report_instance", x => new { x.user_id, x.report_instance_id });
+                    table.ForeignKey(
+                        name: "FK_user_report_instance_report_instance_report_instance_id",
+                        column: x => x.report_instance_id,
+                        principalTable: "report_instance",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_user_report_instance_user_user_id",
+                        column: x => x.user_id,
+                        principalTable: "user",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_av_overview_instance_report_instance_id",
+                table: "user_av_overview_instance",
+                column: "report_instance_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_distribution_linked_user_id",
+                table: "user_distribution",
+                column: "linked_user_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_report_instance_report_instance_id",
+                table: "user_report_instance",
+                column: "report_instance_id");
+            PostUp(migrationBuilder);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            PreDown(migrationBuilder);
+            migrationBuilder.DropTable(
+                name: "user_av_overview_instance");
+
+            migrationBuilder.DropTable(
+                name: "user_distribution");
+
+            migrationBuilder.DropTable(
+                name: "user_report_instance");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "av_overview_instance_id",
+                table: "av_overview_section",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "id",
+                table: "av_overview_instance",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint")
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
+                .OldAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+            PostDown(migrationBuilder);
+        }
+    }
+}

--- a/libs/net/dal/Services/AVOverviewInstanceService.cs
+++ b/libs/net/dal/Services/AVOverviewInstanceService.cs
@@ -6,7 +6,7 @@ using TNO.Entities;
 
 namespace TNO.DAL.Services;
 
-public class AVOverviewInstanceService : BaseService<AVOverviewInstance, int>, IAVOverviewInstanceService
+public class AVOverviewInstanceService : BaseService<AVOverviewInstance, long>, IAVOverviewInstanceService
 {
     #region Variables
     #endregion
@@ -22,7 +22,7 @@ public class AVOverviewInstanceService : BaseService<AVOverviewInstance, int>, I
     #endregion
 
     #region Methods
-    public override AVOverviewInstance? FindById(int id)
+    public override AVOverviewInstance? FindById(long id)
     {
         return this.Context.AVOverviewInstances
             .AsNoTracking()
@@ -133,6 +133,77 @@ public class AVOverviewInstanceService : BaseService<AVOverviewInstance, int>, I
             }
         });
         return base.Update(entity);
+    }
+
+    public IEnumerable<UserAVOverviewInstance> GetUserAVOverviewInstances(long instanceId)
+    {
+        return this.Context.UserAVOverviewInstances
+            .AsNoTracking()
+            .Include(uri => uri.User)
+            .Where(uri => uri.InstanceId == instanceId)
+            .ToArray();
+    }
+
+    public UserAVOverviewInstance Add(UserAVOverviewInstance entity)
+    {
+        this.Context.Add(entity);
+        return entity;
+    }
+
+    public UserAVOverviewInstance AddAndSave(UserAVOverviewInstance entity)
+    {
+        this.Add(entity);
+        this.CommitTransaction();
+        return entity;
+    }
+
+    public UserAVOverviewInstance Update(UserAVOverviewInstance entity)
+    {
+        this.Context.Update(entity);
+        return entity;
+    }
+
+    public UserAVOverviewInstance UpdateAndSave(UserAVOverviewInstance entity)
+    {
+        this.Update(entity);
+        this.CommitTransaction();
+        return entity;
+    }
+
+    public IEnumerable<UserAVOverviewInstance> UpdateAndSave(IEnumerable<UserAVOverviewInstance> entities)
+    {
+        var instanceIds = entities.Select(e => e.InstanceId).Distinct().ToArray();
+        var originalInstances = this.Context.UserAVOverviewInstances.Where(uri => instanceIds.Contains(uri.InstanceId)).ToArray();
+        foreach (var entity in entities)
+        {
+            var original = originalInstances.FirstOrDefault(uri => uri.UserId == entity.UserId && uri.InstanceId == entity.InstanceId);
+            if (original == null)
+            {
+                this.Context.Add(entity);
+            }
+            else
+            {
+                original.Status = entity.Status;
+                original.SentOn = entity.SentOn;
+                original.Response = entity.Response;
+                this.Context.Update(original);
+            }
+        }
+        this.CommitTransaction();
+        return entities;
+    }
+
+    public UserAVOverviewInstance Delete(UserAVOverviewInstance entity)
+    {
+        this.Context.Remove(entity);
+        return entity;
+    }
+
+    public UserAVOverviewInstance DeleteAndSave(UserAVOverviewInstance entity)
+    {
+        this.Delete(entity);
+        this.CommitTransaction();
+        return entity;
     }
     #endregion
 }

--- a/libs/net/dal/Services/Interfaces/IAVOverviewInstanceService.cs
+++ b/libs/net/dal/Services/Interfaces/IAVOverviewInstanceService.cs
@@ -2,7 +2,7 @@ using TNO.Entities;
 
 namespace TNO.DAL.Services;
 
-public interface IAVOverviewInstanceService : IBaseService<AVOverviewInstance, int>
+public interface IAVOverviewInstanceService : IBaseService<AVOverviewInstance, long>
 {
     /// <summary>
     /// Return the first evening overview instance for the specified date.
@@ -16,4 +16,13 @@ public interface IAVOverviewInstanceService : IBaseService<AVOverviewInstance, i
     /// </summary>
     /// <returns></returns>
     AVOverviewInstance? FindLatest();
+
+    IEnumerable<UserAVOverviewInstance> GetUserAVOverviewInstances(long instanceId);
+    UserAVOverviewInstance Add(UserAVOverviewInstance entity);
+    UserAVOverviewInstance AddAndSave(UserAVOverviewInstance entity);
+    UserAVOverviewInstance Update(UserAVOverviewInstance entity);
+    UserAVOverviewInstance UpdateAndSave(UserAVOverviewInstance entity);
+    IEnumerable<UserAVOverviewInstance> UpdateAndSave(IEnumerable<UserAVOverviewInstance> entities);
+    UserAVOverviewInstance Delete(UserAVOverviewInstance entity);
+    UserAVOverviewInstance DeleteAndSave(UserAVOverviewInstance entity);
 }

--- a/libs/net/dal/Services/Interfaces/IReportInstanceService.cs
+++ b/libs/net/dal/Services/Interfaces/IReportInstanceService.cs
@@ -44,5 +44,13 @@ public interface IReportInstanceService : IBaseService<ReportInstance, long>
     /// <param name="updateChildren"></param>
     /// <returns></returns>
     ReportInstance UpdateAndSave(ReportInstance entity, bool updateChildren = false);
-    
+
+    IEnumerable<UserReportInstance> GetUserReportInstances(long instanceId);
+    UserReportInstance Add(UserReportInstance entity);
+    UserReportInstance AddAndSave(UserReportInstance entity);
+    UserReportInstance Update(UserReportInstance entity);
+    UserReportInstance UpdateAndSave(UserReportInstance entity);
+    IEnumerable<UserReportInstance> UpdateAndSave(IEnumerable<UserReportInstance> entities);
+    UserReportInstance Delete(UserReportInstance entity);
+    UserReportInstance DeleteAndSave(UserReportInstance entity);
 }

--- a/libs/net/dal/Services/Interfaces/IUserService.cs
+++ b/libs/net/dal/Services/Interfaces/IUserService.cs
@@ -19,4 +19,6 @@ public interface IUserService : IBaseService<User, int>
     IEnumerable<User> FindByEmail(string email);
     IEnumerable<User> FindByRoles(IEnumerable<string> roles);
     User? TransferAccount(API.Areas.Admin.Models.User.TransferAccountModel account);
+
+    IEnumerable<User> GetDistributionList(int userId);
 }

--- a/libs/net/dal/Services/ReportInstanceService.cs
+++ b/libs/net/dal/Services/ReportInstanceService.cs
@@ -318,5 +318,81 @@ public class ReportInstanceService : BaseService<ReportInstance, long>, IReportI
         this.CommitTransaction();
         return report;
     }
+
+
+    public IEnumerable<UserReportInstance> GetUserReportInstances(long instanceId)
+    {
+        return this.Context.UserReportInstances
+            .AsNoTracking()
+            .Include(uri => uri.User)
+            .Where(uri => uri.InstanceId == instanceId)
+            .ToArray();
+    }
+
+    public UserReportInstance Add(UserReportInstance entity)
+    {
+        this.Context.Add(entity);
+        return entity;
+    }
+
+
+    public UserReportInstance AddAndSave(UserReportInstance entity)
+    {
+        this.Add(entity);
+        this.CommitTransaction();
+        return entity;
+    }
+
+    public UserReportInstance Update(UserReportInstance entity)
+    {
+        this.Context.Update(entity);
+        return entity;
+    }
+
+    public UserReportInstance UpdateAndSave(UserReportInstance entity)
+    {
+        this.Update(entity);
+        this.CommitTransaction();
+        return entity;
+    }
+
+    public IEnumerable<UserReportInstance> UpdateAndSave(IEnumerable<UserReportInstance> entities)
+    {
+        var instanceIds = entities.Select(e => e.InstanceId).Distinct().ToArray();
+        var originalInstances = this.Context.UserReportInstances.Where(uri => instanceIds.Contains(uri.InstanceId)).ToArray();
+        foreach (var entity in entities)
+        {
+            var original = originalInstances.FirstOrDefault(uri => uri.UserId == entity.UserId && uri.InstanceId == entity.InstanceId);
+            if (original == null)
+            {
+                this.Context.Add(entity);
+            }
+            else
+            {
+                original.LinkStatus = entity.LinkStatus;
+                original.LinkSentOn = entity.LinkSentOn;
+                original.LinkResponse = entity.LinkResponse;
+                original.TextStatus = entity.TextStatus;
+                original.TextSentOn = entity.TextSentOn;
+                original.TextResponse = entity.TextResponse;
+                this.Context.Update(original);
+            }
+        }
+        this.CommitTransaction();
+        return entities;
+    }
+
+    public UserReportInstance Delete(UserReportInstance entity)
+    {
+        this.Context.Remove(entity);
+        return entity;
+    }
+
+    public UserReportInstance DeleteAndSave(UserReportInstance entity)
+    {
+        this.Delete(entity);
+        this.CommitTransaction();
+        return entity;
+    }
     #endregion
 }

--- a/libs/net/dal/Services/UserService.cs
+++ b/libs/net/dal/Services/UserService.cs
@@ -498,5 +498,18 @@ public class UserService : BaseService<User, int>, IUserService
 
         return user;
     }
+
+    /// <summary>
+    /// Get all the users in the specified distribution list.
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <returns></returns>
+    public IEnumerable<User> GetDistributionList(int userId)
+    {
+        return (from ud in this.Context.UserDistributions
+                join u in this.Context.Users on ud.LinkedUserId equals u.Id
+                where ud.UserId == userId
+                select u).ToArray();
+    }
     #endregion
 }

--- a/libs/net/dal/TNOContext.cs
+++ b/libs/net/dal/TNOContext.cs
@@ -80,6 +80,8 @@ public class TNOContext : DbContext
     public DbSet<UserMediaType> UserMediaTypes => Set<UserMediaType>();
 
     public DbSet<UserColleague> UserColleagues => Set<UserColleague>();
+
+    public DbSet<UserDistribution> UserDistributions => Set<UserDistribution>();
     #endregion
 
     #region Reports
@@ -95,6 +97,7 @@ public class TNOContext : DbContext
     public DbSet<ReportInstance> ReportInstances => Set<ReportInstance>();
     public DbSet<ReportInstanceContent> ReportInstanceContents => Set<ReportInstanceContent>();
     public DbSet<UserReport> UserReports => Set<UserReport>();
+    public DbSet<UserReportInstance> UserReportInstances => Set<UserReportInstance>();
 
     public DbSet<AVOverviewSection> AVOverviewSections => Set<AVOverviewSection>();
     public DbSet<AVOverviewSectionItem> AVOverviewSectionItems => Set<AVOverviewSectionItem>();
@@ -103,6 +106,7 @@ public class TNOContext : DbContext
     public DbSet<AVOverviewTemplateSection> AVOverviewTemplateSections => Set<AVOverviewTemplateSection>();
     public DbSet<AVOverviewTemplateSectionItem> AVOverviewTemplateSectionItems => Set<AVOverviewTemplateSectionItem>();
     public DbSet<UserAVOverview> UserAVOverviews => Set<UserAVOverview>();
+    public DbSet<UserAVOverviewInstance> UserAVOverviewInstances => Set<UserAVOverviewInstance>();
 
     public DbSet<EventSchedule> EventSchedules => Set<EventSchedule>();
     #endregion

--- a/libs/net/entities/AVOverviewInstance.cs
+++ b/libs/net/entities/AVOverviewInstance.cs
@@ -16,7 +16,7 @@ public class AVOverviewInstance : AuditColumns
     /// </summary>
     [Key]
     [Column("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     /// <summary>
     /// get/set - The type of template.
@@ -50,6 +50,11 @@ public class AVOverviewInstance : AuditColumns
     /// get - A collection of sections in this overview instance.
     /// </summary>
     public List<AVOverviewSection> Sections { get; } = new List<AVOverviewSection>();
+
+    /// <summary>
+    /// get - Collection of user report instance, used to identify who it was sent to.
+    /// </summary>
+    public virtual List<UserAVOverviewInstance> UserInstances { get; } = new List<UserAVOverviewInstance>();
     #endregion
 
     #region Constructors

--- a/libs/net/entities/AVOverviewSection.cs
+++ b/libs/net/entities/AVOverviewSection.cs
@@ -33,7 +33,7 @@ public class AVOverviewSection : AuditColumns
     /// get/set - The foreign key to the overview instance.
     /// </summary>
     [Column("av_overview_instance_id")]
-    public int InstanceId { get; set; }
+    public long InstanceId { get; set; }
 
     /// <summary>
     /// get/set - The evening instance.
@@ -115,7 +115,7 @@ public class AVOverviewSection : AuditColumns
     /// <param name="instanceId"></param>
     /// <param name="otherSource"></param>
     /// <param name="startTime"></param>
-    public AVOverviewSection(string name, int instanceId, string otherSource, string startTime)
+    public AVOverviewSection(string name, long instanceId, string otherSource, string startTime)
     {
         this.Name = name;
         this.InstanceId = instanceId;
@@ -170,7 +170,7 @@ public class AVOverviewSection : AuditColumns
     /// <param name="source"></param>
     /// <param name="otherSource"></param>
     /// <param name="startTime"></param>
-    public AVOverviewSection(string name, int instanceId, int sourceId, string otherSource, string startTime)
+    public AVOverviewSection(string name, long instanceId, int sourceId, string otherSource, string startTime)
     {
         this.Name = name;
         this.InstanceId = instanceId;
@@ -188,7 +188,7 @@ public class AVOverviewSection : AuditColumns
     /// <param name="otherSource"></param>
     /// <param name="seriesId"></param>
     /// <param name="startTime"></param>
-    public AVOverviewSection(string name, int instanceId, int sourceId, string otherSource, int seriesId, string startTime)
+    public AVOverviewSection(string name, long instanceId, int sourceId, string otherSource, int seriesId, string startTime)
     {
         this.Name = name;
         this.InstanceId = instanceId;
@@ -225,7 +225,7 @@ public class AVOverviewSection : AuditColumns
     /// <param name="name"></param>
     /// <param name="instanceId"></param>
     /// <param name="section"></param>
-    public AVOverviewSection(string name, int instanceId, AVOverviewTemplateSection section)
+    public AVOverviewSection(string name, long instanceId, AVOverviewTemplateSection section)
     {
         this.Name = name;
         this.InstanceId = instanceId;

--- a/libs/net/entities/ReportInstance.cs
+++ b/libs/net/entities/ReportInstance.cs
@@ -87,6 +87,11 @@ public class ReportInstance : AuditColumns
     /// get - Collection of content associated with this report instance.
     /// </summary>
     public virtual List<Content> Content { get; } = new List<Content>();
+
+    /// <summary>
+    /// get - Collection of user report instance, used to identify who it was sent to.
+    /// </summary>
+    public virtual List<UserReportInstance> UserInstances { get; } = new List<UserReportInstance>();
     #endregion
 
     #region Constructors

--- a/libs/net/entities/User.cs
+++ b/libs/net/entities/User.cs
@@ -263,6 +263,11 @@ public class User : AuditColumns
     /// get - List of content notifications this user is subscriber to.
     /// </summary>
     public virtual List<UserContentNotification> ContentNotifications { get; } = new List<UserContentNotification>();
+
+    /// <summary>
+    /// get - A collection of users linked to this user.
+    /// </summary>
+    public virtual List<UserDistribution> Distribution { get; } = new List<UserDistribution>();
     #endregion
 
     #region Constructors

--- a/libs/net/entities/UserAVOverviewInstance.cs
+++ b/libs/net/entities/UserAVOverviewInstance.cs
@@ -1,0 +1,102 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json;
+
+namespace TNO.Entities;
+
+/// <summary>
+/// UserAVOverviewInstance class, provides a model to link users with their report instances to track email status.
+/// </summary>
+[Table("user_av_overview_instance")]
+public class UserAVOverviewInstance : AuditColumns
+{
+    #region Properties
+    /// <summary>
+    /// get/set - Primary key and foreign key to the user.
+    /// </summary>
+    [Column("user_id")]
+    public int UserId { get; set; }
+
+    /// <summary>
+    /// get/set - The user who is linked to the report.
+    /// </summary>
+    public User? User { get; set; }
+
+    /// <summary>
+    /// get/set - Primary key and foreign key to the report.
+    /// </summary>
+    [Column("report_instance_id")]
+    public long InstanceId { get; set; }
+
+    /// <summary>
+    /// get/set - the report linked to the user.
+    /// </summary>
+    public AVOverviewInstance? Instance { get; set; }
+
+    /// <summary>
+    /// get/set - The date and time the report was sent on (emailed out).
+    /// </summary>
+    [Column("sent_on")]
+    public DateTime? SentOn { get; set; }
+
+    /// <summary>
+    /// get/set - The status of this report.
+    /// </summary>
+    [Column("status")]
+    public ReportStatus Status { get; set; }
+
+    /// <summary>
+    /// get/set - Response from CHES.
+    /// </summary>
+    [Column("response")]
+    public JsonDocument Response { get; set; } = JsonDocument.Parse("{}");
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    /// Creates a new instance of a UserAVOverviewInstance object, initializes with specified parameters.
+    /// </summary>
+    /// <param name="user"></param>
+    /// <param name="instance"></param>
+    /// <param name="sentOn"></param>
+    /// <param name="status"></param>
+    /// <param name="response"></param>
+    public UserAVOverviewInstance(User user, AVOverviewInstance instance, DateTime? sentOn, ReportStatus status, JsonDocument response)
+    {
+        this.User = user ?? throw new ArgumentNullException(nameof(user));
+        this.UserId = user.Id;
+        this.Instance = instance ?? throw new ArgumentNullException(nameof(instance));
+        this.InstanceId = instance.Id;
+        this.SentOn = sentOn;
+        this.Status = status;
+        this.Response = response ?? throw new ArgumentNullException(nameof(response));
+    }
+
+    /// <summary>
+    /// Creates a new instance of a UserAVOverviewInstance object, initializes with specified parameters.
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <param name="instanceId"></param>
+    /// <param name="sentOn"></param>
+    /// <param name="status"></param>
+    /// <param name="response"></param>
+    public UserAVOverviewInstance(int userId, long instanceId, DateTime? sentOn, ReportStatus status, JsonDocument response)
+    {
+        this.UserId = userId;
+        this.InstanceId = instanceId;
+        this.SentOn = sentOn;
+        this.Status = status;
+        this.Response = response ?? throw new ArgumentNullException(nameof(response));
+    }
+    #endregion
+
+    #region Methods
+    public bool Equals(UserAVOverviewInstance? other)
+    {
+        if (other == null) return false;
+        return this.UserId == other.UserId && this.InstanceId == other.InstanceId;
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as UserAVOverviewInstance);
+    public override int GetHashCode() => (this.UserId, this.InstanceId).GetHashCode();
+    #endregion
+}

--- a/libs/net/entities/UserDistribution.cs
+++ b/libs/net/entities/UserDistribution.cs
@@ -1,0 +1,71 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TNO.Entities;
+
+/// <summary>
+/// UserDistribution class, provides a model to link users to users for distribution lists.
+/// </summary>
+[Table("user_distribution")]
+public class UserDistribution : AuditColumns
+{
+    #region Properties
+    /// <summary>
+    /// get/set - Primary key and foreign key to the user.
+    /// </summary>
+    [Column("user_id")]
+    public int UserId { get; set; }
+
+    /// <summary>
+    /// get/set - The user who is linked to the report.
+    /// </summary>
+    public User? User { get; set; }
+
+    /// <summary>
+    /// get/set - Primary key and foreign key to the report.
+    /// </summary>
+    [Column("linked_user_id")]
+    public int LinkedUserId { get; set; }
+
+    /// <summary>
+    /// get/set - the linked user.
+    /// </summary>
+    public User? LinkedUser { get; set; }
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    /// Creates a new instance of a UserReport object, initializes with specified parameters.
+    /// </summary>
+    /// <param name="user"></param>
+    /// <param name="linkedUser"></param>
+    public UserDistribution(User user, User linkedUser)
+    {
+        this.User = user ?? throw new ArgumentNullException(nameof(user));
+        this.UserId = user.Id;
+        this.LinkedUser = linkedUser ?? throw new ArgumentNullException(nameof(linkedUser));
+        this.LinkedUserId = linkedUser.Id;
+    }
+
+    /// <summary>
+    /// Creates a new instance of a UserReport object, initializes with specified parameters.
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <param name="linkedUserId"></param>
+    public UserDistribution(int userId, int linkedUserId)
+    {
+        this.UserId = userId;
+        this.LinkedUserId = linkedUserId;
+    }
+    #endregion
+
+    #region Methods
+    public bool Equals(UserDistribution? other)
+    {
+        if (other == null) return false;
+        return this.UserId == other.UserId && this.LinkedUserId == other.LinkedUserId;
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as UserDistribution);
+    public override int GetHashCode() => (this.UserId, this.LinkedUserId).GetHashCode();
+    #endregion
+}

--- a/libs/net/entities/UserReportInstance.cs
+++ b/libs/net/entities/UserReportInstance.cs
@@ -1,0 +1,108 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json;
+
+namespace TNO.Entities;
+
+/// <summary>
+/// UserReport class, provides a model to link users with their report instances to track email status.
+/// </summary>
+[Table("user_report_instance")]
+public class UserReportInstance : AuditColumns
+{
+    #region Properties
+    /// <summary>
+    /// get/set - Primary key and foreign key to the user.
+    /// </summary>
+    [Column("user_id")]
+    public int UserId { get; set; }
+
+    /// <summary>
+    /// get/set - The user who is linked to the report.
+    /// </summary>
+    public User? User { get; set; }
+
+    /// <summary>
+    /// get/set - Primary key and foreign key to the report.
+    /// </summary>
+    [Column("report_instance_id")]
+    public long InstanceId { get; set; }
+
+    /// <summary>
+    /// get/set - the report linked to the user.
+    /// </summary>
+    public ReportInstance? Instance { get; set; }
+
+    /// <summary>
+    /// get/set - The status of this report.
+    /// </summary>
+    [Column("link_status")]
+    public ReportStatus LinkStatus { get; set; }
+
+    /// <summary>
+    /// get/set - The date and time the report was sent on (emailed out).
+    /// </summary>
+    [Column("link_sent_on")]
+    public DateTime? LinkSentOn { get; set; }
+
+    /// <summary>
+    /// get/set - Response from CHES.
+    /// </summary>
+    [Column("link_response")]
+    public JsonDocument LinkResponse { get; set; } = JsonDocument.Parse("{}");
+
+    /// <summary>
+    /// get/set - The status of this report.
+    /// </summary>
+    [Column("text_status")]
+    public ReportStatus TextStatus { get; set; }
+
+    /// <summary>
+    /// get/set - The date and time the report was sent on (emailed out).
+    /// </summary>
+    [Column("text_sent_on")]
+    public DateTime? TextSentOn { get; set; }
+
+    /// <summary>
+    /// get/set - Response from CHES.
+    /// </summary>
+    [Column("text_response")]
+    public JsonDocument TextResponse { get; set; } = JsonDocument.Parse("{}");
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    /// Creates a new instance of a UserReportInstance object, initializes with specified parameters.
+    /// </summary>
+    /// <param name="user"></param>
+    /// <param name="instance"></param>
+    public UserReportInstance(User user, ReportInstance instance)
+    {
+        this.User = user ?? throw new ArgumentNullException(nameof(user));
+        this.UserId = user.Id;
+        this.Instance = instance ?? throw new ArgumentNullException(nameof(instance));
+        this.InstanceId = instance.Id;
+    }
+
+    /// <summary>
+    /// Creates a new instance of a UserReportInstance object, initializes with specified parameters.
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <param name="instanceId"></param>
+    public UserReportInstance(int userId, long instanceId)
+    {
+        this.UserId = userId;
+        this.InstanceId = instanceId;
+    }
+    #endregion
+
+    #region Methods
+    public bool Equals(UserReportInstance? other)
+    {
+        if (other == null) return false;
+        return this.UserId == other.UserId && this.InstanceId == other.InstanceId;
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as UserReport);
+    public override int GetHashCode() => (this.UserId, this.InstanceId).GetHashCode();
+    #endregion
+}

--- a/libs/net/models/Areas/Editor/Models/AVOverview/AVOverviewInstanceModel.cs
+++ b/libs/net/models/Areas/Editor/Models/AVOverview/AVOverviewInstanceModel.cs
@@ -9,7 +9,7 @@ public class AVOverviewInstanceModel : AuditColumnsModel
     /// <summary>
     /// get/set - Primary key.
     /// </summary>
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     // <summary>
     // get/set - The template type.

--- a/libs/net/models/Areas/Editor/Models/AVOverview/AvOverviewSectionModel.cs
+++ b/libs/net/models/Areas/Editor/Models/AVOverview/AvOverviewSectionModel.cs
@@ -21,7 +21,7 @@ public class AVOverviewSectionModel : AuditColumnsModel
     /// <summary>
     /// get/set - Foreign key to the instance.
     /// </summary>
-    public int InstanceId { get; set; }
+    public long InstanceId { get; set; }
 
     /// <summary>
     /// get/set - The source reference.

--- a/libs/net/models/Areas/Services/Models/AVOverview/AVOverviewInstanceModel.cs
+++ b/libs/net/models/Areas/Services/Models/AVOverview/AVOverviewInstanceModel.cs
@@ -9,7 +9,7 @@ public class AVOverviewInstanceModel : AuditColumnsModel
     /// <summary>
     /// get/set - Primary key.
     /// </summary>
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     // <summary>
     // get/set - The template type.

--- a/libs/net/models/Areas/Services/Models/AVOverview/AvOverviewSectionModel.cs
+++ b/libs/net/models/Areas/Services/Models/AVOverview/AvOverviewSectionModel.cs
@@ -21,7 +21,7 @@ public class AVOverviewSectionModel : AuditColumnsModel
     /// <summary>
     /// get/set - Foreign key to the instance.
     /// </summary>
-    public int InstanceId { get; set; }
+    public long InstanceId { get; set; }
 
     /// <summary>
     /// get/set - The source reference.

--- a/libs/net/models/Areas/Services/Models/AVOverview/UserAVOverviewInstanceModel.cs
+++ b/libs/net/models/Areas/Services/Models/AVOverview/UserAVOverviewInstanceModel.cs
@@ -1,0 +1,101 @@
+using System.Text.Json;
+using TNO.API.Models;
+
+namespace TNO.API.Areas.Services.Models.AVOverview;
+
+/// <summary>
+/// UserAVOverviewInstanceModel class, provides a model that represents an user report instance.
+/// </summary>
+public class UserAVOverviewInstanceModel : AuditColumnsModel
+{
+    #region Properties
+    /// <summary>
+    /// get/set - Foreign key to the report instance.
+    /// </summary>
+    public long InstanceId { get; set; }
+
+    /// <summary>
+    /// get/set - Foreign key to the owner of the instance.
+    /// </summary>
+    public int UserId { get; set; }
+
+    /// <summary>
+    /// get/set - user's email.
+    /// </summary>
+    public string Email { get; set; } = "";
+
+    /// <summary>
+    /// get/set - User's preferred email.
+    /// </summary>
+    public string PreferredEmail { get; set; } = "";
+
+    /// <summary>
+    /// get/set - The date and time the report was sent on.
+    /// </summary>
+    public DateTime? SentOn { get; set; }
+
+    /// <summary>
+    /// get/set - The report status.
+    /// </summary>
+    public Entities.ReportStatus Status { get; set; }
+
+    /// <summary>
+    /// get/set - CHES response containing keys to find the status of a report.
+    /// </summary>
+    public JsonDocument Response { get; set; } = JsonDocument.Parse("{}");
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    /// Creates a new instance of an UserAVOverviewInstanceModel.
+    /// </summary>
+    public UserAVOverviewInstanceModel() { }
+
+    /// <summary>
+    /// Creates a new instance of an UserAVOverviewInstanceModel, initializes with specified parameter.
+    /// </summary>
+    /// <param name="entity"></param>
+    public UserAVOverviewInstanceModel(Entities.UserAVOverviewInstance entity) : base(entity)
+    {
+        this.UserId = entity.UserId;
+        this.InstanceId = entity.InstanceId;
+        this.SentOn = entity.SentOn;
+        this.Status = entity.Status;
+        this.Response = entity.Response;
+        this.Email = entity.User?.Email ?? "";
+        this.PreferredEmail = entity.User?.PreferredEmail ?? "";
+    }
+
+    /// <summary>
+    /// Creates a new instance of an UserAVOverviewInstanceModel, initializes with specified parameter.
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <param name="instanceId"></param>
+    /// <param name="sentOn"></param>
+    /// <param name="status"></param>
+    /// <param name="response"></param>
+    public UserAVOverviewInstanceModel(int userId, long instanceId, DateTime? sentOn, Entities.ReportStatus status, JsonDocument response)
+    {
+        this.UserId = userId;
+        this.InstanceId = instanceId;
+        this.SentOn = sentOn;
+        this.Status = status;
+        this.Response = response;
+    }
+    #endregion
+
+    #region Methods
+    /// <summary>
+    /// Explicit conversion to entity.
+    /// </summary>
+    /// <param name="model"></param>
+    public static explicit operator Entities.UserAVOverviewInstance(UserAVOverviewInstanceModel model)
+    {
+        var entity = new Entities.UserAVOverviewInstance(model.UserId, model.InstanceId, model.SentOn, model.Status, model.Response)
+        {
+            Version = model.Version ?? 0
+        };
+        return entity;
+    }
+    #endregion
+}

--- a/libs/net/models/Areas/Services/Models/AVOverview/UserModel.cs
+++ b/libs/net/models/Areas/Services/Models/AVOverview/UserModel.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using TNO.Core.Extensions;
 
 namespace TNO.API.Areas.Services.Models.AVOverview;
 
@@ -98,19 +97,10 @@ public class UserModel
     /// Get the preferred email if it has been set.
     /// </summary>
     /// <returns></returns>
-    public string[] GetEmails()
+    public string GetEmail()
     {
-        if (this.AccountType == Entities.UserAccountType.Distribution)
-        {
-            var addresses = this.Preferences.GetElementValue<API.Models.UserEmailModel[]?>(".addresses");
-            if (addresses != null) return addresses.Select(a => a.Email).ToArray();
-            return Array.Empty<string>();
-        }
-        else
-        {
-            var email = String.IsNullOrWhiteSpace(this.PreferredEmail) ? this.Email : this.PreferredEmail;
-            return new string[] { email };
-        }
+        if (this.AccountType == Entities.UserAccountType.Distribution) throw new InvalidOperationException("Unable to get email for distribution lists");
+        return String.IsNullOrWhiteSpace(this.PreferredEmail) ? this.Email : this.PreferredEmail;
     }
     #endregion
 }

--- a/libs/net/models/Areas/Services/Models/ReportInstance/UserReportInstanceModel.cs
+++ b/libs/net/models/Areas/Services/Models/ReportInstance/UserReportInstanceModel.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using TNO.API.Models;
+
+namespace TNO.API.Areas.Services.Models.ReportInstance;
+
+/// <summary>
+/// UserReportInstanceModel class, provides a model that represents an user report instance.
+/// </summary>
+public class UserReportInstanceModel : AuditColumnsModel
+{
+    #region Properties
+    /// <summary>
+    /// get/set - Foreign key to the report instance.
+    /// </summary>
+    public long InstanceId { get; set; }
+
+    /// <summary>
+    /// get/set - Foreign key to the owner of the instance.
+    /// </summary>
+    public int UserId { get; set; }
+
+    /// <summary>
+    /// get/set - user's email.
+    /// </summary>
+    public string Email { get; set; } = "";
+
+    /// <summary>
+    /// get/set - User's preferred email.
+    /// </summary>
+    public string PreferredEmail { get; set; } = "";
+
+    /// <summary>
+    /// get/set - The date and time the report was sent on.
+    /// </summary>
+    public DateTime? LinkSentOn { get; set; }
+
+    /// <summary>
+    /// get/set - The report status.
+    /// </summary>
+    public Entities.ReportStatus LinkStatus { get; set; }
+
+    /// <summary>
+    /// get/set - CHES response containing keys to find the status of a report.
+    /// </summary>
+    public JsonDocument LinkResponse { get; set; } = JsonDocument.Parse("{}");
+
+    /// <summary>
+    /// get/set - The date and time the report was sent on.
+    /// </summary>
+    public DateTime? TextSentOn { get; set; }
+
+    /// <summary>
+    /// get/set - The report status.
+    /// </summary>
+    public Entities.ReportStatus TextStatus { get; set; }
+
+    /// <summary>
+    /// get/set - CHES response containing keys to find the status of a report.
+    /// </summary>
+    public JsonDocument TextResponse { get; set; } = JsonDocument.Parse("{}");
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    /// Creates a new instance of an UserReportInstanceModel.
+    /// </summary>
+    public UserReportInstanceModel() { }
+
+    /// <summary>
+    /// Creates a new instance of an UserReportInstanceModel, initializes with specified parameter.
+    /// </summary>
+    /// <param name="entity"></param>
+    public UserReportInstanceModel(Entities.UserReportInstance entity) : base(entity)
+    {
+        this.UserId = entity.UserId;
+        this.InstanceId = entity.InstanceId;
+        this.LinkSentOn = entity.LinkSentOn;
+        this.LinkStatus = entity.LinkStatus;
+        this.LinkResponse = entity.LinkResponse;
+        this.TextSentOn = entity.TextSentOn;
+        this.TextStatus = entity.TextStatus;
+        this.TextResponse = entity.TextResponse;
+        this.Email = entity.User?.Email ?? "";
+        this.PreferredEmail = entity.User?.PreferredEmail ?? "";
+    }
+
+    /// <summary>
+    /// Creates a new instance of an UserReportInstanceModel, initializes with specified parameter.
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <param name="instanceId"></param>
+    /// <param name="sentOn"></param>
+    /// <param name="status"></param>
+    /// <param name="response"></param>
+    public UserReportInstanceModel(int userId, long instanceId)
+    {
+        this.UserId = userId;
+        this.InstanceId = instanceId;
+    }
+    #endregion
+
+    #region Methods
+    /// <summary>
+    /// Explicit conversion to entity.
+    /// </summary>
+    /// <param name="model"></param>
+    public static explicit operator Entities.UserReportInstance(UserReportInstanceModel model)
+    {
+        var entity = new Entities.UserReportInstance(model.UserId, model.InstanceId)
+        {
+            LinkStatus = model.LinkStatus,
+            LinkSentOn = model.LinkSentOn,
+            LinkResponse = model.LinkResponse,
+            TextStatus = model.TextStatus,
+            TextSentOn = model.TextSentOn,
+            TextResponse = model.TextResponse,
+            Version = model.Version ?? 0
+        };
+        return entity;
+    }
+    #endregion
+}

--- a/libs/net/models/Areas/Subscriber/Models/AVOverview/AVOverviewInstanceModel.cs
+++ b/libs/net/models/Areas/Subscriber/Models/AVOverview/AVOverviewInstanceModel.cs
@@ -9,7 +9,7 @@ public class AVOverviewInstanceModel : AuditColumnsModel
     /// <summary>
     /// get/set - Primary key.
     /// </summary>
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     // <summary>
     // get/set - The template type.

--- a/libs/net/models/Areas/Subscriber/Models/AVOverview/AvOverviewSectionModel.cs
+++ b/libs/net/models/Areas/Subscriber/Models/AVOverview/AvOverviewSectionModel.cs
@@ -21,7 +21,7 @@ public class AVOverviewSectionModel : AuditColumnsModel
     /// <summary>
     /// get/set - Foreign key to the instance.
     /// </summary>
-    public int InstanceId { get; set; }
+    public long InstanceId { get; set; }
 
     /// <summary>
     /// get/set - The source reference.

--- a/libs/net/services/Helpers/ApiService.cs
+++ b/libs/net/services/Helpers/ApiService.cs
@@ -721,11 +721,46 @@ public class ApiService : IApiService
     /// Make a request to the API and update a report instance.
     /// </summary>
     /// <param name="instance"></param>
+    /// <param name="updateContent"></param>
     /// <returns></returns>
-    public async Task<API.Areas.Services.Models.ReportInstance.ReportInstanceModel?> UpdateReportInstanceAsync(API.Areas.Services.Models.ReportInstance.ReportInstanceModel instance)
+    public async Task<API.Areas.Services.Models.ReportInstance.ReportInstanceModel?> UpdateReportInstanceAsync(API.Areas.Services.Models.ReportInstance.ReportInstanceModel instance, bool updateContent)
     {
-        var url = this.Options.ApiUrl.Append($"services/report/instances/{instance.Id}");
+        var url = this.Options.ApiUrl.Append($"services/report/instances/{instance.Id}?updateContent={updateContent}");
         return await RetryRequestAsync(async () => await this.OpenClient.PutAsync<API.Areas.Services.Models.ReportInstance.ReportInstanceModel>(url, JsonContent.Create(instance)));
+    }
+
+    /// <summary>
+    /// Get user report instance for the specified 'id'.
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    public async Task<IEnumerable<API.Areas.Services.Models.ReportInstance.UserReportInstanceModel>> GetUserReportInstancesAsync(long id)
+    {
+        var url = this.Options.ApiUrl.Append($"services/report/instances/{id}/responses");
+        return await RetryRequestAsync(async () => await this.OpenClient.GetAsync<IEnumerable<API.Areas.Services.Models.ReportInstance.UserReportInstanceModel>>(url))
+            ?? Array.Empty<API.Areas.Services.Models.ReportInstance.UserReportInstanceModel>();
+    }
+
+    /// <summary>
+    /// Add or update user report instance.
+    /// </summary>
+    /// <param name="instance"></param>
+    /// <returns></returns>
+    public async Task<API.Areas.Services.Models.ReportInstance.UserReportInstanceModel?> AddOrUpdateUserReportInstanceAsync(API.Areas.Services.Models.ReportInstance.UserReportInstanceModel instance)
+    {
+        var url = this.Options.ApiUrl.Append($"services/report/instances/response");
+        return await RetryRequestAsync(async () => await this.OpenClient.PostAsync<API.Areas.Services.Models.ReportInstance.UserReportInstanceModel>(url, JsonContent.Create(instance)));
+    }
+
+    /// <summary>
+    /// Add or update user report instances.
+    /// </summary>
+    /// <param name="instances"></param>
+    /// <returns></returns>
+    public async Task<IEnumerable<API.Areas.Services.Models.ReportInstance.UserReportInstanceModel>> AddOrUpdateUserReportInstancesAsync(IEnumerable<API.Areas.Services.Models.ReportInstance.UserReportInstanceModel> instances)
+    {
+        var url = this.Options.ApiUrl.Append($"services/report/instances/responses");
+        return await RetryRequestAsync(async () => await this.OpenClient.PostAsync<IEnumerable<API.Areas.Services.Models.ReportInstance.UserReportInstanceModel>>(url, JsonContent.Create(instances))) ?? Array.Empty<API.Areas.Services.Models.ReportInstance.UserReportInstanceModel>();
     }
     #endregion
 
@@ -739,6 +774,18 @@ public class ApiService : IApiService
     {
         var url = this.Options.ApiUrl.Append($"services/users/{id}");
         return await RetryRequestAsync(async () => await this.OpenClient.GetAsync<API.Areas.Services.Models.User.UserModel?>(url));
+    }
+
+
+    /// <summary>
+    /// Make a request to the API to fetch all the users in a distribution list for the specified 'id'.
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    public async Task<IEnumerable<API.Areas.Services.Models.User.UserModel>> GetDistributionListAsync(int id)
+    {
+        var url = this.Options.ApiUrl.Append($"services/users/{id}/distribution");
+        return await RetryRequestAsync(async () => await this.OpenClient.GetAsync<IEnumerable<API.Areas.Services.Models.User.UserModel>>(url)) ?? Array.Empty<API.Areas.Services.Models.User.UserModel>();
     }
     #endregion
 
@@ -795,7 +842,7 @@ public class ApiService : IApiService
     /// </summary>
     /// <param name="id"></param>
     /// <returns></returns>
-    public async Task<API.Areas.Services.Models.AVOverview.AVOverviewInstanceModel?> GetAVOverviewInstanceAsync(int id)
+    public async Task<API.Areas.Services.Models.AVOverview.AVOverviewInstanceModel?> GetAVOverviewInstanceAsync(long id)
     {
         var url = this.Options.ApiUrl.Append($"services/reports/av/overviews/{id}");
         return await RetryRequestAsync(async () => await this.OpenClient.GetAsync<API.Areas.Services.Models.AVOverview.AVOverviewInstanceModel?>(url));
@@ -810,6 +857,40 @@ public class ApiService : IApiService
     {
         var url = this.Options.ApiUrl.Append($"services/reports/av/overviews/{model.Id}");
         return await RetryRequestAsync(async () => await this.OpenClient.PutAsync<API.Areas.Services.Models.AVOverview.AVOverviewInstanceModel?>(url, JsonContent.Create(model)));
+    }
+
+    /// <summary>
+    /// Get user report instance for the specified 'id'.
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    public async Task<IEnumerable<API.Areas.Services.Models.AVOverview.UserAVOverviewInstanceModel>> GetUserAVOverviewInstancesAsync(long id)
+    {
+        var url = this.Options.ApiUrl.Append($"services/reports/av/overviews/{id}/responses");
+        return await RetryRequestAsync(async () => await this.OpenClient.GetAsync<IEnumerable<API.Areas.Services.Models.AVOverview.UserAVOverviewInstanceModel>>(url))
+            ?? Array.Empty<API.Areas.Services.Models.AVOverview.UserAVOverviewInstanceModel>();
+    }
+
+    /// <summary>
+    /// Add or update user report instance.
+    /// </summary>
+    /// <param name="instance"></param>
+    /// <returns></returns>
+    public async Task<API.Areas.Services.Models.AVOverview.UserAVOverviewInstanceModel?> AddOrUpdateUserAVOverviewInstanceAsync(API.Areas.Services.Models.AVOverview.UserAVOverviewInstanceModel instance)
+    {
+        var url = this.Options.ApiUrl.Append($"services/reports/av/overviews/response");
+        return await RetryRequestAsync(async () => await this.OpenClient.PostAsync<API.Areas.Services.Models.AVOverview.UserAVOverviewInstanceModel>(url, JsonContent.Create(instance)));
+    }
+
+    /// <summary>
+    /// Add or update user report instances.
+    /// </summary>
+    /// <param name="instances"></param>
+    /// <returns></returns>
+    public async Task<IEnumerable<API.Areas.Services.Models.AVOverview.UserAVOverviewInstanceModel>> AddOrUpdateUserAVOverviewInstancesAsync(IEnumerable<API.Areas.Services.Models.AVOverview.UserAVOverviewInstanceModel> instances)
+    {
+        var url = this.Options.ApiUrl.Append($"services/reports/av/overviews/responses");
+        return await RetryRequestAsync(async () => await this.OpenClient.PostAsync<IEnumerable<API.Areas.Services.Models.AVOverview.UserAVOverviewInstanceModel>>(url, JsonContent.Create(instances))) ?? Array.Empty<API.Areas.Services.Models.AVOverview.UserAVOverviewInstanceModel>();
     }
     #endregion
 

--- a/libs/net/services/Helpers/IApiService.cs
+++ b/libs/net/services/Helpers/IApiService.cs
@@ -288,6 +288,13 @@ public interface IApiService
     /// <param name="id"></param>
     /// <returns></returns>
     Task<API.Areas.Services.Models.User.UserModel?> GetUserAsync(int id);
+
+    /// <summary>
+    /// Make a request to the API to fetch all the users in a distribution list for the specified 'id'.
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    Task<IEnumerable<API.Areas.Services.Models.User.UserModel>> GetDistributionListAsync(int id);
     #endregion
 
     #region Ministers
@@ -378,8 +385,9 @@ public interface IApiService
     /// Make a request to the API and update a report instance.
     /// </summary>
     /// <param name="instance"></param>
+    /// <param name="updateContent"></param>
     /// <returns></returns>
-    Task<API.Areas.Services.Models.ReportInstance.ReportInstanceModel?> UpdateReportInstanceAsync(API.Areas.Services.Models.ReportInstance.ReportInstanceModel instance);
+    Task<API.Areas.Services.Models.ReportInstance.ReportInstanceModel?> UpdateReportInstanceAsync(API.Areas.Services.Models.ReportInstance.ReportInstanceModel instance, bool updateContent);
 
     /// <summary>
     /// Make a request to the API to clear all content from folders in this report.
@@ -387,6 +395,27 @@ public interface IApiService
     /// <param name="instance"></param>
     /// <returns></returns>
     Task<API.Areas.Services.Models.Report.ReportModel?> ClearFoldersInReport(int reportId);
+
+    /// <summary>
+    /// Get user report instance for the specified 'id'.
+    /// </summary>
+    /// <param name="instanceId"></param>
+    /// <returns></returns>
+    Task<IEnumerable<API.Areas.Services.Models.ReportInstance.UserReportInstanceModel>> GetUserReportInstancesAsync(long instanceId);
+
+    /// <summary>
+    /// Add or update user report instance.
+    /// </summary>
+    /// <param name="instance"></param>
+    /// <returns></returns>
+    Task<API.Areas.Services.Models.ReportInstance.UserReportInstanceModel?> AddOrUpdateUserReportInstanceAsync(API.Areas.Services.Models.ReportInstance.UserReportInstanceModel instance);
+
+    /// <summary>
+    /// Add or update user report instances.
+    /// </summary>
+    /// <param name="instances"></param>
+    /// <returns></returns>
+    Task<IEnumerable<API.Areas.Services.Models.ReportInstance.UserReportInstanceModel>> AddOrUpdateUserReportInstancesAsync(IEnumerable<API.Areas.Services.Models.ReportInstance.UserReportInstanceModel> instances);
     #endregion
 
     #region Event Schedules
@@ -417,7 +446,7 @@ public interface IApiService
     /// </summary>
     /// <param name="id"></param>
     /// <returns></returns>
-    Task<API.Areas.Services.Models.AVOverview.AVOverviewInstanceModel?> GetAVOverviewInstanceAsync(int id);
+    Task<API.Areas.Services.Models.AVOverview.AVOverviewInstanceModel?> GetAVOverviewInstanceAsync(long id);
 
     /// <summary>
     /// Make a request to the API to update the evening overview instance for the specified 'model'.
@@ -425,6 +454,28 @@ public interface IApiService
     /// <param name="model"></param>
     /// <returns></returns>
     Task<API.Areas.Services.Models.AVOverview.AVOverviewInstanceModel?> UpdateAVOverviewInstanceAsync(API.Areas.Services.Models.AVOverview.AVOverviewInstanceModel model);
+
+
+    /// <summary>
+    /// Get user report instance for the specified 'id'.
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    Task<IEnumerable<API.Areas.Services.Models.AVOverview.UserAVOverviewInstanceModel>> GetUserAVOverviewInstancesAsync(long id);
+
+    /// <summary>
+    /// Add or update user report instance.
+    /// </summary>
+    /// <param name="instance"></param>
+    /// <returns></returns>
+    Task<API.Areas.Services.Models.AVOverview.UserAVOverviewInstanceModel?> AddOrUpdateUserAVOverviewInstanceAsync(API.Areas.Services.Models.AVOverview.UserAVOverviewInstanceModel instance);
+
+    /// <summary>
+    /// Add or update user report instances.
+    /// </summary>
+    /// <param name="instances"></param>
+    /// <returns></returns>
+    Task<IEnumerable<API.Areas.Services.Models.AVOverview.UserAVOverviewInstanceModel>> AddOrUpdateUserAVOverviewInstancesAsync(IEnumerable<API.Areas.Services.Models.AVOverview.UserAVOverviewInstanceModel> instances);
     #endregion
 
     #region Folders

--- a/libs/net/template/Models/Reports/AvOverviewSectionModel.cs
+++ b/libs/net/template/Models/Reports/AvOverviewSectionModel.cs
@@ -14,7 +14,7 @@ public class AVOverviewSectionModel
     /// <summary>
     /// get/set - Foreign key to the instance.
     /// </summary>
-    public int InstanceId { get; set; }
+    public long InstanceId { get; set; }
 
     /// <summary>
     /// get/set - The source reference.

--- a/libs/net/tests/dal/TnoTestContext.cs
+++ b/libs/net/tests/dal/TnoTestContext.cs
@@ -155,6 +155,21 @@ public class TnoTestContext : TNOContext
             .HasConversion(
                 v => JsonDocumentToString(v),
                 v => JsonDocument.Parse(v, new JsonDocumentOptions()));
+
+        modelBuilder.Entity<Entities.UserReportInstance>().Property(p => p.LinkResponse)
+            .HasConversion(
+                v => JsonDocumentToString(v),
+                v => JsonDocument.Parse(v, new JsonDocumentOptions()));
+
+        modelBuilder.Entity<Entities.UserReportInstance>().Property(p => p.TextResponse)
+            .HasConversion(
+                v => JsonDocumentToString(v),
+                v => JsonDocument.Parse(v, new JsonDocumentOptions()));
+
+        modelBuilder.Entity<Entities.UserAVOverviewInstance>().Property(p => p.Response)
+            .HasConversion(
+                v => JsonDocumentToString(v),
+                v => JsonDocument.Parse(v, new JsonDocumentOptions()));
     }
 
     /// <summary>

--- a/services/net/reporting/Models/UserEmail.cs
+++ b/services/net/reporting/Models/UserEmail.cs
@@ -1,0 +1,57 @@
+﻿namespace TNO.Services.Reporting.Models;
+
+/// <summary>
+/// UserEmail class, provides a model to identify users to send emails to.
+/// </summary>
+public class UserEmail
+{
+    #region Properties
+    /// <summary>
+    /// get/set - Foreign key to user.  Or 0 if not a user.
+    /// </summary>
+    public int UserId { get; set; }
+
+    /// <summary>
+    /// get/set - The email address.
+    /// </summary>
+    public string To { get; set; }
+
+    /// <summary>
+    /// get/set - An array of CC to include with this email.
+    /// </summary>
+    public UserEmail[] CC { get; set; } = Array.Empty<UserEmail>();
+
+    /// <summary>
+    /// get/set - An array of BCC to include with this email.
+    /// </summary>
+    public UserEmail[] BCC { get; set; } = Array.Empty<UserEmail>();
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    /// Creates a new instance of a UserEmail.
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <param name="to"></param>
+    /// <param name="cc"></param>
+    /// <param name="bcc"></param>
+    public UserEmail(int userId, string to, UserEmail[]? cc = null, UserEmail[]? bcc = null)
+    {
+        this.UserId = userId;
+        this.To = to;
+        this.CC = cc ?? Array.Empty<UserEmail>();
+        this.BCC = bcc ?? Array.Empty<UserEmail>();
+    }
+    #endregion
+
+    #region Methods
+    public bool Equals(UserEmail? other)
+    {
+        if (other == null) return false;
+        return this.To == other.To;
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as UserEmail);
+    public override int GetHashCode() => this.To.GetHashCode();
+    #endregion
+}


### PR DESCRIPTION
The reporting service now has the ability to send emails out to individuals.  If a failure occurs it will pick up where it left off.

## Summary

- Add DB migration 1.2.0
- Updated Editor app
- Updated API
- Updated Reporting Service