### PR TITLE
TNO-2971: Press gallery input too small 

### DIFF
--- a/app/subscriber/src/components/tool-bar/ContentActionBar.tsx
+++ b/app/subscriber/src/components/tool-bar/ContentActionBar.tsx
@@ -104,7 +104,9 @@ export const ContentActionBar: React.FC<IContentActionBarProps> = ({
           <div className="check-area">
             <Row gap="0.25rem">
               <Checkbox id="select-all" checked={isSelectAllChecked} onChange={onSelectAll} />
-              <label htmlFor="select-all">SELECT ALL</label>
+              <label htmlFor="select-all" className="select-all-label">
+                SELECT ALL
+              </label>
             </Row>
           </div>
         </Row>

--- a/app/subscriber/src/components/tool-bar/styled/ContentActionBar.tsx
+++ b/app/subscriber/src/components/tool-bar/styled/ContentActionBar.tsx
@@ -37,6 +37,12 @@ export const ContentActionBar = styled(Row)`
     }
   }
 
+  @media (max-width: 320px) {
+    .select-all-label {
+      display: none;
+    }
+  }
+
   .right-side-items {
     color: ${(props) => props.theme.css.btnBkPrimary};
     @media (max-width: 768px) {

--- a/app/subscriber/src/features/landing/styled/Landing.tsx
+++ b/app/subscriber/src/features/landing/styled/Landing.tsx
@@ -67,6 +67,7 @@ export const Landing = styled(Col)`
     }
     @media (max-width: 768px) {
       .page-section-title {
+        max-width: calc(100vw - 55px);
         margin: 0.25em;
       }
     }
@@ -76,6 +77,7 @@ export const Landing = styled(Col)`
     .content {
       background-color: white;
       @media (max-width: 500px) {
+        max-width: calc(100vw - 50px);
         padding: 0.25em;
       }
       @media (min-width: 500px) {

--- a/app/subscriber/src/features/press-gallery/PressGallery.tsx
+++ b/app/subscriber/src/features/press-gallery/PressGallery.tsx
@@ -203,7 +203,7 @@ export const PressGallery: React.FC = () => {
             }
           }}
           name="date-select"
-          width={'9em'}
+          width={FieldSize.Small}
         />
         <FaFilterCircleXmark
           className="reset"


### PR DESCRIPTION
Simply change the size of the select input on the Press Gallery page, as well as some additional CSS cleanup.