### PR TITLE
Remove count from press gallery

### DIFF
--- a/app/subscriber/src/features/press-gallery/PressGallery.tsx
+++ b/app/subscriber/src/features/press-gallery/PressGallery.tsx
@@ -187,11 +187,7 @@ export const PressGallery: React.FC = () => {
           isClearable={false}
           options={dateOptions.map((d) => {
             return {
-              label: `${d.label} ${
-                !pressGalleryFilter.dateFilter
-                  ? `(${contentByDate?.[d.label as keyof IGroupedDates]?.length ?? 0})`
-                  : ''
-              }`,
+              label: `${d.label}`,
               value: d.value,
             };
           })}
@@ -223,7 +219,7 @@ export const PressGallery: React.FC = () => {
             }
           }}
           name="date-select"
-          width={FieldSize.Medium}
+          width={FieldSize.Small}
         />
         <FaFilterCircleXmark
           className="reset"

--- a/app/subscriber/src/features/press-gallery/utils/generateDates.ts
+++ b/app/subscriber/src/features/press-gallery/utils/generateDates.ts
@@ -5,7 +5,7 @@ export const generateDates = () => {
   const dates: any = Array.from({ length: 7 }, (_, i) => {
     const date = moment().subtract(i, 'days');
     return {
-      label: date.format('MMMM DD - YYYY'),
+      label: date.format('YYYY-MM-DD'),
       value: date.format(),
     };
   });


### PR DESCRIPTION
Too much of a time sink to get the count to be accurate, removing as it is not consistent. Also reduced size of input to small, and reverted the format to its original state.

![image](https://github.com/user-attachments/assets/04322d19-fd08-4d61-84be-a298cc1395c7)
