### PR TITLE
[Ready] Fix scroll bug, better spacing, move alert

### DIFF
--- a/app/subscriber/src/features/login/IDPOptions.tsx
+++ b/app/subscriber/src/features/login/IDPOptions.tsx
@@ -13,10 +13,9 @@ export interface IIDPOptionsProps {
 export const IDPOptions: React.FC<IIDPOptionsProps> = ({ login, children }) => {
   const keycloak = useKeycloakWrapper();
   const authority = keycloak.instance.authServerUrl?.replace(/\/$/, '') ?? window.location.href;
-  // const isLocal =
-  //   new URL(authority).host.startsWith('localhost') ||
-  //   new URL(authority).host.startsWith('host.docker.internal');
-  const isLocal = false;
+  const isLocal =
+    new URL(authority).host.startsWith('localhost') ||
+    new URL(authority).host.startsWith('host.docker.internal');
   return (
     <Row className="containing-row">
       <div className="containing-box">

--- a/app/subscriber/src/features/login/IDPOptions.tsx
+++ b/app/subscriber/src/features/login/IDPOptions.tsx
@@ -13,9 +13,10 @@ export interface IIDPOptionsProps {
 export const IDPOptions: React.FC<IIDPOptionsProps> = ({ login, children }) => {
   const keycloak = useKeycloakWrapper();
   const authority = keycloak.instance.authServerUrl?.replace(/\/$/, '') ?? window.location.href;
-  const isLocal =
-    new URL(authority).host.startsWith('localhost') ||
-    new URL(authority).host.startsWith('host.docker.internal');
+  // const isLocal =
+  //   new URL(authority).host.startsWith('localhost') ||
+  //   new URL(authority).host.startsWith('host.docker.internal');
+  const isLocal = false;
   return (
     <Row className="containing-row">
       <div className="containing-box">

--- a/app/subscriber/src/features/login/styled/AppLogin.tsx
+++ b/app/subscriber/src/features/login/styled/AppLogin.tsx
@@ -35,7 +35,7 @@ export const AppLogin = styled(Col)`
       margin-left: auto;
       margin-right: auto;
       margin-top: 3em;
-      &:hover {
+      &:hover {v
         cursor: pointer;
       }
     }
@@ -51,7 +51,7 @@ export const AppLogin = styled(Col)`
     margin-left: auto;
     margin-right: auto;
     @media (max-width: 768px) {
-      margin-top: 5em;
+      margin-top: 0;
     }
     @media (min-width: 768px) {
       margin-top: 10em;

--- a/app/subscriber/src/features/login/styled/AppLogin.tsx
+++ b/app/subscriber/src/features/login/styled/AppLogin.tsx
@@ -2,15 +2,20 @@ import styled from 'styled-components';
 import { Col } from 'tno-core';
 
 export const AppLogin = styled(Col)`
-  height: 100dvh;
   overflow-y: auto;
   .app-logo {
-    padding-left: 2.5%;
-    padding-top: 2.5%;
+    @media (min-width: 768px) {
+      padding-top: 2.5%;
+      padding-left: 2.5%;
+    }
     width: fit-content;
     @media (max-width: 768px) {
       height: fit-content;
-      width: 25em;
+      width: 22em;
+    }
+    @media (max-width: 768px) {
+      padding: 1%;
+      margin-bottom: 1em;
     }
   }
   .login-box {
@@ -35,7 +40,7 @@ export const AppLogin = styled(Col)`
       margin-left: auto;
       margin-right: auto;
       margin-top: 3em;
-      &:hover {v
+      &:hover {
         cursor: pointer;
       }
     }
@@ -60,7 +65,12 @@ export const AppLogin = styled(Col)`
       padding: 0.75em;
       border-radius: 0.5em 0.5em 0 0;
       background-color: ${(props) => props.theme.css.darkHeaderColor};
-      font-size: 1.25em;
+      @media (max-width: 768px) {
+        font-size: 1em;
+      }
+      @media (min-width: 768px) {
+        font-size: 1.25em;
+      }
       color: ${(props) => props.theme.css.fPrimaryInvertColor};
     }
   }

--- a/app/subscriber/src/features/login/styled/UnauthenticatedHome.tsx
+++ b/app/subscriber/src/features/login/styled/UnauthenticatedHome.tsx
@@ -5,14 +5,12 @@ import { IUnauthenticatedHomeProps } from '..';
 export const UnauthenticatedHome = styled.div<IUnauthenticatedHomeProps>`
   position: relative;
   overflow-x: auto;
-  overflow-y: hidden;
   background: ${(props) => props.theme.css.bkPrimary};
   width: 100%;
   height: 100dvh;
 
   .containing-row {
     overflow-x: auto;
-    overflow-y: hidden;
     height: auto;
   }
 


### PR DESCRIPTION
You can now scroll the below page when a viewing device is too small to support all the content. This is the iPhone 5, which to my knowledge is one of the smallest screen sizes (in terms of iPhones at least) and the login page is quite functional.

![image](https://github.com/user-attachments/assets/1bf687b5-8816-4f4a-ae3b-9581755e928e)

