### PR TITLE
TNO-2830: Common shortcut keys no longer work on the Content Form

### DIFF
--- a/app/editor/src/features/content/form/ContentActions.tsx
+++ b/app/editor/src/features/content/form/ContentActions.tsx
@@ -16,7 +16,9 @@ import {
   ValueType,
 } from 'tno-core';
 
+import { ActionNames } from './constants/actionsEnum';
 import { IContentForm } from './interfaces';
+import { StyledShortcutKey } from './styled';
 import { getDefaultCommentaryExpiryValue } from './utils';
 
 export interface IContentActionsProps {
@@ -136,14 +138,19 @@ export const ContentActions = React.forwardRef<HTMLDivElement, IContentActionsPr
 
         if (e.ctrlKey) {
           switch (e.code) {
-            case 'KeyC':
-              handleToggleAction('Commentary');
+            case 'KeyM':
+              handleToggleAction(ActionNames.Commentary);
               break;
-            case 'KeyO':
-              handleToggleAction('Top Story');
+            case 'KeyI':
+              handleToggleAction(ActionNames.TopStory);
               break;
-            case 'KeyF':
-              handleToggleAction('Featured Story');
+            case 'KeyU':
+              e.preventDefault();
+              handleToggleAction(ActionNames.FeaturedStory);
+              break;
+            case 'KeyL':
+              e.preventDefault();
+              handleToggleAction(ActionNames.NonQualifiedSubject);
               break;
             default:
               break;
@@ -163,12 +170,41 @@ export const ContentActions = React.forwardRef<HTMLDivElement, IContentActionsPr
     const inputs = options.map((a, rowIndex) => {
       const actionIndex = formActions.findIndex((ca) => ca.id === a.id);
       const found = formActions[actionIndex];
+      const labelContent = (() => {
+        if (a.name === 'Top Story') {
+          return (
+            <div>
+              Top Stor<StyledShortcutKey>i</StyledShortcutKey>es
+            </div>
+          );
+        } else if (a.name === 'Commentary') {
+          return (
+            <div>
+              Co<StyledShortcutKey>m</StyledShortcutKey>mentary
+            </div>
+          );
+        } else if (a.name === 'Featured Story') {
+          return (
+            <div>
+              Feat<StyledShortcutKey>u</StyledShortcutKey>red Stories
+            </div>
+          );
+        } else if (a.name === 'Non Qualified Subject') {
+          return (
+            <div>
+              Non Qua<StyledShortcutKey>l</StyledShortcutKey>ified Subject
+            </div>
+          );
+        } else {
+          return a.name;
+        }
+      })();
       return (
         <React.Fragment key={a.id}>
           {addRowOn?.(a, rowIndex) && <div className="forceFlexRow"></div>}
           {a.valueType === ValueType.Boolean && (
             <FormikCheckbox
-              label={a.name}
+              label={labelContent}
               name={field('value', actionIndex)}
               value="true"
               checked={found?.value === 'true'}
@@ -180,7 +216,7 @@ export const ContentActions = React.forwardRef<HTMLDivElement, IContentActionsPr
           )}
           {a.valueType !== ValueType.Boolean && (
             <Checkbox
-              label={a.name}
+              label={labelContent}
               name={field('placeholder', actionIndex)}
               value={true}
               checked={!!hidden.find((h) => h.id === a.id)?.value}

--- a/app/editor/src/features/content/form/constants/actionsEnum.ts
+++ b/app/editor/src/features/content/form/constants/actionsEnum.ts
@@ -1,0 +1,7 @@
+export enum ActionNames {
+  Commentary = 'Commentary',
+  TopStory = 'Top Story',
+  FeaturedStory = 'Featured Story',
+  NonQualifiedSubject = 'Non Qualified Subject',
+  PublishedSelectected = 'Published Selected',
+}

--- a/app/editor/src/features/content/form/styled/ContentActions.tsx
+++ b/app/editor/src/features/content/form/styled/ContentActions.tsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const StyledShortcutKey = styled.span`
+  text-decoration: underline;
+  font-weight: bold;
+`;

--- a/app/editor/src/features/content/form/styled/index.ts
+++ b/app/editor/src/features/content/form/styled/index.ts
@@ -1,3 +1,4 @@
+export * from './ContentActions';
 export * from './ContentClipForm';
 export * from './ContentForm';
 export * from './ContentLabelsForm';

--- a/app/editor/src/features/content/papers/Papers.tsx
+++ b/app/editor/src/features/content/papers/Papers.tsx
@@ -340,19 +340,27 @@ const Papers: React.FC<IPapersProps> = (props) => {
         <PaperToolbar onSearch={fetch} />
         <div className="paper-totals">
           <div>
-            <div>Top Stories:</div>
+            <div>
+              Top Stor<span className="shortcut-key">i</span>es:
+            </div>
             <div>{totals.topStories}</div>
           </div>
           <div>
-            <div>Commentary:</div>
+            <div>
+              Co<span className="shortcut-key">m</span>mentary:
+            </div>
             <div>{totals.commentary}</div>
           </div>
           <div>
-            <div>Featured Stories:</div>
+            <div>
+              Feat<span className="shortcut-key">u</span>red Stories:
+            </div>
             <div>{totals.featuredStories}</div>
           </div>
           <div>
-            <div>Published:</div>
+            <div>
+              Pu<span className="shortcut-key">b</span>lished:
+            </div>
             <div>{totals.published}</div>
           </div>
         </div>

--- a/app/editor/src/features/content/papers/components/ReportActions.tsx
+++ b/app/editor/src/features/content/papers/components/ReportActions.tsx
@@ -1,5 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { AxiosError } from 'axios';
+import { ActionNames } from 'features/content/form/constants/actionsEnum';
 import { getDefaultCommentaryExpiryValue } from 'features/content/form/utils';
 import { IContentListFilter } from 'features/content/interfaces';
 import * as React from 'react';
@@ -79,16 +80,16 @@ export const ReportActions: React.FunctionComponent<IReportActionProps> = ({
     (action: string) => {
       let actionId;
       switch (action) {
-        case 'Commentary':
+        case ActionNames.Commentary:
           actionId = commentaryActionId;
           break;
-        case 'Top Story':
+        case ActionNames.TopStory:
           actionId = topStoryActionId;
           break;
-        case 'Featured Story':
+        case ActionNames.FeaturedStory:
           actionId = featuredStoryActionId;
           break;
-        case 'Published Selected':
+        case ActionNames.PublishedSelectected:
           break;
         default:
           return;
@@ -112,17 +113,18 @@ export const ReportActions: React.FunctionComponent<IReportActionProps> = ({
       if (e.ctrlKey) {
         e.preventDefault();
         switch (e.code) {
-          case 'KeyC':
-            handleToggleAction('Commentary');
+          case 'KeyM':
+            handleToggleAction(ActionNames.Commentary);
             break;
-          case 'KeyO':
-            handleToggleAction('Top Story');
+          case 'KeyI':
+            handleToggleAction(ActionNames.TopStory);
             break;
-          case 'KeyF':
-            handleToggleAction('Featured Story');
+          case 'KeyU':
+            e.preventDefault();
+            handleToggleAction(ActionNames.FeaturedStory);
             break;
-          case 'KeyP':
-            handleToggleAction('Published Selected');
+          case 'KeyB':
+            handleToggleAction(ActionNames.PublishedSelectected);
             break;
           default:
             break;

--- a/app/editor/src/features/content/papers/styled/Papers.tsx
+++ b/app/editor/src/features/content/papers/styled/Papers.tsx
@@ -109,6 +109,10 @@ export const Papers = styled(FormPage)`
         padding: 0 0.15rem;
       }
     }
+    .shortcut-key {
+      text-decoration: underline;
+      font-weight: bold;
+    }
   }
 
   .grid-table:nth-child(2) {


### PR DESCRIPTION
### Updated Shortcut Keys

The following shortcut keys have been updated to avoid overriding common actions performed by the operating system or web browsers:

- **Featured Stories**: `Ctrl + U`  
  _(Overridden)_ Previously used by web browsers to view the source code of the current webpage.

- **Top Stories**: `Ctrl + I`

- **Commentary**: `Ctrl + M`

- **Published**: `Ctrl + B`

- **Non Qualified Subject**: `Ctrl + L`  
  _(Overridden)_ Previously used by web browsers to move to the address bar.

### Editor UI

Included bolding and underline to the letter associated with the shortcut key.

**Papers page:**
<img width="1229" alt="image" src="https://github.com/user-attachments/assets/be444dec-7180-4135-9134-a043c3d7d977">

**Contents page:**
<img width="1225" alt="image" src="https://github.com/user-attachments/assets/645f855e-ef32-4585-8d6c-b8c9a8bbd36b">