### PR TITLE
Fix Reporting Service

### DIFF
--- a/api/net/Areas/Admin/Controllers/ReportController.cs
+++ b/api/net/Areas/Admin/Controllers/ReportController.cs
@@ -217,7 +217,7 @@ public class ReportController : ControllerBase
         var username = User.GetUsername() ?? throw new NotAuthorizedException("Username is missing");
         var user = _userService.FindByUsername(username) ?? throw new NotAuthorizedException($"User [{username}] does not exist");
 
-        var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.Content, report.Id, new { })
+        var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.Content, report.Id, JsonDocument.Parse("{}"))
         {
             RequestorId = user.Id,
             To = to,
@@ -245,7 +245,7 @@ public class ReportController : ControllerBase
         var username = User.GetUsername() ?? throw new NotAuthorizedException("Username is missing");
         var user = _userService.FindByUsername(username) ?? throw new NotAuthorizedException($"User [{username}] does not exist");
 
-        var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.Content, report.Id, new { })
+        var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.Content, report.Id, JsonDocument.Parse("{}"))
         {
             RequestorId = user.Id
         };

--- a/api/net/Areas/Admin/Controllers/ReportInstanceController.cs
+++ b/api/net/Areas/Admin/Controllers/ReportInstanceController.cs
@@ -150,7 +150,7 @@ public class ReportInstanceController : ControllerBase
         instance.Status = new[] { Entities.ReportStatus.Pending, Entities.ReportStatus.Reopen }.Contains(instance.Status) ? Entities.ReportStatus.Submitted : instance.Status;
         instance = _reportInstanceService.UpdateAndSave(instance);
 
-        var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.Content, instance.ReportId, instance.Id, new { })
+        var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.Content, instance.ReportId, instance.Id, JsonDocument.Parse("{}"))
         {
             RequestorId = user.Id,
             Resend = resend || instance.Status == ReportStatus.Reopen,

--- a/api/net/Areas/Editor/Controllers/AVOverviewController.cs
+++ b/api/net/Areas/Editor/Controllers/AVOverviewController.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Mime;
+using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Annotations;
@@ -203,7 +204,7 @@ public class AVOverviewController : ControllerBase
         var username = User.GetUsername() ?? throw new NotAuthorizedException("Username is missing");
         var user = _userService.FindByUsername(username) ?? throw new NotAuthorizedException($"User [{username}] does not exist");
 
-        var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.AVOverview, 0, instance.Id, new { })
+        var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.AVOverview, 0, instance.Id, JsonDocument.Parse("{}"))
         {
             RequestorId = user.Id
         };

--- a/api/net/Areas/Editor/Controllers/ReportController.cs
+++ b/api/net/Areas/Editor/Controllers/ReportController.cs
@@ -223,7 +223,7 @@ public class ReportController : ControllerBase
         var username = User.GetUsername() ?? throw new NotAuthorizedException("Username is missing");
         var user = _userService.FindByUsername(username) ?? throw new NotAuthorizedException($"User [{username}] does not exist");
 
-        var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.Content, report.Id, new { })
+        var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.Content, report.Id, JsonDocument.Parse("{}"))
         {
             RequestorId = user.Id,
             SendToSubscribers = true,

--- a/api/net/Areas/Helpers/ReportHelper.cs
+++ b/api/net/Areas/Helpers/ReportHelper.cs
@@ -207,7 +207,7 @@ public class ReportHelper : IReportHelper
         });
 
         var result = await GenerateReportAsync(model, null, sections, viewOnWebOnly, isPreview);
-        result.Data = elasticResults;
+        result.Data = JsonDocument.Parse(JsonSerializer.Serialize(elasticResults));
         return result;
 
         throw new NotImplementedException($"Report template type '{model.Template.ReportType.GetName()}' has not been implemented");
@@ -254,7 +254,7 @@ public class ReportHelper : IReportHelper
         var template = _overviewTemplateService.FindById(instance.TemplateType) ?? throw new InvalidOperationException($"AV overview template '{instance.TemplateType.GetName()}' not found.");
         if (template.Template == null) throw new InvalidOperationException($"Report template '{instance.TemplateType.GetName()}' not found.");
         var result = await GenerateReportAsync(new Areas.Services.Models.AVOverview.ReportTemplateModel(template.Template, _serializerOptions), instance, isPreview);
-        result.Data = instance;
+        result.Data = JsonDocument.Parse(JsonSerializer.Serialize(instance));
         return result;
     }
 

--- a/api/net/Areas/Subscriber/Controllers/ReportInstanceController.cs
+++ b/api/net/Areas/Subscriber/Controllers/ReportInstanceController.cs
@@ -215,7 +215,7 @@ public class ReportInstanceController : ControllerBase
         var instance = _reportInstanceService.FindById(id) ?? throw new NoContentException("Report does not exist");
         if (instance.OwnerId != user.Id) throw new NotAuthorizedException("Not authorized to send this report"); // User does not own the report
 
