### PR TITLE
Enable edit failed report

### DIFF
--- a/app/subscriber/src/features/my-reports/edit/ReportEditPage.tsx
+++ b/app/subscriber/src/features/my-reports/edit/ReportEditPage.tsx
@@ -48,7 +48,12 @@ export const ReportEditPage = () => {
 
   const instance = report.instances.length ? report.instances[0] : undefined;
   const canEdit = instance
-    ? [ReportStatusName.Pending, ReportStatusName.Reopen].includes(instance.status)
+    ? [
+        ReportStatusName.Pending,
+        ReportStatusName.Reopen,
+        ReportStatusName.Failed,
+        ReportStatusName.Cancelled,
+      ].includes(instance.status)
     : true;
 
   React.useEffect(() => {


### PR DESCRIPTION
Allow users to edit a failed or cancelled report.  I'm not certain this won't cause any other issues.