### PR TITLE
TNO-2911: Fix count on Press Gallery date options

### DIFF
--- a/app/subscriber/src/features/press-gallery/utils/generateDates.ts
+++ b/app/subscriber/src/features/press-gallery/utils/generateDates.ts
@@ -5,7 +5,7 @@ export const generateDates = () => {
   const dates: any = Array.from({ length: 7 }, (_, i) => {
     const date = moment().subtract(i, 'days');
     return {
-      label: date.format('YYYY-MM-DD'),
+      label: date.format('MMMM DD - YYYY'),
       value: date.format(),
     };
   });


### PR DESCRIPTION
The issue was that the logic relied on the label of the select option as a key, when we changed the way a date was formatted in one place it broke the other. 

Here is the area the label broke:
![image](https://github.com/user-attachments/assets/cc40a662-13df-4bc7-91b2-d85d2aee1231)

