### PR TITLE
TNO-2967 Check current date length

### DIFF
--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -99,7 +99,7 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
       setTotalResults(currDateResults.length + prevDateResults.length);
       if (!groupStoredContent) {
         if (res.hits.total.value === 0) toast.warn('No results found.');
-        if (res.hits.total.value >= 500)
+        if (currDateResults.length >= 500)
           toast.warn(
             'Search returned 500+ results, only showing first 500. Please consider refining your search.',
           );


### PR DESCRIPTION
Since we 7 days in advance and then group by the current date range (not considering the full search), the warning of more than 500 rows show be based on the current date range, not the total hits from the elastic search.
Although is not a severe issue it may cause confusion to the users.