### PR TITLE
Margin fixes for add to report menu

### DIFF
--- a/app/subscriber/src/components/tool-bar/styled/AddToMenu.tsx
+++ b/app/subscriber/src/components/tool-bar/styled/AddToMenu.tsx
@@ -16,7 +16,7 @@ export const AddToMenu = styled.div`
     color: ${(props) => props.theme.css.btnBkPrimary};
   }
   .report-name {
-    margin-left: 1.25em;
+    margin-left: 1.5em;
   }
   .react-tooltip {
     font-size: 1.1em;
@@ -37,7 +37,7 @@ export const AddToMenu = styled.div`
       position: absolute;
       left: 2.85em;
     }
-    margin-left: 3em;
+    margin-left: 3.5em;
     &:not(:hover) {
       .active-section {
         display: none;


### PR DESCRIPTION
Found this small styling bug when working on a report ticket. Not sure when this occurred but assuming it was some sort of css regression. 

Before: 
![image](https://github.com/user-attachments/assets/a3043620-4e67-4137-9fae-6baf6677dcbf)

After:
![image](https://github.com/user-attachments/assets/0b393a51-3c47-4145-be2c-4143d183ceee)
