### PR TITLE
Visual fix for Commentary Box

### DIFF
--- a/app/subscriber/src/features/commentary/styled/Commentary.tsx
+++ b/app/subscriber/src/features/commentary/styled/Commentary.tsx
@@ -10,4 +10,13 @@ export const Commentary = styled.div`
   .content-list {
     padding: 1em;
   }
+
+  a.headline {
+    @media (min-width: 1825px) {
+      width: 20em;
+    }
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 `;


### PR DESCRIPTION
When headlines were too long they would wrap and look out of place. This PR ensure that they are cut off with an ellipsis and do not wrap.