-        var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.Content, instance.ReportId, instance.Id, new { })
+        var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.Content, instance.ReportId, instance.Id, JsonDocument.Parse("{}"))
         {
             RequestorId = user.Id,
             To = to,
@@ -247,7 +247,7 @@ public class ReportInstanceController : ControllerBase
         instance.Status = new[] { Entities.ReportStatus.Pending, Entities.ReportStatus.Reopen }.Contains(instance.Status) ? Entities.ReportStatus.Submitted : instance.Status;
         instance = _reportInstanceService.UpdateAndSave(instance);
 
-        var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.Content, instance.ReportId, instance.Id, new { })
+        var request = new ReportRequestModel(ReportDestination.ReportingService, Entities.ReportType.Content, instance.ReportId, instance.Id, JsonDocument.Parse("{}"))
         {
             RequestorId = user.Id,
             Resend = resend || instance.Status == Entities.ReportStatus.Reopen,

--- a/libs/net/core/Extensions/StringExtensions.cs
+++ b/libs/net/core/Extensions/StringExtensions.cs
@@ -392,6 +392,7 @@ public static class StringExtensions
 
     /// <summary>
     /// Determines if the email address is valid.
+    /// Regrettably the following email "name@name" is valid, but will fail in most cases.
     /// </summary>
     /// <param name="value"></param>
     /// <returns></returns>

--- a/libs/net/kafka/Models/ReportRequestModel.cs
+++ b/libs/net/kafka/Models/ReportRequestModel.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace TNO.Kafka.Models;
 
 /// <summary>
@@ -37,7 +39,7 @@ public class ReportRequestModel
     /// <summary>
     /// get/set - JSON object with data to be passed to the report template.
     /// </summary>
-    public dynamic Data { get; set; } = new { };
+    public JsonDocument Data { get; set; } = JsonDocument.Parse("{}");
 
     /// <summary>
     /// get/set - Foreign key to user who requested the report.
@@ -89,7 +91,7 @@ public class ReportRequestModel
     /// <param name="type"></param>
     /// <param name="reportId"></param>
     /// <param name="data"></param>
-    public ReportRequestModel(ReportDestination destination, Entities.ReportType type, int reportId, object data)
+    public ReportRequestModel(ReportDestination destination, Entities.ReportType type, int reportId, JsonDocument data)
     {
         this.ReportType = type;
         this.Destination = destination;
@@ -106,7 +108,7 @@ public class ReportRequestModel
     /// <param name="data"></param>
     /// <param name="assignedId"></param>
     /// <param name="to"></param>
-    public ReportRequestModel(ReportDestination destination, Entities.ReportType type, int reportId, object data, int assignedId, string to = "")
+    public ReportRequestModel(ReportDestination destination, Entities.ReportType type, int reportId, JsonDocument data, int assignedId, string to = "")
         : this(destination, type, reportId, data)
     {
         this.AssignedId = assignedId;
@@ -123,7 +125,7 @@ public class ReportRequestModel
     /// <param name="requestorId"></param>
     /// <param name="assignedId"></param>
     /// <param name="to"></param>
-    public ReportRequestModel(ReportDestination destination, Entities.ReportType type, int reportId, object data, int requestorId, int assignedId, string to = "")
+    public ReportRequestModel(ReportDestination destination, Entities.ReportType type, int reportId, JsonDocument data, int requestorId, int assignedId, string to = "")
         : this(destination, type, reportId, data, assignedId, to)
     {
         this.RequestorId = requestorId;
@@ -137,7 +139,7 @@ public class ReportRequestModel
     /// <param name="reportId"></param>
     /// <param name="reportInstanceId"></param>
     /// <param name="data"></param>
-    public ReportRequestModel(ReportDestination destination, Entities.ReportType type, int reportId, long reportInstanceId, object data)
+    public ReportRequestModel(ReportDestination destination, Entities.ReportType type, int reportId, long reportInstanceId, JsonDocument data)
         : this(destination, type, reportId, data)
     {
         this.ReportInstanceId = reportInstanceId;
@@ -153,7 +155,7 @@ public class ReportRequestModel
     /// <param name="data"></param>
     /// <param name="assignedId"></param>
     /// <param name="to"></param>
-    public ReportRequestModel(ReportDestination destination, Entities.ReportType type, int reportId, long reportInstanceId, object data, int assignedId, string to = "")
+    public ReportRequestModel(ReportDestination destination, Entities.ReportType type, int reportId, long reportInstanceId, JsonDocument data, int assignedId, string to = "")
         : this(destination, type, reportId, reportInstanceId, data)
     {
         this.AssignedId = assignedId;
@@ -171,7 +173,7 @@ public class ReportRequestModel
     /// <param name="requestorId"></param>
     /// <param name="assignedId"></param>
     /// <param name="to"></param>
-    public ReportRequestModel(ReportDestination destination, Entities.ReportType type, int reportId, long reportInstanceId, object data, int requestorId, int assignedId, string to = "")
+    public ReportRequestModel(ReportDestination destination, Entities.ReportType type, int reportId, long reportInstanceId, JsonDocument data, int requestorId, int assignedId, string to = "")
         : this(destination, type, reportId, reportInstanceId, data, assignedId, to)
     {
         this.RequestorId = requestorId;

--- a/libs/net/models/Areas/Services/Models/Report/UserModel.cs
+++ b/libs/net/models/Areas/Services/Models/Report/UserModel.cs
@@ -118,24 +118,5 @@ public class UserModel
     {
         return String.IsNullOrWhiteSpace(this.PreferredEmail) ? this.Email : this.PreferredEmail;
     }
-
-    /// <summary>
-    /// Get the preferred email if it has been set.
-    /// </summary>
-    /// <returns></returns>
-    public string[] GetEmails()
-    {
-        if (this.AccountType == Entities.UserAccountType.Distribution)
-        {
-            var addresses = this.Preferences.GetElementValue<API.Models.UserEmailModel[]?>(".addresses");
-            if (addresses != null) return addresses.Select(a => a.Email).ToArray();
-            return Array.Empty<string>();
-        }
-        else
-        {
-            var email = String.IsNullOrWhiteSpace(this.PreferredEmail) ? this.Email : this.PreferredEmail;
-            return new string[] { email };
-        }
-    }
     #endregion
 }

--- a/libs/net/services/Managers/IngestManager`.cs
+++ b/libs/net/services/Managers/IngestManager`.cs
@@ -153,7 +153,7 @@ public abstract class IngestManager<TActionManager, TOption> : ServiceManager<TO
                                 }
                                 else
                                 {
-                                    // Auto-reset time delay hasnt passed yet.
+                                    // Auto-reset time delay hasn't passed yet.
                                     this.Logger.LogWarning("Ingest [{name}] has reached maximum failure limit. Auto-reset will occur at [{timestamp}]", ingest.Name, ingest.LastRanOn!.Value.AddMilliseconds(ingest.ResetRetryAfterDelayMs).ToLocalTime());
                                     continue;
                                 }
@@ -182,7 +182,7 @@ public abstract class IngestManager<TActionManager, TOption> : ServiceManager<TO
                         // Reached limit return to ingest manager, send email.
                         if (manager.Ingest.FailedAttempts >= manager.Ingest.RetryLimit)
                         {
-                            await this.SendEmailAsync($"Ingest [{ingest.Name}] failed. Reached [{manager.Ingest.RetryLimit}] maximum retries.", ex);
+                            await this.SendErrorEmailAsync($"Ingest [{ingest.Name}] failed. Reached [{manager.Ingest.RetryLimit}] maximum retries.", ex);
                         }
                     }
                     catch (Exception ex)
@@ -195,7 +195,7 @@ public abstract class IngestManager<TActionManager, TOption> : ServiceManager<TO
                         // Reached limit return to ingest manager, send email.
                         if (manager.Ingest.FailedAttempts >= manager.Ingest.RetryLimit)
                         {
-                            await this.SendEmailAsync($"Ingest ['{ingest.Name}'] failed. Reached [{manager.Ingest.RetryLimit}] maximum retries.", ex);
+                            await this.SendErrorEmailAsync($"Ingest ['{ingest.Name}'] failed. Reached [{manager.Ingest.RetryLimit}] maximum retries.", ex);
                         }
                     }
                 }
@@ -281,7 +281,7 @@ public abstract class IngestManager<TActionManager, TOption> : ServiceManager<TO
             {
                 this.Logger.LogError(ex, "Failed to fetch ingests for ingest type '{type}'", ingestType);
                 this.State.RecordFailure();
-                await this.SendEmailAsync($"Failed to fetch ingests for ingest type '{ingestType}", ex);
+                await this.SendErrorEmailAsync($"Failed to fetch ingests for ingest type '{ingestType}", ex);
             }
         }
 

--- a/libs/net/services/Managers/ServiceManager`.cs
+++ b/libs/net/services/Managers/ServiceManager`.cs
@@ -122,7 +122,7 @@ public abstract class ServiceManager<TOption> : IServiceManager
     /// <param name="subject"></param>
     /// <param name="ex"></param>
     /// <returns></returns>
-    public async Task SendEmailAsync(string subject, Exception ex)
+    public async Task SendErrorEmailAsync(string subject, Exception ex)
     {
         string env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production";
         string? serviceName = GetType().FullName ?? "Service";

--- a/libs/net/template/Models/Reports/ReportResultModel.cs
+++ b/libs/net/template/Models/Reports/ReportResultModel.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace TNO.TemplateEngine.Models.Reports;
 
 /// <summary>
@@ -29,7 +31,7 @@ public class ReportResultModel
     /// <summary>
     /// get/set - JSON data that was used to generate the report.
     /// </summary>
-    public object? Data { get; set; }
+    public JsonDocument? Data { get; set; }
     #endregion
 
     #region Constructors
@@ -44,7 +46,7 @@ public class ReportResultModel
     /// <param name="subject"></param>
     /// <param name="body"></param>
     /// <param name="data"></param>
-    public ReportResultModel(Entities.ReportInstance instance, object? data = null)
+    public ReportResultModel(Entities.ReportInstance instance, JsonDocument? data = null)
     {
         this.ReportId = instance.ReportId;
         this.InstanceId = instance.Id;

--- a/openshift/kustomize/services/reporting/base/config-map.yaml
+++ b/openshift/kustomize/services/reporting/base/config-map.yaml
@@ -20,3 +20,4 @@ data:
   CHES_EMAIL_ENABLED: "true"
   CHES_EMAIL_AUTHORIZED: "true"
   CHARTS_URL: http://charts-api:8080
+  RESEND_ON_FAILURE: "true"

--- a/openshift/kustomize/services/reporting/base/deploy.yaml
+++ b/openshift/kustomize/services/reporting/base/deploy.yaml
@@ -150,6 +150,11 @@ spec:
                 configMapKeyRef:
                   name: reporting-service
                   key: MAX_FAIL_LIMIT
+            - name: Service__ResendOnFailure
+              valueFrom:
+                configMapKeyRef:
+                  name: reporting-service
+                  key: RESEND_ON_FAILURE
             - name: Service__Topics
               valueFrom:
                 configMapKeyRef:

--- a/services/net/content/ContentManager.cs
+++ b/services/net/content/ContentManager.cs
@@ -139,7 +139,7 @@ public class ContentManager : ServiceManager<ContentOptions>
                 {
                     this.Logger.LogError(ex, "Service had an unexpected failure.");
                     this.State.RecordFailure();
-                    await this.SendEmailAsync("Service had an Unexpected Failure", ex);
+                    await this.SendErrorEmailAsync("Service had an Unexpected Failure", ex);
                 }
             }
 
@@ -268,12 +268,12 @@ public class ContentManager : ServiceManager<ContentOptions>
             if (ex is HttpClientRequestException httpEx)
             {
                 this.Logger.LogError(ex, "HTTP exception while consuming. {response}", httpEx.Data["body"] ?? "");
-                await this.SendEmailAsync("HTTP exception while consuming. {response}", ex);
+                await this.SendErrorEmailAsync("HTTP exception while consuming. {response}", ex);
             }
             else
             {
                 this.Logger.LogError(ex, "Failed to handle message");
-                await this.SendEmailAsync("Failed to handle message", ex);
+                await this.SendErrorEmailAsync("Failed to handle message", ex);
             }
             ListenerErrorHandler(this, new ErrorEventArgs(ex));
         }

--- a/services/net/extract-quotes/ExtractQuotesManager.cs
+++ b/services/net/extract-quotes/ExtractQuotesManager.cs
@@ -124,7 +124,7 @@ public partial class ExtractQuotesManager : ServiceManager<ExtractQuotesOptions>
                 {
                     Logger.LogError(ex, "Service had an unexpected failure.");
                     State.RecordFailure();
-                    await SendEmailAsync("Service had an Unexpected Failure", ex);
+                    await SendErrorEmailAsync("Service had an Unexpected Failure", ex);
                 }
             }
 
