### PR TITLE
TNO-2895 Configure landing and screen size

### DIFF
--- a/app/subscriber/src/features/landing/Landing.tsx
+++ b/app/subscriber/src/features/landing/Landing.tsx
@@ -34,10 +34,28 @@ export const Landing: React.FC = () => {
   );
   /* active content will be stored from this context in order to inject into subsequent components */
   const [activeContent, setActiveContent] = React.useState<IContentModel[]>();
+  const [isFullScreen, setIsFullScreen] = React.useState(false);
   /* keep active item in sync with url */
   React.useEffect(() => {
     if (id) setActiveItem(navbarOptions.find((item) => item.path.includes(id ?? '')));
   }, [id]);
+
+  const checkFullScreen = React.useCallback((item: INavbarOptionItem | undefined) => {
+    return (
+      item === NavbarOptions.todaysFrontPages ||
+      item === NavbarOptions.topStories ||
+      item === NavbarOptions.home ||
+      !item
+    );
+  }, []);
+
+  React.useEffect(() => {
+    if (checkFullScreen(activeItem)) {
+      setIsFullScreen(false);
+    } else {
+      setIsFullScreen(true);
+    }
+  }, [activeItem, checkFullScreen]);
 
   return (
     <styled.Landing className="main-container">
@@ -66,7 +84,7 @@ export const Landing: React.FC = () => {
                   )}
                 </>
               }
-              className="main-panel"
+              className={`main-panel ${isFullScreen ? 'full-screen' : ''}`}
               includeContentActions={!activeItem && !popout}
             >
               <div className="content">
@@ -111,7 +129,7 @@ export const Landing: React.FC = () => {
             </PageSection>
             {/* unsure of whether these items will change depending on selected item */}
             <Col className="right-panel">
-              <Show visible={activeItem !== NavbarOptions.eveningOverview && !popout}>
+              <Show visible={!isFullScreen && !popout}>
                 <Commentary />
                 <TopDomains />
               </Show>

--- a/app/subscriber/src/features/landing/styled/Landing.tsx
+++ b/app/subscriber/src/features/landing/styled/Landing.tsx
@@ -82,4 +82,8 @@ export const Landing = styled(Col)`
       overflow-x: clip;
     }
   }
+
+  .full-screen {
+    width: 98%;
+  }
 `;


### PR DESCRIPTION
Show Commentary and Top Domains only on requested pages:

- Featured Stories
- Top Stories
- Today’s front pages
- Story detail page

And handle screen size on landing in case there's no extra windows.

![image](https://github.com/user-attachments/assets/c6dc51fd-b3d1-4e7d-b717-74ab6ccf3a40)
