### PR TITLE
TNO-2969: Navigation bar being cut off on smaller devices

### DIFF
--- a/app/subscriber/src/components/layout/styled/Layout.tsx
+++ b/app/subscriber/src/components/layout/styled/Layout.tsx
@@ -30,6 +30,8 @@ export const Layout = styled.div<ILayoutProps>`
 
     .nav-bar {
       grid-area: nav-bar;
+      max-height: calc(100dvh - 11.5em);
+      overflow: auto;
     }
 
     .contents-container {

--- a/app/subscriber/src/components/navbar/styled/Navbar.tsx
+++ b/app/subscriber/src/components/navbar/styled/Navbar.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import { Col } from 'tno-core';
 
 export const Navbar = styled(Col)<{ $expanded: boolean }>`
-  height: calc(100dvh); // 100% height of section
   svg:not(.expand-control) {
     height: ${(props) => (props.$expanded ? '' : '1.5em')};
     width: ${(props) => (props.$expanded ? '' : '1.5em')};

--- a/app/subscriber/src/features/landing/styled/Landing.tsx
+++ b/app/subscriber/src/features/landing/styled/Landing.tsx
@@ -65,6 +65,11 @@ export const Landing = styled(Col)`
     @media (min-width: 1000px) {
       width: 70%;
     }
+    @media (max-width: 768px) {
+      .page-section-title {
+        margin: 0.25em;
+      }
+    }
     flex-grow: 1;
     margin: 0 0 0.75rem 0.75rem;
 


### PR DESCRIPTION
Finding quite a few little responsive things that need tweaking, have some more in an upcoming PR just need to finish polishing. For now I am splitting off one of the tickets.

![image](https://github.com/user-attachments/assets/e4c27ed5-f305-4563-a9c4-22c877d6b8b3)

This sidebar will also scroll for smaller devices like the iPhone 5:
![image](https://github.com/user-attachments/assets/b0b8490a-2813-4337-8f9f-944192dbf2c8)