@@ -235,12 +235,12 @@ public partial class ExtractQuotesManager : ServiceManager<ExtractQuotesOptions>
             if (ex is HttpClientRequestException httpEx)
             {
                 Logger.LogError(ex, "HTTP exception while consuming. {response}", httpEx.Data["body"] ?? "");
-                await SendEmailAsync("HTTP exception while consuming. {response}", ex);
+                await SendErrorEmailAsync("HTTP exception while consuming. {response}", ex);
             }
             else
             {
                 Logger.LogError(ex, "Failed to handle message");
-                await SendEmailAsync("Failed to handle message", ex);
+                await SendErrorEmailAsync("Failed to handle message", ex);
             }
             ListenerErrorHandler(this, new ErrorEventArgs(ex));
         }

--- a/services/net/folder-collection/FolderCollectionManager.cs
+++ b/services/net/folder-collection/FolderCollectionManager.cs
@@ -132,7 +132,7 @@ public class FolderCollectionManager : ServiceManager<FolderCollectionOptions>
                 {
                     this.Logger.LogError(ex, "Service had an unexpected failure.");
                     this.State.RecordFailure();
-                    await this.SendEmailAsync("Service had an Unexpected Failure", ex);
+                    await this.SendErrorEmailAsync("Service had an Unexpected Failure", ex);
                 }
             }
 
