### PR TITLE
Advanced Search locking up browser

### DIFF
--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -60,6 +60,7 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
 
   const [filterId, setFilterId] = React.useState(0);
   const [searchFilter, setSearchFilter] = React.useState<IFilterSettingsModel | null>(null);
+  const [showResults, setShowResults] = React.useState(false);
 
   React.useEffect(() => {
     const parsedId = id ? parseInt(id) : 0;
@@ -142,6 +143,7 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
     async (filter: IFilterSettingsModel, storedContent?: any) => {
       try {
         setIsLoading(true);
+        setShowResults(false);
         let newFilter = filter;
         if (filter.dateOffset !== undefined) {
           newFilter = {
@@ -184,6 +186,7 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
       } catch {
       } finally {
         setIsLoading(false);
+        setShowResults(true);
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -222,13 +225,6 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
     fetchResults(filter);
   }, [fetchResults, filter]);
 
-  const handleAdvancedSearch = React.useCallback(
-    async (updatedFilterSettings: IFilterSettingsModel) => {
-      fetchResults(updatedFilterSettings);
-    },
-    [fetchResults],
-  );
-
   const executeSearch = React.useCallback(
     async (filter: IFilterSettingsModel) => {
       fetchResults(filter);
@@ -242,7 +238,7 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
         {/* LEFT SIDE */}
         <Show visible={showAdvanced}>
           <Col className="adv-search-container">
-            <AdvancedSearch onSearch={handleAdvancedSearch} setSearchFilter={setSearchFilter} />
+            <AdvancedSearch onSearch={executeSearch} setSearchFilter={setSearchFilter} />
           </Col>
         </Show>
         {/* RIGHT SIDE */}
@@ -284,16 +280,18 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
                 <div className="filter-name">{activeFilter?.name}</div>
               </div>
             </Show>
-            <ContentList
-              onContentSelected={handleContentSelected}
-              content={currDateResults}
-              selected={selected}
-              showDate
-              showTime
-              showSeries
-              scrollWithin
-              filter={searchFilter ?? undefined}
-            />
+            <Show visible={showResults && !!currDateResults.length}>
+              <ContentList
+                onContentSelected={handleContentSelected}
+                content={currDateResults}
+                selected={selected}
+                showDate
+                showTime
+                showSeries
+                scrollWithin
+                filter={searchFilter ?? undefined}
+              />
+            </Show>
             <Show visible={!currDateResults.length}>
               <PreviousResults
                 currDateResults={currDateResults}

--- a/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
@@ -217,7 +217,11 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ onSearch, setSe
 
   const addSearch = React.useCallback(
     async (name: string) => {
-      const settings = filterFormat(search);
+      const updatedSearch = {
+        ...search,
+        search: searchTerms ?? search.search,
+      };
+      const settings = filterFormat(updatedSearch);
       const query = genQuery(settings);
       const filter: IFilterModel = { ...defaultFilter, name, query, settings };
 
@@ -239,7 +243,7 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ onSearch, setSe
         })
         .catch(() => {});
     },
-    [search, genQuery, addFilter, storeFilter, storeSearchFilter, navigate, myFilters],
+    [search, searchTerms, genQuery, myFilters, addFilter, storeFilter, storeSearchFilter, navigate],
   );
 
   const handleSearchTermsChanged = React.useCallback(

--- a/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/AdvancedSearch.tsx
@@ -138,10 +138,9 @@ export const AdvancedSearch: React.FC<IAdvancedSearchProps> = ({ onSearch, setSe
       search: searchTerms,
     };
 
+    onSearch?.(updatedFilterSettings);
     storeSearchFilter(updatedFilterSettings);
     setSearchFilter(updatedFilterSettings);
-
-    onSearch?.(updatedFilterSettings);
   };
 
   React.useEffect(() => {


### PR DESCRIPTION
**Issue: Multiple Unnecessary Re-renders of ContentList on Search Execution**

When the user clicks the Search button in AdvancedSearch component, the `executeSearch` function is triggered, which subsequently calls `fetchResults` function within the SearchPage component. This action causes the SearchPage component to re-render, leading to multiple unnecessary re-renders of the ContentList component. Since ContentList is responsible for handling the bolding of search terms, these repeated re-renders can cause freezing the browser.

**Solution**
To enhance performance and prevent browser freezing, we need to optimize the rendering process so that ContentList re-renders only once after the search results are fetched.

**Additional Issue: Search Terms Not Saved on New Search Creation**
During testing, when creating a new search, the search terms (searchTerms) are not being saved correctly. This issue occurs because searchTerms are only updated when the user clicks the Search button. We need to ensure that searchTerms are properly included when a new search is created, similar to how they are handled during updates.

**Solution**
Update the `addSearch` function to include searchTerms when creating a new search.