### PR TITLE
TNO-2859 Change the search event trigger

### DIFF
--- a/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
+++ b/app/editor/src/features/reports/av-overview/OverviewGrid.tsx
@@ -111,7 +111,8 @@ export const OverviewGrid: React.FC<IOverviewGridProps> = ({ editable = true, in
     if (fetch) {
       searchClips();
     }
-  }, [index, searchClips, values?.id, values?.sections]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [index, searchClips, values.id, values?.sections[index].startTime]);
 
   /** function that runs after a user drops an item in the list */
   const handleDrop = (droppedItem: any) => {


### PR DESCRIPTION
Only trigger the search event when there's a change on AV Id or Start time.
It prevents extra calls to the search method.