### PR TITLE
flex display for report instance view in subscriber

### DIFF
--- a/app/subscriber/src/features/my-reports/styled/ReportInstanceView.tsx
+++ b/app/subscriber/src/features/my-reports/styled/ReportInstanceView.tsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 
 export const ReportInstanceView = styled.div`
+  display: flex;
+  flex-direction: column;
   padding: 1rem;
 
   .preview-subject {
@@ -11,14 +13,19 @@ export const ReportInstanceView = styled.div`
   }
 
   p {
-    /* Need this to stop the paragraph from making the div wider than it should be */
-    width: 0;
-    min-width: 100%;
+    width: 100%;
   }
 
   .article {
-    /* Need this to stop the paragraph from making the div wider than it should be */
-    width: 0;
-    min-width: 100%;
+    width: 100%;
+  }
+
+  .preview-body {
+    word-wrap: break-word;
+    width: 100%;
+  }
+  img {
+    max-width: 100%;
+    height: auto;
   }
 `;


### PR DESCRIPTION
Update styles with flexbox for report instance preview, especially for mobile browser users, and handle large IMG display as well. 
This is because after the user receives the email and clicks to view it on the website, we will redirect them to the report instance view. On that page, we are missing some Flex-related feature.

Result:
![image](https://github.com/user-attachments/assets/87114d4d-9a23-4bc0-b6b9-de7714f81f19)
