### PR TITLE
TNO-2945: When  a schedule is enabled, at least one day must be selected for running

### DIFF
--- a/app/subscriber/src/features/my-reports/edit/settings/template/ReportSchedule.tsx
+++ b/app/subscriber/src/features/my-reports/edit/settings/template/ReportSchedule.tsx
@@ -22,6 +22,7 @@ export const ReportSchedule: React.FC<IReportScheduleProps> = ({ index, label })
 
   const schedule = values.events.length > index ? values.events[index] : undefined;
 
+  console.log(schedule);
   return (
     <Row gap="1rem" className="schedule" nowrap>
       <Col gap="0.25rem" className="frm-in">
@@ -44,8 +45,9 @@ export const ReportSchedule: React.FC<IReportScheduleProps> = ({ index, label })
           </p>
         </Col>
       </Col>
-      <Col className="frm-in">
+      <Col className="frm-in run-on">
         <label>Run On</label>
+        <div role="alert">{getIn(errors, `events.${index}.runOnWeekDays`)}</div>
         <FormikStringEnumCheckbox<ScheduleWeekDayName>
           label="Monday"
           name={`events.${index}.runOnWeekDays`}

--- a/app/subscriber/src/features/my-reports/edit/settings/template/ReportSchedule.tsx
+++ b/app/subscriber/src/features/my-reports/edit/settings/template/ReportSchedule.tsx
@@ -19,10 +19,8 @@ export interface IReportScheduleProps {
 
 export const ReportSchedule: React.FC<IReportScheduleProps> = ({ index, label }) => {
   const { values, setFieldValue, errors } = useReportEditContext();
-
   const schedule = values.events.length > index ? values.events[index] : undefined;
 
-  console.log(schedule);
   return (
     <Row gap="1rem" className="schedule" nowrap>
       <Col gap="0.25rem" className="frm-in">

--- a/app/subscriber/src/features/my-reports/edit/styled/ReportEditForm.tsx
+++ b/app/subscriber/src/features/my-reports/edit/styled/ReportEditForm.tsx
@@ -77,6 +77,14 @@ export const ReportEditForm = styled.div`
   }
 
   .report-edit-section {
+    div[role='alert'] {
+      color: ${(props) => props.theme.css.fRedColor};
+    }
+    .run-on {
+      p[role='alert'] {
+        display: none;
+      }
+    }
     flex: 1;
     position: relative;
 

--- a/app/subscriber/src/features/my-reports/edit/validation/ReportFormScheduleSchema.ts
+++ b/app/subscriber/src/features/my-reports/edit/validation/ReportFormScheduleSchema.ts
@@ -3,6 +3,12 @@ const regex24hour = /^(?:[01][0-9]|2[0-3]):[0-5][0-9](?::[0-5][0-9])?$/;
 export const ReportFormScheduleSchema = object().shape(
   {
     isEnabled: boolean(),
+    runOnWeekDays: string()
+      .when('isEnabled', {
+        is: true,
+        then: (schema) => schema.required('Schedule must have at least one weekday when Enabled.'),
+      })
+      .notOneOf(['NA'], 'Schedule must have at least one weekday when Enabled.'),
     startAt: string().when('isEnabled', {
       is: true,
       then: (schema) =>


### PR DESCRIPTION
Just adding some validation for reports.

Previously, you could enable a schedule, set a start time and save. Now you must select at least one day before saving.

![image](https://github.com/user-attachments/assets/a60e127d-fb17-485a-9a86-15a3b1c2ba28)
