### PR TITLE
TNO-2967 Filter options implementation

### DIFF
--- a/app/subscriber/src/components/media-type-filters/FilterOptions.tsx
+++ b/app/subscriber/src/components/media-type-filters/FilterOptions.tsx
@@ -33,7 +33,8 @@ export interface IMediaTypeFiltersProps {
     | 'topStories'
     | 'avOverview'
     | 'eventOfTheDay'
-    | 'pressGalleryFilter';
+    | 'pressGalleryFilter'
+    | 'searchResults';
 }
 
 /**

--- a/app/subscriber/src/components/media-type-filters/utils/determineStore.ts
+++ b/app/subscriber/src/components/media-type-filters/utils/determineStore.ts
@@ -8,6 +8,8 @@ export const determineStore = (target: keyof IContentState) => {
       return 'storeTodaysCommentaryFilter';
     case 'topStories':
       return 'storeTopStoriesFilter';
+    case 'searchResults':
+      return 'storeSearchResultsFilter';
     default:
       return 'storeHomeFilter';
   }

--- a/app/subscriber/src/features/search-page/styled/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/styled/SearchPage.tsx
@@ -16,9 +16,6 @@ export const SearchPage = styled.div<{ expanded: boolean }>`
   }
   .header-row {
     width: 100%;
-    .view-options {
-      margin-left: auto;
-    }
   }
   .result-total {
     font-size: 0.5em;

--- a/app/subscriber/src/store/hooks/subscriber/useContent.ts
+++ b/app/subscriber/src/store/hooks/subscriber/useContent.ts
@@ -30,6 +30,7 @@ export interface IContentController {
   storeAvOverviewDateFilter: (filter: IFilterSettingsModel) => void;
   storeEventofTheDayDateFilter: (filter: IFilterSettingsModel) => void;
   storeMediaTypeFilter: (filter: IFilterSettingsModel) => void;
+  storeSearchResultsFilter: (filter: IFilterSettingsModel) => void;
   stream: (path: string) => Promise<string>;
   addContent: (content: IContentModel) => Promise<IContentModel | undefined>;
   updateContent: (content: IContentModel) => Promise<IContentModel | undefined>;
@@ -100,6 +101,7 @@ export const useContent = (props?: IContentProps): [IContentState, IContentContr
       storeFrontPageFilter: actions.storeFrontPageFilter,
       storeMediaTypeFilter: actions.storeMediaTypeFilter,
       storeMyMinisterFilter: actions.storeMyMinisterFilter,
+      storeSearchResultsFilter: actions.storeSearchResultsFilter,
       addContent: async (content: IContentModel) => {
         const response = await dispatch('add-content', () => api.addContent(content), 'content');
         return response.data;

--- a/app/subscriber/src/store/slices/content/constants/initialContentState.ts
+++ b/app/subscriber/src/store/slices/content/constants/initialContentState.ts
@@ -48,4 +48,7 @@ export const initialContentState: IContentState = {
   eventOfTheDay: {
     filter: defaultContentFilter,
   },
+  searchResults: {
+    filter: defaultContentFilter,
+  },
 };

--- a/app/subscriber/src/store/slices/content/contentSlice.ts
+++ b/app/subscriber/src/store/slices/content/contentSlice.ts
@@ -45,6 +45,9 @@ export const contentSlice = createSlice({
     storeTopStoriesFilter(state: IContentState, action: PayloadAction<IFilterSettingsModel>) {
       state.topStories.filter = action.payload;
     },
+    storeSearchResultsFilter(state: IContentState, action: PayloadAction<IFilterSettingsModel>) {
+      state.searchResults.filter = action.payload;
+    },
     storeSearchContent(
       state: IContentState,
       action: PayloadAction<KnnSearchResponse<IContentModel> | undefined>,
@@ -109,4 +112,5 @@ export const {
   storeTodaysCommentaryContent,
   storeTopStoriesContent,
   storeMediaTypeFilter,
+  storeSearchResultsFilter,
 } = contentSlice.actions;

--- a/app/subscriber/src/store/slices/content/interfaces/IContentState.ts
+++ b/app/subscriber/src/store/slices/content/interfaces/IContentState.ts
@@ -43,4 +43,7 @@ export interface IContentState {
   eventOfTheDay: {
     filter: IFilterSettingsModel;
   };
+  searchResults: {
+    filter: IFilterSettingsModel;
+  };
 }

--- a/app/subscriber/src/store/slices/content/useContentStore.ts
+++ b/app/subscriber/src/store/slices/content/useContentStore.ts
@@ -18,6 +18,7 @@ import {
   storeMyMinisterFilter,
   storeSearchContent,
   storeSearchFilter,
+  storeSearchResultsFilter,
   storeTodaysCommentaryContent,
   storeTodaysCommentaryFilter,
   storeTopStoriesContent,
@@ -40,6 +41,7 @@ export interface IContentStore {
   storeMyMinisterFilter: (filter: IFilterSettingsModel) => void;
   storeTodaysCommentaryFilter: (filter: IFilterSettingsModel) => void;
   storeHomeFilter: (filter: IFilterSettingsModel) => void;
+  storeSearchResultsFilter: (filter: IFilterSettingsModel) => void;
   storeTopStoriesFilter: (filter: IFilterSettingsModel) => void;
   storeSearchContent: (content: KnnSearchResponse<IContentModel>) => void;
   storeFrontPageContent: (content: KnnSearchResponse<IContentModel>) => void;
@@ -88,6 +90,9 @@ export const useContentStore = (props?: IContentProps): [IContentState, IContent
       },
       storeMediaTypeFilter: (filter: IFilterSettingsModel) => {
         dispatch(storeMediaTypeFilter(filter));
+      },
+      storeSearchResultsFilter: (filter: IFilterSettingsModel) => {
+        dispatch(storeSearchResultsFilter(filter));
       },
       storeSearchContent: (content: KnnSearchResponse<IContentModel>) => {
         dispatch(storeSearchContent(content));


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6bd71378-4de9-4370-b80d-cfe32b5b8ef6)

Implemented the FilterOptions bar, as a secondary filter, and merge into the main filter before run the query, without persisting into the main filter.