### PR TITLE
Elastic Info: default to simple-query

### DIFF
--- a/app/subscriber/src/features/search-page/components/advanced-search/components/ElasticQueryHelp.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/components/ElasticQueryHelp.tsx
@@ -9,9 +9,9 @@ export interface IElasticQueryHelpProps {
 }
 
 /** Component that displays help text for elastic search queries */
-export const ElasticQueryHelp: React.FC<IElasticQueryHelpProps> = ({ queryType }) => {
-  if (!queryType) return null;
-
+export const ElasticQueryHelp: React.FC<IElasticQueryHelpProps> = ({
+  queryType = 'simple-query-string',
+}) => {
   return (
     <styled.ElasticInfo className="elastic-info">
       <FaInfoCircle data-tooltip-id="elastic-info" className="info-icon" />


### PR DESCRIPTION
When first loading the page, you would have to click Simple Query to have the simple query info text appear, even though this is the default.

It will now load this cheat sheet by default, and update appropriately when clicking Advanced Query.