### PR TITLE
TNO-2859 Triggers clip search when the AV ID is changed

### DIFF
--- a/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
+++ b/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
@@ -58,65 +58,60 @@ export const OverviewGrid: React.FC<IOverviewGridProps> = ({ editable = true, in
   const queryDate = values.publishedOn ? new Date(values.publishedOn) : new Date();
   const startTime = values.sections[index]?.startTime?.split(':');
 
-  /** flag to keep track of when new complete start time is entered and trigger another search
-   * for relevant clips
-   */
-  const shouldFetch = React.useMemo(() => {
-    return (
-      !!values?.sections[index]?.startTime && !values?.sections[index]?.startTime?.includes('_')
-    );
-  }, [index, values?.sections]);
-
   /** fetch pieces of content that are related to the series to display as options for associated clips, search for clips published after the start time if it is specified - otherwise filter based on that day.*/
-  React.useEffect(() => {
-    if (shouldFetch) {
-      const seriesIds: number[] =
-        values.sections.length > index && values.sections[index].seriesId
-          ? [values.sections[index].seriesId!]
-          : [];
-      const sourceIds: number[] =
-        values.sections.length > index && values.sections[index].sourceId
-          ? [values.sections[index].sourceId!]
-          : [];
-      const startDate = queryDate;
-      if (values.sections[index].startTime) {
-        startDate.setHours(Number(startTime[0]), Number(startTime[1]), Number(startTime[2]));
-      }
-      const endDate = new Date(startDate);
-      endDate.setHours(23, 59, 59);
-      const query = generateQuery({
-        searchUnpublished: false,
-        size: 0,
-        seriesIds,
-        startDate: startDate.toISOString(),
-        endDate: endDate.toISOString(),
-        sourceIds,
-        sort: [{ publishedOn: 'asc' }],
-      });
-      findContentWithElasticsearch(query, false)
-        .then((data) => {
-          const results: IContentModel[] = data.hits.hits.map((h) => h._source!);
-          setContentItems(results);
-          const newClips = results.map((c) => {
-            const publishedOnTime = c.publishedOn
-              ? `${moment(c.publishedOn).format('HH:mm')} `
-              : '';
-            const itemHeadline = `${publishedOnTime}${c.headline}`;
-            return new OptionItem(itemHeadline, c.id);
-          }) as IOptionItem[];
-          // check if any previously selected clips are no longer available, if not, unselect them
-          items.forEach((item, itemIndex) => {
-            if (item.contentId && !newClips.some((clip) => clip.value === item.contentId)) {
-              setFieldValue(`sections.${index}.items.${itemIndex}.contentId`, null);
-            }
-          });
-          setClips(newClips);
-        })
-        .catch(() => {});
+  const searchClips = React.useCallback(() => {
+    const seriesIds: number[] =
+      values.sections.length > index && values.sections[index].seriesId
+        ? [values.sections[index].seriesId!]
+        : [];
+    const sourceIds: number[] =
+      values.sections.length > index && values.sections[index].sourceId
+        ? [values.sections[index].sourceId!]
+        : [];
+    const startDate = queryDate;
+    if (values.sections[index].startTime) {
+      startDate.setHours(Number(startTime[0]), Number(startTime[1]), Number(startTime[2]));
     }
-    // only want to fire on init, and when start time is changed
+    const endDate = new Date(startDate);
+    endDate.setHours(23, 59, 59);
+    const query = generateQuery({
+      searchUnpublished: false,
+      size: 0,
+      seriesIds,
+      startDate: startDate.toISOString(),
+      endDate: endDate.toISOString(),
+      sourceIds,
+      sort: [{ publishedOn: 'asc' }],
+    });
+    findContentWithElasticsearch(query, false)
+      .then((data) => {
+        const results: IContentModel[] = data.hits.hits.map((h) => h._source!);
+        setContentItems(results);
+        const newClips = results.map((c) => {
+          const publishedOnTime = c.publishedOn ? `${moment(c.publishedOn).format('HH:mm')} ` : '';
+          const itemHeadline = `${publishedOnTime}${c.headline}`;
+          return new OptionItem(itemHeadline, c.id);
+        }) as IOptionItem[];
+        // check if any previously selected clips are no longer available, if not, unselect them
+        items.forEach((item, itemIndex) => {
+          if (item.contentId && !newClips.some((clip) => clip.value === item.contentId)) {
+            setFieldValue(`sections.${index}.items.${itemIndex}.contentId`, null);
+          }
+        });
+        setClips(newClips);
+      })
+      .catch(() => {});
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldFetch]);
+  }, []);
+
+  // only want to fire on id change, and when start time is changed and completed
+  React.useEffect(() => {
+    const fetch =
+      !!values?.sections[index]?.startTime && !values?.sections[index]?.startTime?.includes('_');
+    if (fetch) {
+      searchClips();
+    }
+  }, [index, searchClips, values?.id, values?.sections]);
 
   /** function that runs after a user drops an item in the list */
   const handleDrop = (droppedItem: any) => {


### PR DESCRIPTION
There was an issue preventing the search for clips when toggle between dates.
When the start time between sessions are identical (very common on AV Overview), the was no trigger to search for new clips.
I changed a little bit the logic checking also the ID change and then validating the start time.
So with this changes, it keeps working when completing the session start time, but also loads the correct clips when toggling between existing AV Overviews.