### PR TITLE
Fix multiple charts

### DIFF
--- a/app/subscriber/src/features/my-reports/edit/ReportEditContext.tsx
+++ b/app/subscriber/src/features/my-reports/edit/ReportEditContext.tsx
@@ -60,8 +60,6 @@ export interface IReportEditContext {
   setPreviewLastUpdatedOn: React.Dispatch<React.SetStateAction<string | undefined>>;
   testData: IReportInstanceContentModel[];
   regenerateTestData: () => void;
-  showReportData: boolean;
-  toggleReportData: () => void;
 }
 
 /**
@@ -86,8 +84,6 @@ export const ReportEditContext = React.createContext<IReportEditContext>({
   setPreviewLastUpdatedOn: () => {},
   testData: [],
   regenerateTestData: () => {},
-  showReportData: true,
-  toggleReportData: () => {},
 });
 
 /**
@@ -135,20 +131,12 @@ export const ReportEditContextProvider: React.FC<IReportEditContextProviderProps
   const instance = values.instances.length ? values.instances[0] : undefined;
   const [activeInstance, setActiveInstance] = React.useState<IReportInstanceModel>();
   const [previewLastUpdatedOn, setPreviewLastUpdatedOn] = React.useState<string | undefined>();
-  const [showReportData, setShowReportData] = React.useState(
-    values.instances.length > 0 && values.instances[0].content.length > 0,
-  );
   const [testData, setTestData] = React.useState(
     generateReportInstanceContents({
       sections: { min: 1, max: 10 },
       content: { min: 20, max: 50 },
     }),
   );
-
-  React.useEffect(() => {
-    // If there is data, then show it in the charts.
-    setShowReportData(values.instances.length > 0 && values.instances[0].content.length > 0);
-  }, [values.instances]);
 
   React.useEffect(() => {
     // Set the active form based on the route.
@@ -261,8 +249,6 @@ export const ReportEditContextProvider: React.FC<IReportEditContextProviderProps
     );
   }, []);
 
-  const toggleReportData = React.useCallback(() => setShowReportData((show) => !show), []);
-
   return (
     <ReportEditContext.Provider
       value={{
@@ -289,8 +275,6 @@ export const ReportEditContextProvider: React.FC<IReportEditContextProviderProps
         setPreviewLastUpdatedOn,
         testData,
         regenerateTestData,
-        showReportData,
-        toggleReportData,
       }}
     >
       {children}

--- a/app/subscriber/src/features/my-reports/edit/settings/template/ReportSectionMediaAnalyticsChart.tsx
+++ b/app/subscriber/src/features/my-reports/edit/settings/template/ReportSectionMediaAnalyticsChart.tsx
@@ -33,8 +33,7 @@ export const ReportSectionMediaAnalyticsChart = React.forwardRef<
   HTMLDivElement,
   IReportSectionMediaAnalyticsChartProps
 >(({ showConfig: initShowConfig, sectionIndex, chartIndex, onDisableDrag, ...rest }, ref) => {
-  const { values, setFieldValue, testData, regenerateTestData, showReportData, toggleReportData } =
-    useReportEditContext();
+  const { values, setFieldValue, testData, regenerateTestData } = useReportEditContext();
 
   const section = values.sections[sectionIndex];
   const chart = section.chartTemplates[chartIndex];
@@ -44,6 +43,16 @@ export const ReportSectionMediaAnalyticsChart = React.forwardRef<
   const [reportContent, setReportContent] = React.useState(
     values.instances ? values.instances[0].content : [],
   );
+  const [showReportData, setShowReportData] = React.useState(
+    values.instances.length > 0 && values.instances[0].content.length > 0,
+  );
+
+  const toggleReportData = React.useCallback(() => setShowReportData((show) => !show), []);
+
+  React.useEffect(() => {
+    // If there is data, then show it in the charts.
+    setShowReportData(values.instances.length > 0 && values.instances[0].content.length > 0);
+  }, [values.instances]);
 
   React.useEffect(() => {
     setData(generateChartData(chart, showReportData ? reportContent : testData, values.sections));

--- a/app/subscriber/src/features/my-reports/edit/settings/template/charts/ChartViewer.tsx
+++ b/app/subscriber/src/features/my-reports/edit/settings/template/charts/ChartViewer.tsx
@@ -34,7 +34,7 @@ ChartJS.register(
   ChartDataLabels,
 );
 
-let myChart: ChartJS;
+let myChart: Record<string, ChartJS> = {};
 
 export interface IChartViewerProps extends IChartSectionProps {
   /** Chart data */
@@ -53,14 +53,15 @@ export const ChartViewer: React.FC<IChartViewerProps> = ({ sectionIndex, chartIn
 
   const section = values.sections[sectionIndex];
   const chart = section.chartTemplates[chartIndex];
+  const uid = `${section.id}_${sectionIndex}`;
 
   React.useEffect(() => {
     if (canvasRef.current !== null && data) {
-      myChart?.destroy();
+      myChart[uid]?.destroy();
       if (chart.sectionSettings.height) canvasRef.current.height = chart.sectionSettings.height;
       if (chart.sectionSettings.width) canvasRef.current.width = chart.sectionSettings.width;
 
-      myChart = new ChartJS(canvasRef.current, {
+      myChart[uid] = new ChartJS(canvasRef.current, {
         type: chart.sectionSettings.chartType as keyof ChartTypeRegistry,
         data: {
           ...data,
@@ -84,13 +85,13 @@ export const ChartViewer: React.FC<IChartViewerProps> = ({ sectionIndex, chartIn
         },
         options: generateChartOptions(data, chart.sectionSettings),
       });
-      myChart.resize(chart.sectionSettings.width, chart.sectionSettings.height);
+      myChart[uid].resize(chart.sectionSettings.width, chart.sectionSettings.height);
     }
-  }, [chart.sectionSettings, data, values.sections]);
+  }, [chart.sectionSettings, data, values.sections, uid]);
 
   return (
     <div>
-      <canvas ref={canvasRef} id="my-chart" />
+      <canvas ref={canvasRef} id={`my-chart-${uid}`} />
     </div>
   );
 };


### PR DESCRIPTION
When adding charts to reports, this will allow multiple charts to be displayed at the same time.

## Subscriber Report Chart Editor

![image](https://github.com/user-attachments/assets/62bda556-d166-4699-9aa3-e8f7e8f742d3)
