### PR TITLE
TNO-2949 Prevent sending report with no subscribers 

### DIFF
--- a/app/editor/src/features/admin/reports/ReportForm.tsx
+++ b/app/editor/src/features/admin/reports/ReportForm.tsx
@@ -12,6 +12,7 @@ import {
   hasErrors,
   IconButton,
   IReportModel,
+  IUserReportModel,
   Modal,
   Row,
   Show,
@@ -102,6 +103,10 @@ const ReportForm: React.FC = () => {
     } catch {}
   };
 
+  const hasSubscribers = (subscribers: IUserReportModel[]) => {
+    return subscribers.some((s) => s.isSubscribed);
+  };
+
   return (
     <styled.ReportForm>
       <FormikForm
@@ -132,7 +137,11 @@ const ReportForm: React.FC = () => {
               >
                 Save
               </Button>
-              <Button variant={ButtonVariant.secondary} onClick={() => handlePublish(values)}>
+              <Button
+                variant={ButtonVariant.secondary}
+                onClick={() => handlePublish(values)}
+                disabled={!hasSubscribers(values.subscribers)}
+              >
                 Send
               </Button>
               <Show visible={!!values.id}>
@@ -278,7 +287,11 @@ const ReportForm: React.FC = () => {
                     >
                       Save
                     </Button>
-                    <Button variant={ButtonVariant.secondary} onClick={() => handlePublish(values)}>
+                    <Button
+                      variant={ButtonVariant.secondary}
+                      onClick={() => handlePublish(values)}
+                      disabled={!hasSubscribers(values.subscribers)}
+                    >
                       Send
                     </Button>
                     <Show visible={!!values.id}>

--- a/app/subscriber/src/features/my-reports/ReportPreview.tsx
+++ b/app/subscriber/src/features/my-reports/ReportPreview.tsx
@@ -43,6 +43,7 @@ export const ReportPreview = ({ report, onFetch, onClose }: IReportPreviewProps)
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
   const instance = report?.instances.length ? report.instances[0] : undefined;
+  const hasSubscribers = report?.subscribers?.some((s) => s.isSubscribed === true) ?? false;
 
   const fetchReport = React.useCallback(
     async (id: number) => {
@@ -194,10 +195,18 @@ export const ReportPreview = ({ report, onFetch, onClose }: IReportPreviewProps)
               ![ReportStatusName.Submitted].includes(instance.status)
             }
           >
-            <Button onClick={() => report && instance && toggleSend()} disabled={isSubmitting}>
+            <Button
+              onClick={() => report && instance && toggleSend()}
+              disabled={isSubmitting || !hasSubscribers}
+              title={
+                !hasSubscribers
+                  ? 'There are no subscribers for this report. Add subscribers to enable sending.'
+                  : ''
+              }
+            >
               Send
               <FaPaperPlane />
-            </Button>
+            </Button>{' '}
           </Show>
           <Show visible={!!instance?.sentOn}>
             <Show visible={getReportKind(report) === ReportKindName.Manual}>

--- a/app/subscriber/src/features/my-reports/ReportPreview.tsx
+++ b/app/subscriber/src/features/my-reports/ReportPreview.tsx
@@ -206,7 +206,7 @@ export const ReportPreview = ({ report, onFetch, onClose }: IReportPreviewProps)
             >
               Send
               <FaPaperPlane />
-            </Button>{' '}
+            </Button>
           </Show>
           <Show visible={!!instance?.sentOn}>
             <Show visible={getReportKind(report) === ReportKindName.Manual}>

--- a/app/subscriber/src/features/my-reports/edit/view/ReportViewForm.tsx
+++ b/app/subscriber/src/features/my-reports/edit/view/ReportViewForm.tsx
@@ -41,6 +41,7 @@ export const ReportViewForm: React.FC = () => {
 
   const instance = values.instances.length ? values.instances[0] : undefined;
   const isAdmin = userInfo?.roles.includes(Claim.administrator);
+  const isSubscribed = values.subscribers.some((s) => s.isSubscribed === true);
   const [{ publishReportInstance }] = useReportInstances();
 
   const handleSend = React.useCallback(
@@ -158,7 +159,10 @@ export const ReportViewForm: React.FC = () => {
           <Row alignItems="flex-start" className="preview-send-details-row">
             <Button
               disabled={
-                isSubmitting || !instance || instance?.status === ReportStatusName.Submitted
+                isSubmitting ||
+                !instance ||
+                instance?.status === ReportStatusName.Submitted ||
+                !isSubscribed
               }
               onClick={() => toggleSend()}
               variant="success"


### PR DESCRIPTION
disable sending button in editor and subscriber 
prevent any sending with no subscribers in reporting service, and set status to failed.

![image](https://github.com/user-attachments/assets/2b454440-9103-4307-8867-e87cfbb06b17)
