### PR TITLE
Fix bug 500+ return bug

### DIFF
--- a/app/subscriber/src/features/home/Home.tsx
+++ b/app/subscriber/src/features/home/Home.tsx
@@ -34,6 +34,7 @@ export const Home: React.FC = () => {
       ...filter,
       actions: [getBooleanActionValue(featuredStoryActionId)],
       startDate: filter.startDate ?? moment().startOf('day').toISOString(),
+      size: 500,
       sort: [{ publishedOn: 'desc' }],
     }).catch();
     // only want to fire when filter changes, or when the featured story action id changes

--- a/app/subscriber/src/features/home/Home.tsx
+++ b/app/subscriber/src/features/home/Home.tsx
@@ -34,7 +34,8 @@ export const Home: React.FC = () => {
       ...filter,
       actions: [getBooleanActionValue(featuredStoryActionId)],
       startDate: filter.startDate ?? moment().startOf('day').toISOString(),
-    }).then(() => {});
+      sort: [{ publishedOn: 'desc' }],
+    }).catch();
     // only want to fire when filter changes, or when the featured story action id changes
     // react does not like dependencies that are from a hook it seems.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
+++ b/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
@@ -47,7 +47,6 @@ export const TodaysCommentary: React.FC = () => {
     if (commentaryActionId) {
       let actionFilters = getActionFilters();
       const commentaryAction = actionFilters.find((a) => a.id === commentaryActionId);
-      setIsLoading(true);
       commentaryAction &&
         fetchResults({
           ...filter,
@@ -55,7 +54,8 @@ export const TodaysCommentary: React.FC = () => {
           startDate: filter.startDate ?? moment().startOf('day').toISOString(),
           searchUnpublished: false,
           sort: [{ publishedOn: 'desc' }],
-        });
+          size: 500,
+        }).catch();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [commentaryActionId, filter, findContentWithElasticsearch, getActionFilters]);

--- a/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
+++ b/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
@@ -54,7 +54,7 @@ export const TodaysCommentary: React.FC = () => {
           actions: [commentaryAction],
           startDate: filter.startDate ?? moment().startOf('day').toISOString(),
           searchUnpublished: false,
-          size: 500,
+          sort: [{ publishedOn: 'desc' }],
         });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/subscriber/src/features/top-stories/TopStories.tsx
+++ b/app/subscriber/src/features/top-stories/TopStories.tsx
@@ -37,6 +37,7 @@ export const TopStories: React.FC = () => {
           ...filter,
           actions: [topStoryAction],
           startDate: filter.startDate ?? moment().startOf('day').toISOString(),
+          sort: [{ publishedOn: 'desc' }],
         });
     }
     // react does not like dependencies that are from a hook

--- a/app/subscriber/src/features/top-stories/TopStories.tsx
+++ b/app/subscriber/src/features/top-stories/TopStories.tsx
@@ -37,8 +37,9 @@ export const TopStories: React.FC = () => {
           ...filter,
           actions: [topStoryAction],
           startDate: filter.startDate ?? moment().startOf('day').toISOString(),
+          size: 500,
           sort: [{ publishedOn: 'desc' }],
-        });
+        }).catch();
     }
     // react does not like dependencies that are from a hook
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
When 500+ results were returned it would truncate - meaning that the currently selected date may not have the results present on the page even if there were some (as the previous 5 days could be taking those spots).