@@ -243,7 +243,7 @@ public class FolderCollectionManager : ServiceManager<FolderCollectionOptions>
         catch (HttpClientRequestException ex)
         {
             this.Logger.LogError(ex, "HTTP exception while consuming. {response}", ex.Data["body"] ?? "");
-            await this.SendEmailAsync("HTTP exception while consuming. {response}", ex);
+            await this.SendErrorEmailAsync("HTTP exception while consuming. {response}", ex);
         }
     }
 

--- a/services/net/indexing/IndexingManager.cs
+++ b/services/net/indexing/IndexingManager.cs
@@ -127,7 +127,7 @@ public class IndexingManager : ServiceManager<IndexingOptions>
                 {
                     this.Logger.LogError(ex, "Service had an unexpected failure.");
                     this.State.RecordFailure();
-                    await this.SendEmailAsync("Service had an Unexpected Failure", ex);
+                    await this.SendErrorEmailAsync("Service had an Unexpected Failure", ex);
                 }
             }
 
@@ -252,12 +252,12 @@ public class IndexingManager : ServiceManager<IndexingOptions>
             if (ex is HttpClientRequestException httpEx)
             {
                 this.Logger.LogError(ex, "HTTP exception while consuming. {response}", httpEx.Data["body"] ?? "");
-                await this.SendEmailAsync("HTTP exception while consuming. {response}", ex);
+                await this.SendErrorEmailAsync("HTTP exception while consuming. {response}", ex);
             }
             else
             {
                 this.Logger.LogError(ex, "Failed to handle message");
-                await this.SendEmailAsync("Failed to handle message", ex);
+                await this.SendErrorEmailAsync("Failed to handle message", ex);
             }
             ListenerErrorHandler(this, new ErrorEventArgs(ex));
         }

--- a/services/net/notification/NotificationManager.cs
+++ b/services/net/notification/NotificationManager.cs
@@ -141,7 +141,7 @@ public class NotificationManager : ServiceManager<NotificationOptions>
                 {
                     this.Logger.LogError(ex, "Service had an unexpected failure.");
                     this.State.RecordFailure();
-                    await this.SendEmailAsync("Service had an Unexpected Failure", ex);
+                    await this.SendErrorEmailAsync("Service had an Unexpected Failure", ex);
                 }
             }
 
@@ -251,12 +251,12 @@ public class NotificationManager : ServiceManager<NotificationOptions>
             if (ex is HttpClientRequestException httpEx)
             {
                 this.Logger.LogError(ex, "HTTP exception while consuming. {response}", httpEx.Data["body"] ?? "");
-                await this.SendEmailAsync("HTTP exception while consuming. {response}", ex);
+                await this.SendErrorEmailAsync("HTTP exception while consuming. {response}", ex);
             }
             else
             {
                 this.Logger.LogError(ex, "Failed to handle message");
-                await this.SendEmailAsync("Failed to handle message", ex);
+                await this.SendErrorEmailAsync("Failed to handle message", ex);
             }
             ListenerErrorHandler(this, new ErrorEventArgs(ex));
         }

--- a/services/net/reporting/Config/ReportingOptions.cs
+++ b/services/net/reporting/Config/ReportingOptions.cs
@@ -15,13 +15,28 @@ public class ReportingOptions : ServiceOptions
     public string Topics { get; set; } = "";
 
     /// <summary>
+    /// get/set- Whether a failure should make the report resend.
+    /// </summary>
+    public bool ResendOnFailure { get; set; }
+
+    /// <summary>
+    /// get/set - Number of attempts that will be made to resend a failed report before giving up.
+    /// </summary>
+    public int ResendAttemptLimit { get; set; } = 3;
+
+    /// <summary>
     /// get/set - Whether to use the mail merge option.
     /// </summary>
     public bool UseMailMerge { get; set; } = true;
 
     /// <summary>
-    /// get/set- Whether a failure should make the report resend.
+    /// get/set - Whether a failure to send to one subscriber should stop the process, or whether it should attempt to send to all subscribers before failing.
     /// </summary>
-    public bool ResendOnFailure { get; set; }
+    public bool SendToAllSubscribersBeforeFailing { get; set; } = true;
+
+    /// <summary>
+    /// get/set - Number of retries allowed when a concurrency error occurs.
+    /// </summary>
+    public int RetryConcurrencyFailureLimit { get; set; } = 10;
     #endregion
 }

