### PR TITLE
TNO-2945: Fix validation blocker for manual reports

### DIFF
--- a/app/subscriber/src/features/my-reports/edit/settings/template/ReportSchedule.tsx
+++ b/app/subscriber/src/features/my-reports/edit/settings/template/ReportSchedule.tsx
@@ -21,6 +21,7 @@ export const ReportSchedule: React.FC<IReportScheduleProps> = ({ index, label })
   const { values, setFieldValue, errors } = useReportEditContext();
   const schedule = values.events.length > index ? values.events[index] : undefined;
 
+  console.log(schedule);
   return (
     <Row gap="1rem" className="schedule" nowrap>
       <Col gap="0.25rem" className="frm-in">

--- a/app/subscriber/src/features/my-reports/edit/settings/template/ReportSchedule.tsx
+++ b/app/subscriber/src/features/my-reports/edit/settings/template/ReportSchedule.tsx
@@ -21,7 +21,6 @@ export const ReportSchedule: React.FC<IReportScheduleProps> = ({ index, label })
   const { values, setFieldValue, errors } = useReportEditContext();
   const schedule = values.events.length > index ? values.events[index] : undefined;
 
-  console.log(schedule);
   return (
     <Row gap="1rem" className="schedule" nowrap>
       <Col gap="0.25rem" className="frm-in">

--- a/app/subscriber/src/features/my-reports/edit/validation/ReportFormScheduleSchema.ts
+++ b/app/subscriber/src/features/my-reports/edit/validation/ReportFormScheduleSchema.ts
@@ -3,6 +3,11 @@ const regex24hour = /^(?:[01][0-9]|2[0-3]):[0-5][0-9](?::[0-5][0-9])?$/;
 export const ReportFormScheduleSchema = object().shape(
   {
     isEnabled: boolean(),
+    runOnWeekDays: string().when('isEnabled', {
+      is: true,
+      then: (schema) =>
+        schema.notOneOf(['NA'], 'Schedule must have at least one weekday when Enabled.'),
+    }),
     startAt: string().when('isEnabled', {
       is: true,
       then: (schema) =>


### PR DESCRIPTION
Previously `notOneOf` fell outside of the `isEnabled` block, which in turn caused manual reports to be blocked.