### PR TITLE
TNO-2940 Group, mentions and filter settings

### DIFF
--- a/app/subscriber/src/features/my-minister/MyMinister.tsx
+++ b/app/subscriber/src/features/my-minister/MyMinister.tsx
@@ -97,7 +97,7 @@ export const MyMinister: React.FC = () => {
           if (r.summary.includes(m.name) || r.body.includes(m.name)) {
             includeMention = true;
           }
-          if (includeMention && m.name !== ministerName) {
+          if (includeMention) {
             mentions.push(!!aliases ? aliases[0] : m.name);
           }
         });
@@ -151,7 +151,9 @@ export const MyMinister: React.FC = () => {
               }
             }
           }
-          setContent(contentList);
+          const ids = contentList.map(({ id }) => id);
+          const grouped = contentList.filter(({ id }, index) => !ids.includes(id, index + 1));
+          setContent(grouped);
           setUserMinisters(ministerModels);
         }
       }
@@ -173,11 +175,21 @@ export const MyMinister: React.FC = () => {
     }
     setUserMinisters(ministersList);
     let filteredContent = [...content];
-    ministersList
+    const mentionsToHide = ministersList
       .filter((m) => m.hide)
-      .forEach((m) => {
-        filteredContent = filteredContent.filter((c) => c.ministerName !== m.name);
+      .map((m) => {
+        const aliases = m.aliases.split(',');
+        return !!aliases ? aliases[0] : m.name;
       });
+    filteredContent = filteredContent.filter((c) => {
+      let count = 0;
+      mentionsToHide.forEach((h) => {
+        if (c.ministerMentions?.includes(h)) {
+          count++;
+        }
+      });
+      return count !== c.ministerMentions?.length;
+    });
     setFilteredContent(filteredContent);
   };
 
@@ -193,15 +205,17 @@ export const MyMinister: React.FC = () => {
         <span className="option">SHOW:</span>
         {userMinisters.map((m) => {
           return (
-            <Checkbox
-              key={m.id}
-              label={`${m.name} (${m.contentCount})`}
-              className="option"
-              checked={!m.hide}
-              onChange={(e) => {
-                hideGroup(m, !(e.target as HTMLInputElement).checked);
-              }}
-            />
+            <>
+              <Checkbox
+                key={m.id}
+                className="option"
+                checked={!m.hide}
+                onChange={(e) => {
+                  hideGroup(m, !(e.target as HTMLInputElement).checked);
+                }}
+              />
+              <span className="check-label">{`${m.name} (${m.contentCount})`}</span>
+            </>
           );
         })}
       </div>

--- a/app/subscriber/src/features/my-minister/styled/MyMinister.tsx
+++ b/app/subscriber/src/features/my-minister/styled/MyMinister.tsx
@@ -39,4 +39,9 @@ export const MyMinister = styled.div`
     line-height: 12px; /* 100% */
     text-transform: uppercase;
   }
+
+  .check-label {
+    margin-top: 0.35em;
+    margin-right: 1em;
+  }
 `;


### PR DESCRIPTION
This PR fixes:

TNO-2940
- Remove duplicates from results (having more than 1 minister mentioned).
- Add mentions properly, since we don't have an "owner", all ministers should be mentioned if found in content.
- Change the hide show feature to accommodate the new logic of adding mentions.

TNO-2941
- Remove the click on the label  allowing proper toggle.