--- a/services/net/reporting/ReportingErrors.cs
+++ b/services/net/reporting/ReportingErrors.cs
@@ -7,5 +7,5 @@ public enum ReportingErrors
     FailedToAddInstance = 2,
     FailedToUpdateInstance = 3,
     FailedToGenerateOutput = 4,
-    FailedToEmail = 4,
+    FailedToEmail = 5,
 }

--- a/services/net/reporting/ReportingManager.cs
+++ b/services/net/reporting/ReportingManager.cs
@@ -143,7 +143,7 @@ public class ReportingManager : ServiceManager<ReportingOptions>
                 {
                     this.Logger.LogError(ex, "Service had an unexpected failure.");
                     this.State.RecordFailure();
-                    await this.SendEmailAsync("Service had an Unexpected Failure", ex);
+                    await this.SendErrorEmailAsync("Service had an Unexpected Failure", ex);
                 }
             }
 
@@ -228,6 +228,16 @@ public class ReportingManager : ServiceManager<ReportingOptions>
     /// <returns></returns>
     private async Task HandleMessageAsync(ConsumeResult<string, ReportRequestModel> result)
     {
+        var failureCount = result.Message.Value.Data.GetElementValue<int?>(".failureCount") ?? 0;
+        var errorStatus = result.Message.Value.Data.GetElementValue<ReportingErrors?>(".error");
+        if (errorStatus != null)
+        {
+            this.Logger.LogInformation("Retrying report after failure. ReportId:{reportId} InstanceId:{instanceId} FailureStatus:{status} RetryCount:{count}",
+                result.Message.Value.ReportId,
+                result.Message.Value.ReportInstanceId,
+                errorStatus,
+                failureCount);
+        }
         try
         {
             // The service has stopped, so to should consuming messages.
@@ -249,36 +259,39 @@ public class ReportingManager : ServiceManager<ReportingOptions>
         {
             // Failures will require retrying the report.  However, depending on the error the report instance could be in a unique state.
             // Resending a failure can result in cascading failures however, so it should limit the number of attempts.
-            // TODO: Limit number of retries.
-
             this.Logger.LogError(ex, "Failed to handle message");
-            await this.SendEmailAsync("Failed to handle message", ex);
+            await this.SendErrorEmailAsync("Failed to handle message", ex);
             ListenerErrorHandler(this, new ErrorEventArgs(ex));
 
             result.Message.Value.ReportInstanceId = ex.InstanceId;
-            result.Message.Value.Data = new { ex.Error };
+            result.Message.Value.Data = JsonDocument.Parse(JsonSerializer.Serialize(new { ex.Error, FailureCount = failureCount + 1 }, _serializationOptions));
             result.Message.Value.Resend = false;
-            if (this.Options.ResendOnFailure)
+            // Add the report request back to Kafka so that it runs again.
+            if (this.Options.ResendOnFailure && failureCount < this.Options.ResendAttemptLimit)
                 await this.Api.SendMessageAsync(result.Message.Value);
         }
         catch (HttpClientRequestException ex)
         {
             this.Logger.LogError(ex, "HTTP exception while consuming. {response}", ex.Data["body"] ?? "");
-            await this.SendEmailAsync("HTTP exception while consuming. {response}", ex);
+            await this.SendErrorEmailAsync("HTTP exception while consuming. {response}", ex);
             ListenerErrorHandler(this, new ErrorEventArgs(ex));
 
             result.Message.Value.Resend = false;
-            if (this.Options.ResendOnFailure)
+            result.Message.Value.Data = JsonDocument.Parse(JsonSerializer.Serialize(new { FailureCount = failureCount + 1 }, _serializationOptions));
+            // Add the report request back to Kafka so that it runs again.
+            if (this.Options.ResendOnFailure && failureCount < this.Options.ResendAttemptLimit)
                 await this.Api.SendMessageAsync(result.Message.Value);
         }
         catch (Exception ex)
         {
             this.Logger.LogError(ex, "Failed to handle message");
-            await this.SendEmailAsync("Failed to handle message", ex);
+            await this.SendErrorEmailAsync("Failed to handle message", ex);
             ListenerErrorHandler(this, new ErrorEventArgs(ex));
 
             result.Message.Value.Resend = false;
-            if (this.Options.ResendOnFailure)
+            result.Message.Value.Data = JsonDocument.Parse(JsonSerializer.Serialize(new { FailureCount = failureCount + 1 }, _serializationOptions));
+            // Add the report request back to Kafka so that it runs again.
+            if (this.Options.ResendOnFailure && failureCount < this.Options.ResendAttemptLimit)
                 await this.Api.SendMessageAsync(result.Message.Value);
         }
         finally
@@ -543,9 +556,9 @@ public class ReportingManager : ServiceManager<ReportingOptions>
     /// <param name="request"></param>
     /// <param name="instance"></param>
     /// <returns></returns>
-    private bool IsResend(ReportRequestModel request, API.Areas.Services.Models.ReportInstance.ReportInstanceModel? instance)
+    private static bool IsResend(ReportRequestModel request, API.Areas.Services.Models.ReportInstance.ReportInstanceModel? instance)
     {
-        return (request.Resend || instance?.SentOn.HasValue == true) && !String.IsNullOrWhiteSpace(instance?.Subject) && !String.IsNullOrWhiteSpace(instance?.Body);
+        return request.Resend && !String.IsNullOrWhiteSpace(instance?.Subject) && !String.IsNullOrWhiteSpace(instance?.Body);
     }
 
     /// <summary>
@@ -730,7 +743,7 @@ public class ReportingManager : ServiceManager<ReportingOptions>
                 userReportInstances.AddRange(await this.Api.GetUserReportInstancesAsync(instance.Id));
             }
 
-            var (linkEmails, fullEmails) = await GetEmailAddressesAsync(request, report, userReportInstances);
+            var (linkEmails, fullEmails) = await GetEmailAddressesAsync(request, report, instance, userReportInstances);
 
             if (instance != null && request.GenerateInstance)
             {
@@ -744,12 +757,20 @@ public class ReportingManager : ServiceManager<ReportingOptions>
             if (!report.Settings.DoNotSendEmail && String.IsNullOrEmpty(request.To) && (linkEmails[EmailSentTo.To].Any() || linkEmails[EmailSentTo.CC].Any() || linkEmails[EmailSentTo.BCC].Any()))
             {
                 // Send the email.
-                var responseLinkOnly = await SendEmailAsync(request, linkEmails[EmailSentTo.To], linkEmails[EmailSentTo.CC], linkEmails[EmailSentTo.BCC], subject, linkBody, $"{report.Name}-{report.Id}-linkOnly", UpdateUserReportInstances(report, instance, userReportInstances, false));
+                var (linkOnlyStatus, responseLinkOnly) = await SendEmailAsync(
+                    request,
+                    linkEmails[EmailSentTo.To],
+                    linkEmails[EmailSentTo.CC],
+                    linkEmails[EmailSentTo.BCC],
+                    subject,
+                    linkBody,
+                    $"{report.Name}-{report.Id}-linkOnly",
+                    UpdateUserReportInstances(report, instance, userReportInstances, false));
                 responseModel.LinkOnlyFormatResponse = JsonDocument.Parse(JsonSerializer.Serialize(responseLinkOnly, _serializationOptions));
 
                 if (instance != null)
                 {
-                    instance.Status = ReportStatus.Accepted;
+                    instance.Status = linkOnlyStatus;
                     instance.Response = JsonDocument.Parse(JsonSerializer.Serialize(responseModel, _serializationOptions));
                 }
             }
@@ -757,12 +778,20 @@ public class ReportingManager : ServiceManager<ReportingOptions>
             if (!report.Settings.DoNotSendEmail && (fullEmails[EmailSentTo.To].Any() || fullEmails[EmailSentTo.CC].Any() || fullEmails[EmailSentTo.BCC].Any() || !String.IsNullOrEmpty(request.To)))
             {
                 // Send the email.
-                var responseFullText = await SendEmailAsync(request, fullEmails[EmailSentTo.To], fullEmails[EmailSentTo.CC], fullEmails[EmailSentTo.BCC], subject, fullBody, $"{report.Name}-{report.Id}", UpdateUserReportInstances(report, instance, userReportInstances, true));
+                var (fullTextStatus, responseFullText) = await SendEmailAsync(
+                    request,
+                    fullEmails[EmailSentTo.To],
+                    fullEmails[EmailSentTo.CC],
+                    fullEmails[EmailSentTo.BCC],
+                    subject,
+                    fullBody,
+                    $"{report.Name}-{report.Id}",
+                    UpdateUserReportInstances(report, instance, userReportInstances, true));
                 responseModel.FullTextFormatResponse = JsonDocument.Parse(JsonSerializer.Serialize(responseFullText, _serializationOptions));
 
                 if (instance != null)
                 {
-                    instance.Status = ReportStatus.Accepted;
+                    instance.Status = fullTextStatus;
                     instance.Response = JsonDocument.Parse(JsonSerializer.Serialize(responseModel, _serializationOptions));
                 }
             }
@@ -805,8 +834,8 @@ public class ReportingManager : ServiceManager<ReportingOptions>
     private async Task UpdateReportInstanceAsync(API.Areas.Services.Models.ReportInstance.ReportInstanceModel instance, bool updateContent)
     {
         // Need to keep trying until successful.
-        // TODO: limit number of attempts.
         var isUpdated = false;
+        var count = 0;
         while (!isUpdated)
         {
             try
@@ -830,7 +859,10 @@ public class ReportingManager : ServiceManager<ReportingOptions>
             }
             catch (Exception ex)
             {
+                count++;
                 this.Logger.LogError(ex, "Failed to update report instance. ReportId:{reportId} InstanceId:{instanceId}", instance.ReportId, instance.Id);
+                if (count >= this.Options.RetryConcurrencyFailureLimit)
+                    throw;
             }
         }
     }
@@ -905,7 +937,7 @@ public class ReportingManager : ServiceManager<ReportingOptions>
     private async Task UpdateReportInstanceAsync(API.Areas.Services.Models.AVOverview.AVOverviewInstanceModel instance)
     {
         // Need to keep trying until successful.
-        // TODO: limit number of attempts.
+        var count = 0;
         var isUpdated = false;
         while (!isUpdated)
         {
@@ -926,25 +958,48 @@ public class ReportingManager : ServiceManager<ReportingOptions>
             }
             catch (Exception ex)
             {
+                count++;
                 this.Logger.LogError(ex, "Failed to update AV overview report instance. InstanceId:{instanceId}", instance.Id);
+                if (count >= this.Options.RetryConcurrencyFailureLimit)
+                    throw;
             }
         }
     }
 
     /// <summary>
     /// Get all the emails that both the link and full text report should be sent to.
