### PR TITLE
TNO-2859 Fix find by date method

### DIFF
--- a/libs/net/dal/Services/AVOverviewInstanceService.cs
+++ b/libs/net/dal/Services/AVOverviewInstanceService.cs
@@ -40,7 +40,8 @@ public class AVOverviewInstanceService : BaseService<AVOverviewInstance, long>, 
     /// <returns></returns>
     public AVOverviewInstance? FindByDate(DateTime publishedOn)
     {
-        var date = new DateTime(publishedOn.Year, publishedOn.Month, publishedOn.Day, 0, 0, 0, DateTimeKind.Utc);
+        var startDate = new DateTime(publishedOn.Year, publishedOn.Month, publishedOn.Day, 0, 0, 0, DateTimeKind.Utc);
+        var endDate = new DateTime(publishedOn.Year, publishedOn.Month, publishedOn.Day, 23, 59, 59, DateTimeKind.Utc);
         return this.Context.AVOverviewInstances
             .AsNoTracking()
             .Include(i => i.Template)
@@ -48,7 +49,7 @@ public class AVOverviewInstanceService : BaseService<AVOverviewInstance, long>, 
             .Include(i => i.Sections).ThenInclude(s => s.Series)
             .Include(i => i.Sections).ThenInclude(s => s.Items).ThenInclude(i => i.Content).ThenInclude(c => c!.FileReferences)
             .OrderByDescending(r => r.PublishedOn)
-            .Where(i => i.PublishedOn == date)
+            .Where(i => i.PublishedOn >= startDate && i.PublishedOn <= endDate)
             .FirstOrDefault();
     }
 


### PR DESCRIPTION
Looks like this is a long time bug, and was causing a lot of confusion.

The find by date method was never returning data, since the date comparison was wrong never bringing the actual AV Overview, every time it was only loaded with the template data.
Since the template was loaded, the search methods were never called, bringing invalid data from previous states, showing wrong data to the user when switching between dates.

Once this is merged, I'll make some final tests in dev, but I believe, data wise it's the definitive fix.