### PR TITLE
TNO-2965: Missing byline field 

### DIFF
--- a/app/subscriber/src/features/my-reports/components/ReportContentInlineText.tsx
+++ b/app/subscriber/src/features/my-reports/components/ReportContentInlineText.tsx
@@ -5,9 +5,13 @@ import { IReportInstanceContentForm } from '../interfaces';
 
 export interface IReportContentInlineTextProps {
   row: IReportInstanceContentForm;
+  userId: number;
 }
 
-export const ReportContentInlineText: React.FC<IReportContentInlineTextProps> = ({ row }) => {
+export const ReportContentInlineText: React.FC<IReportContentInlineTextProps> = ({
+  row,
+  userId,
+}) => {
   if (!row || !row.content) return null;
 
   let contentDetails = '';
@@ -22,7 +26,13 @@ export const ReportContentInlineText: React.FC<IReportContentInlineTextProps> = 
   } else {
     // General Content format
     contentDetails =
-      `${row.content.byline ? `${row.content.byline} | ` : ''}` +
+      `${
+        row.content.versions?.[userId]?.byline
+          ? `${row.content.versions[userId].byline ?? ''} | `
+          : row.content.byline
+          ? `${row.content.byline} | `
+          : ''
+      }` +
       `${row.content.otherSource ? `${row.content.otherSource} | ` : ''}` +
       `${row.content.page ? `P.${row.content.page} | ` : ''}` +
       `${row.content.publishedOn ? moment(row.content.publishedOn).format('DD-MMM-YYYY') : ''}`;

--- a/app/subscriber/src/features/my-reports/edit/content/ContentEditForm.tsx
+++ b/app/subscriber/src/features/my-reports/edit/content/ContentEditForm.tsx
@@ -197,7 +197,14 @@ export const ContentEditForm = React.forwardRef<HTMLDivElement | null, IContentE
         </div>
         {form && !!form.content.id && (
           <Bar className="content-bar">
-            <Col className="byline">by {form.content.byline}</Col>
+            <Col className="byline">
+              by{' '}
+              {form.content.versions?.[userId]?.byline
+                ? form.content.versions?.[userId]?.byline
+                : form.content.byline
+                ? form.content.byline
+                : ''}
+            </Col>
             <Col className="date">{formatDate(form.content.publishedOn, true)}</Col>
             <Col flex="1"></Col>
             <Col className="source">

--- a/app/subscriber/src/features/my-reports/edit/content/sort/ReportContentSectionRow.tsx
+++ b/app/subscriber/src/features/my-reports/edit/content/sort/ReportContentSectionRow.tsx
@@ -93,7 +93,7 @@ export const ReportContentSectionRow: React.FC<IReportContentSectionRowProps> = 
         </span>
       </Col>
       <Col className="story-details">
-        <ReportContentInlineText row={row} />
+        <ReportContentInlineText row={row} userId={userId} />
       </Col>
       {!disabled && showSelectSection && sectionOptions?.length && (
         <Col className="story-section">

--- a/app/subscriber/src/features/my-reports/edit/content/stories/ContentForm.tsx
+++ b/app/subscriber/src/features/my-reports/edit/content/stories/ContentForm.tsx
@@ -38,6 +38,7 @@ export const ContentForm: React.FC<IContentFormProps> = ({
   const userId = userInfo?.id ?? 0;
   const isAV = content.contentType === ContentTypeName.AudioVideo;
   const versions = content.versions?.[userId] ?? {
+    byline: content.byline,
     headline: content.headline,
     summary: '',
     body: isAV
@@ -46,6 +47,7 @@ export const ContentForm: React.FC<IContentFormProps> = ({
         : content.summary
       : content.body,
   };
+  const byline = versions.byline ?? '';
   const headline = versions.headline ?? '';
   const summary = versions.summary ?? '';
   const body =
@@ -56,6 +58,31 @@ export const ContentForm: React.FC<IContentFormProps> = ({
     <Col className={`edit-content${className ? ` ${className}` : ''}`} {...rest}>
       <Show visible={loading}>
         <Loading />
+      </Show>
+      <Show visible={show === 'all'}>
+        <TextArea
+          name={`byline`}
+          label="Byline"
+          rows={1}
+          disabled={disabled}
+          onChange={(e) => {
+            const values = {
+              ...content,
+              versions: {
+                ...content.versions,
+                [userId]: {
+                  ...content.versions?.[userId],
+                  byline: e.target.value,
+                  headline: headline,
+                  summary: summary,
+                  body: body,
+                },
+              },
+            };
+            onContentChange?.(values);
+          }}
+          value={byline}
+        />
       </Show>
       <Show visible={show === 'all'}>
         <TextArea
@@ -70,6 +97,7 @@ export const ContentForm: React.FC<IContentFormProps> = ({
                 ...content.versions,
                 [userId]: {
                   ...content.versions?.[userId],
+                  byline: byline,
                   headline: e.target.value,
                   summary: summary,
                   body: body,
@@ -95,6 +123,7 @@ export const ContentForm: React.FC<IContentFormProps> = ({
                 ...content.versions,
                 [userId]: {
                   ...content.versions?.[userId],
+                  byline: byline,
                   headline: headline,
                   summary: text,
                   body: body,

--- a/app/subscriber/src/features/my-reports/edit/content/stories/ReportContentSectionRow.tsx
+++ b/app/subscriber/src/features/my-reports/edit/content/stories/ReportContentSectionRow.tsx
@@ -90,7 +90,7 @@ export const ReportContentSectionRow: React.FC<IReportContentSectionRowProps> = 
           </span>
         </Col>
         <Col className="story-details">
-          <ReportContentInlineText row={row} />
+          <ReportContentInlineText row={row} userId={userId} />
         </Col>
         {!disabled && showSortOrder && (
           <Col className="story-sortOrder">


### PR DESCRIPTION
- Ability to edit byline in the subscriber story version:

In Subscriber, under Content > Quick Sort:
![image](https://github.com/user-attachments/assets/95dab65e-7d73-4a61-b974-53323fa93ad6)

Change byline _Yuri Kageyama_ for _Yuri Wong_ and clicked Save Story:
![image](https://github.com/user-attachments/assets/a098486f-b601-4820-a968-1b8d9dff37a6)

The version is updated for Subscriber:
![image](https://github.com/user-attachments/assets/bd344d59-f0c3-489b-a9d9-1b5a42ab5cf6)

The byline is updated in the version of the content in database. Then, the editor keeps the original byline:
![image](https://github.com/user-attachments/assets/2192979f-d34e-4ab8-af3b-1aa69cfc7dc2)