+    /// Do not include subscribers that have already received this report unless this is a resend.
     /// </summary>
     /// <param name="request"></param>
     /// <param name="report"></param>
+    /// <param name="instance"></param>
     /// <param name="userReportInstances"></param>
     /// <returns></returns>
     private async Task<(Dictionary<EmailSentTo, List<UserEmail>> link, Dictionary<EmailSentTo, List<UserEmail>> full)> GetEmailAddressesAsync(
             ReportRequestModel request,
             API.Areas.Services.Models.Report.ReportModel report,
+            API.Areas.Services.Models.ReportInstance.ReportInstanceModel? instance,
             IEnumerable<API.Areas.Services.Models.ReportInstance.UserReportInstanceModel> userReportInstances)
     {
-        var linkOnlyFormatSubscribers = report.Subscribers.Where(s => s.IsSubscribed && s.User != null && LinkOnlyFormats.Contains(s.Format)).ToArray();
-        var fullTextFormatSubscribers = report.Subscribers.Where(s => s.IsSubscribed && s.User != null && FullTextFormats.Contains(s.Format)).ToArray();
+
+        var linkOnlyFormatSubscribers = report.Subscribers.Where(s =>
+            s.IsSubscribed &&
+            s.User != null &&
+            LinkOnlyFormats.Contains(s.Format) &&
+            (request.Resend ||
+                !userReportInstances.Any(uri =>
+                    uri.UserId == s.UserId &&
+                    _successfulEmailStatuses.Contains(uri.LinkStatus) &&
+                    (instance == null || uri.InstanceId == instance.Id)))).ToArray();
+        var fullTextFormatSubscribers = report.Subscribers.Where(s =>
+            s.IsSubscribed &&
+            s.User != null &&
+            FullTextFormats.Contains(s.Format) &&
+            (request.Resend ||
+                !userReportInstances.Any(uri =>
+                    uri.UserId == s.UserId &&
+                    _successfulEmailStatuses.Contains(uri.LinkStatus) &&
+                    (instance == null || uri.InstanceId == instance.Id)))).ToArray();
 
         var linkEmails = await GetEmailAddressesAsync(request, linkOnlyFormatSubscribers, userReportInstances);
         var fullEmails = await GetEmailAddressesAsync(request, fullTextFormatSubscribers, userReportInstances);
@@ -958,12 +1013,12 @@ public class ReportingManager : ServiceManager<ReportingOptions>
     /// </summary>
     /// <param name="request"></param>
     /// <param name="subscribers"></param>
-    /// <param name="instances"></param>
+    /// <param name="userReportInstances"></param>
     /// <returns></returns>
     private async Task<Dictionary<EmailSentTo, List<UserEmail>>> GetEmailAddressesAsync(
         ReportRequestModel request,
         API.Areas.Services.Models.Report.UserReportModel[] subscribers,
-        IEnumerable<API.Areas.Services.Models.ReportInstance.UserReportInstanceModel> instances)
+        IEnumerable<API.Areas.Services.Models.ReportInstance.UserReportInstanceModel> userReportInstances)
     {
         var emails = new Dictionary<EmailSentTo, List<UserEmail>>()
         {
@@ -978,9 +1033,9 @@ public class ReportingManager : ServiceManager<ReportingOptions>
 
             // Only include users who have not received an email yet.
             var (a, b, c) = await GetEmailAddressesAsync(user.UserId, user.User.GetEmail(), user.User.AccountType, user.SendTo);
-            emails[EmailSentTo.To].AddRange(a.Where(s => request.Resend || !instances.Any(uri => uri.UserId == s.UserId && _successfulEmailStatuses.Contains(uri.LinkStatus))));
-            emails[EmailSentTo.CC].AddRange(b.Where(s => request.Resend || !instances.Any(uri => uri.UserId == s.UserId && _successfulEmailStatuses.Contains(uri.LinkStatus))));
-            emails[EmailSentTo.BCC].AddRange(c.Where(s => request.Resend || !instances.Any(uri => uri.UserId == s.UserId && _successfulEmailStatuses.Contains(uri.LinkStatus))));
+            emails[EmailSentTo.To].AddRange(a.Where(s => request.Resend || !userReportInstances.Any(uri => uri.UserId == s.UserId && _successfulEmailStatuses.Contains(uri.LinkStatus))));
+            emails[EmailSentTo.CC].AddRange(b.Where(s => request.Resend || !userReportInstances.Any(uri => uri.UserId == s.UserId && _successfulEmailStatuses.Contains(uri.LinkStatus))));
+            emails[EmailSentTo.BCC].AddRange(c.Where(s => request.Resend || !userReportInstances.Any(uri => uri.UserId == s.UserId && _successfulEmailStatuses.Contains(uri.LinkStatus))));
         }
 
         return emails;
@@ -1004,7 +1059,7 @@ public class ReportingManager : ServiceManager<ReportingOptions>
         if (accountType == UserAccountType.Distribution)
         {
             var users = await this.Api.GetDistributionListAsync(userId);
-            var filteredUsers = users.Where(u => !u.IsVacationMode()).ToList();
+            var filteredUsers = users.Where(u => !u.IsVacationMode() && u.GetEmail().IsValidEmail()).ToList();
             var emails = filteredUsers.Select(u => new UserEmail(u.Id, u.GetEmail()));
             switch (sendTo)
             {
@@ -1019,7 +1074,7 @@ public class ReportingManager : ServiceManager<ReportingOptions>
                     break;
             }
         }
-        else
+        else if (email.IsValidEmail())
         {
             switch (sendTo)
             {
@@ -1033,6 +1088,10 @@ public class ReportingManager : ServiceManager<ReportingOptions>
                     bcc.Add(new UserEmail(userId, email));
                     break;
             }
+        }
+        else
+        {
+            this.Logger.LogError("Email address is invalid {email}", email);
         }
 
         return (to.Distinct(), cc.Distinct(), bcc.Distinct());
@@ -1082,7 +1141,7 @@ public class ReportingManager : ServiceManager<ReportingOptions>
                 var body = await this.ReportEngine.GenerateReportBodyAsync(template, model, false);
 
                 // Send the email.
-                var response = await SendEmailAsync(request, to, cc, bcc, subject, body, $"{instance.TemplateType}-{instance.Id}", async (users, status, response) =>
+                var (status, response) = await SendEmailAsync(request, to, cc, bcc, subject, body, $"{instance.TemplateType}-{instance.Id}", async (users, status, response) =>
                 {
                     if (instance.Id > 0)
                     {
@@ -1113,7 +1172,7 @@ public class ReportingManager : ServiceManager<ReportingOptions>
     /// <param name="body"></param>
     /// <param name="tag"></param>
     /// <returns></returns>
-    private async Task<EmailResponseModel[]> SendEmailAsync(
+    private async Task<(ReportStatus status, EmailResponseModel[] response)> SendEmailAsync(
         ReportRequestModel request,
         IEnumerable<UserEmail> to,
         IEnumerable<UserEmail> cc,
@@ -1165,7 +1224,7 @@ public class ReportingManager : ServiceManager<ReportingOptions>
             }
         }
 
-        if (!contexts.Any()) return Array.Empty<EmailResponseModel>();
+        if (!contexts.Any()) return (ReportStatus.Cancelled, Array.Empty<EmailResponseModel>());
 
         if (this.Options.UseMailMerge)
         {
@@ -1186,11 +1245,12 @@ public class ReportingManager : ServiceManager<ReportingOptions>
                 await updateCallbackAsync(contexts.Select(c => c.User), ReportStatus.Accepted, document);
             }
 
-            return new[] { response };
+            return (ReportStatus.Accepted, new[] { response });
         }
         else
         {
             var responses = new List<EmailResponseModel>();
+            var hasFailure = false;
             foreach (var (user, context) in contexts)
             {
                 var allUsers = new[] { user }.Concat(user.CC.Concat(user.BCC)).Distinct();
@@ -1217,28 +1277,32 @@ public class ReportingManager : ServiceManager<ReportingOptions>
                 }
                 catch (ChesException ex)
                 {
+                    hasFailure = true;
                     if (user.UserId != 0)
                     {
                         // Save the status of each email sent.
                         var document = JsonDocument.Parse(JsonSerializer.Serialize(ex.Data["error"], _serializationOptions));
                         await updateCallbackAsync(allUsers, ReportStatus.Failed, document);
                     }
-                    throw;
+                    if (!this.Options.SendToAllSubscribersBeforeFailing)
+                        throw;
                 }
                 catch (Exception ex)
                 {
+                    hasFailure = true;
                     if (user.UserId != 0)
                     {
                         // Save the status of each email sent.
                         var document = JsonDocument.Parse(JsonSerializer.Serialize(new { Error = ex.GetAllMessages() }, _serializationOptions));
                         await updateCallbackAsync(allUsers, ReportStatus.Failed, document);
                     }
-                    throw;
+                    if (!this.Options.SendToAllSubscribersBeforeFailing)
+                        throw;
                 }
             }
             this.Logger.LogInformation("Report sent to CHES. ReportId:{report}, InstanceId:{instance}", request.ReportId, request.ReportInstanceId);
 
-            return responses.ToArray();
+            return (hasFailure ? ReportStatus.Failed : ReportStatus.Accepted, responses.ToArray());
         }
     }
 

--- a/services/net/scheduler/SchedulerManager.cs
+++ b/services/net/scheduler/SchedulerManager.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using TNO.API.Areas.Services.Models.EventSchedule;
@@ -98,7 +99,7 @@ public class SchedulerManager : ServiceManager<SchedulerOptions>
                 {
                     this.Logger.LogError(ex, "Service had an unexpected failure.");
                     this.State.RecordFailure();
-                    await this.SendEmailAsync("Service had an Unexpected Failure", ex);
+                    await this.SendErrorEmailAsync("Service had an Unexpected Failure", ex);
                 }
             }
 
@@ -171,7 +172,7 @@ public class SchedulerManager : ServiceManager<SchedulerOptions>
         var autoSend = scheduledEvent.Settings.GetDictionaryJsonValue<bool?>("autoSend") ?? false;
 
         if (reportId == null || reportId == 0) throw new InvalidOperationException($"Event schedule configuration must have a valid report {scheduledEvent.Id}:{scheduledEvent.Name}");
-        var request = new ReportRequestModel(destination, reportType, reportId.Value, data)
+        var request = new ReportRequestModel(destination, reportType, reportId.Value, JsonDocument.Parse(JsonSerializer.Serialize(data)))
         {
             EventScheduleId = scheduledEvent.Id,
             ReportInstanceId = reportInstanceId,

--- a/services/net/transcription/TranscriptionManager.cs
+++ b/services/net/transcription/TranscriptionManager.cs
@@ -109,7 +109,7 @@ public class TranscriptionManager : ServiceManager<TranscriptionOptions>
                 {
                     this.Logger.LogError(ex, "Service had an unexpected failure.");
                     this.State.RecordFailure();
-                    await this.SendEmailAsync("Service had an Unexpected Failure", ex);
+                    await this.SendErrorEmailAsync("Service had an Unexpected Failure", ex);
                 }
             }
 
@@ -238,12 +238,12 @@ public class TranscriptionManager : ServiceManager<TranscriptionOptions>
             if (ex is HttpClientRequestException httpEx)
             {
                 this.Logger.LogError(ex, "HTTP exception while consuming. {response}", httpEx.Data["body"] ?? "");
-                await this.SendEmailAsync("HTTP exception while consuming. {response}", ex);
+                await this.SendErrorEmailAsync("HTTP exception while consuming. {response}", ex);
             }
             else
             {
                 this.Logger.LogError(ex, "Failed to handle message");
-                await this.SendEmailAsync("Failed to handle message", ex);
+                await this.SendErrorEmailAsync("Failed to handle message", ex);
             }
             ListenerErrorHandler(this, new ErrorEventArgs(ex));
         }


### PR DESCRIPTION
The Reporting Service can now be configured to resend on failures, and whether it will attempt to send the report to every subscriber before it logs the report send as a failure.  This provides a way to get a report out to subscribers when only a single subscriber's email is failing.

## Summary

- Updated Reporting Service
- Updated API

## Reporting Service Configuration Options

- ResendOnFailure = Whether a failure will result in another attempt
- ResendAttemptLimit = Only retry a failed report this many times
- SendToAllSubscribersBeforeFailing = Whether to attempt to send to all subscribers and ignore failures
- RetryConcurrencyFailureLimit = Limit on concurrency error retries