### PR TITLE
Reset view when changing feature bug fix

### DIFF
--- a/app/subscriber/src/features/landing/Landing.tsx
+++ b/app/subscriber/src/features/landing/Landing.tsx
@@ -53,7 +53,10 @@ export const Landing: React.FC = () => {
 
   React.useEffect(() => {
     if (isMobile) {
-      window.scrollTo(0, 0);
+      const mainElement = document.querySelector('main');
+      if (mainElement) {
+        mainElement.scrollTo(0, 0);
+      }
     }
     // only want to fire when id changes (user navigates to a new section)
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Previously if there was overflow this would not behave as expected as `window.scrollTo(0, 0)` could still be at position 0,0 and be displaying the middle of the page.

Using the `<main>` element, we avoid this problem entirely.