### PR TITLE
TNO-2966: Scroll to top of page when navigating on mobile device

### DIFF
--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -11,6 +11,7 @@ import { FaCopyright } from 'react-icons/fa6';
 import { useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useApiHub, useContent, useWorkOrders } from 'store/hooks';
+import useMobile from 'store/hooks/app/useMobile';
 import { useMinisters } from 'store/hooks/subscriber/useMinisters';
 import { useProfileStore } from 'store/slices';
 import {
@@ -65,6 +66,8 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent, act
   const [, api] = useMinisters();
   const [, { transcribe, findWorkOrders }] = useWorkOrders();
   const hub = useApiHub();
+  const isMobile = useMobile();
+  const topRef = React.useRef<HTMLDivElement>(null);
 
   // flag to keep track of the bolding completion in my minister view
   const [boldingComplete, setBoldingComplete] = React.useState(false);
@@ -119,6 +122,13 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent, act
       // Ignore this failure it is handled by our global ajax requests.
     }
   }, [workOrders, transcribe, content]);
+
+  // scroll to top when navigating to new content from a mobile device
+  React.useEffect(() => {
+    if (isMobile && topRef.current) {
+      topRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [id, isMobile]);
 
   React.useEffect(() => {
     if (!ministers.length) {
@@ -280,7 +290,7 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent, act
   }, [cleanBody, cleanSummary]);
 
   return (
-    <styled.ViewContent className={`${!!popout && 'popout'}`}>
+    <styled.ViewContent className={`${!!popout && 'popout'}`} ref={topRef}>
       <div className="headline">{formattedHeadline}</div>
       <Bar className="info-bar" vanilla>
         <Show visible={!!content?.byline}>

--- a/app/subscriber/src/features/landing/Landing.tsx
+++ b/app/subscriber/src/features/landing/Landing.tsx
@@ -19,6 +19,7 @@ import { TodaysFrontPages } from 'features/todays-front-pages';
 import { TopStories } from 'features/top-stories';
 import React from 'react';
 import { useParams } from 'react-router-dom';
+import useMobile from 'store/hooks/app/useMobile';
 import { Col, IContentModel, Row, Show } from 'tno-core';
 
 import * as styled from './styled';
@@ -32,6 +33,7 @@ export const Landing: React.FC = () => {
   const [activeItem, setActiveItem] = React.useState<INavbarOptionItem | undefined>(
     NavbarOptions.home,
   );
+  const isMobile = useMobile();
   /* active content will be stored from this context in order to inject into subsequent components */
   const [activeContent, setActiveContent] = React.useState<IContentModel[]>();
   const [isFullScreen, setIsFullScreen] = React.useState(false);
@@ -48,6 +50,12 @@ export const Landing: React.FC = () => {
       !item
     );
   }, []);
+
+  React.useEffect(() => {
+    if (isMobile) {
+      window.scrollTo(0, 0);
+    }
+  }, [id]);
 
   React.useEffect(() => {
     if (checkFullScreen(activeItem)) {

--- a/app/subscriber/src/features/landing/Landing.tsx
+++ b/app/subscriber/src/features/landing/Landing.tsx
@@ -55,6 +55,8 @@ export const Landing: React.FC = () => {
     if (isMobile) {
       window.scrollTo(0, 0);
     }
+    // only want to fire when id changes (user navigates to a new section)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
 
   React.useEffect(() => {

--- a/app/subscriber/src/store/hooks/app/index.ts
+++ b/app/subscriber/src/store/hooks/app/index.ts
@@ -1,2 +1,3 @@
 export * from './useApp';
+export * from './useMobile';
 export * from './useToastError';

--- a/app/subscriber/src/store/hooks/app/useMobile.tsx
+++ b/app/subscriber/src/store/hooks/app/useMobile.tsx
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+const useMobile = (): boolean => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const userAgent = window.navigator.userAgent;
+    const mobileCheck = /iPhone|iPad|iPod|Android/i.test(userAgent);
+    setIsMobile(mobileCheck);
+  }, []);
+
+  return isMobile;
+};
+
+export default useMobile;


### PR DESCRIPTION
Previously, if you had scrolled down the page and clicked a navigation item it would save your screen position when entering the new page.

This lead to confusion for users finding content.

These changes scroll to the top after navigating on a mobile device so nothing is hidden.