### PR TITLE
TNO-2905: Autoplay inline video

### DIFF
--- a/app/subscriber/src/components/content-list/ContentRow.tsx
+++ b/app/subscriber/src/components/content-list/ContentRow.tsx
@@ -66,18 +66,19 @@ export const ContentRow: React.FC<IContentRowProps> = ({
   /** This is a workaround for the autoplay attribute on <video>. Most chromium browser do not allow autoplay with the muted attribute included; however, we can avoid this issue by programatically calling play. The logic below will play the video
    * once the user clicks the inline play button. */
   React.useEffect(() => {
-    if (!videoRef.current) return;
-    const handleCanPlay = () => {
-      !!videoRef.current &&
-        videoRef.current.play().catch((e) => console.error('Failed to play video', e));
-    };
+    const videoElement = videoRef.current;
+    if (!!videoElement && activeStream?.source) {
+      const handleCanPlay = () => {
+        videoElement.play().catch((e) => console.error('Failed to play video', e));
+      };
 
-    // need to have an event listener to trigger the play, otherwise it will error out on the play call (calls too early)
-    videoRef.current.addEventListener('canplay', handleCanPlay);
+      // need to have an event listener to trigger the play, otherwise it will error out on the play call (calls too early)
+      videoElement.addEventListener('canplay', handleCanPlay);
 
-    return () => {
-      videoRef.current && videoRef.current.removeEventListener('canplay', handleCanPlay);
-    };
+      return () => {
+        videoElement.removeEventListener('canplay', handleCanPlay);
+      };
+    }
   }, [activeStream]);
 
   return (


### PR DESCRIPTION
Taking a break from my other ticket...

Now when the user clicks the "play inline" button, the video will start playing automatically and with sound. 

Note that I used a workaround to get the sound to work, if it is too much of a work around, we can go back to just adding the `autoplay` attribute with the tradeoff of losing audio until the user un-mutes.