### PR TITLE
Enhance Reporting Service

### DIFF
--- a/app/subscriber/src/features/my-reports/MyReports.tsx
+++ b/app/subscriber/src/features/my-reports/MyReports.tsx
@@ -12,7 +12,6 @@ import {
   IReportModel,
   Loading,
   MessageTargetKey,
-  ReportStatusName,
   Row,
   Show,
   useModal,
@@ -48,14 +47,12 @@ export const MyReports: React.FC = () => {
   hub.useHubEffect(MessageTargetKey.ReportStatus, async (message: IReportMessageModel) => {
     if (report) {
       try {
-        if (message.status === ReportStatusName.Accepted) {
-          const instance = await getReportInstance(message.id, false);
-          if (instance) {
-            setReport({
-              ...report,
-              instances: report.instances.map((i) => (i.id === message.id ? instance : i)),
-            });
-          }
+        const instance = await getReportInstance(message.id, false);
+        if (instance) {
+          setReport({
+            ...report,
+            instances: report.instances.map((i) => (i.id === message.id ? instance : i)),
+          });
         }
       } catch {}
     }

--- a/app/subscriber/src/features/my-reports/ReportCard.tsx
+++ b/app/subscriber/src/features/my-reports/ReportCard.tsx
@@ -9,7 +9,8 @@ import { useApp, useReports } from 'store/hooks';
 import { Col, IReportModel, ReportSectionTypeName, Row, Show, Spinner } from 'tno-core';
 
 import { ReportKindIcon } from './components';
-import { calcNextScheduleSend, getLastSent, getStatus } from './utils';
+import { ReportStatus } from './ReportStatus';
+import { calcNextScheduleSend, getLastSent } from './utils';
 
 export interface IReportCardProps {
   /** The report to display on this card. */
@@ -102,7 +103,9 @@ export const ReportCard: React.FC<IReportCardProps> = ({
               <Show visible={!!instance}>
                 <Row>
                   <Col>Status:</Col>
-                  <Col flex="1">{instance ? getStatus(instance.status) : 'Draft'}</Col>
+                  <Col>
+                    <ReportStatus status={instance?.status} />
+                  </Col>
                 </Row>
               </Show>
               <Row>

--- a/app/subscriber/src/features/my-reports/ReportStatus.tsx
+++ b/app/subscriber/src/features/my-reports/ReportStatus.tsx
@@ -1,0 +1,16 @@
+import { ReportStatusName } from 'tno-core';
+
+import * as styled from './styled';
+import { getStatus } from './utils';
+
+export interface IReportStatusProps {
+  status?: ReportStatusName;
+}
+
+export const ReportStatus: React.FC<IReportStatusProps> = ({ status }) => {
+  return status ? (
+    <styled.ReportStatus className={`report-status${status ? ` ${status}` : ''}`}>
+      {status ? getStatus(status) : 'Draft'}
+    </styled.ReportStatus>
+  ) : null;
+};

--- a/app/subscriber/src/features/my-reports/edit/ReportEditActions.tsx
+++ b/app/subscriber/src/features/my-reports/edit/ReportEditActions.tsx
@@ -91,12 +91,7 @@ export const ReportEditActions = ({
 
   return (
     <styled.ReportEditActions className="report-edit-actions">
-      <Show
-        visible={
-          active?.startsWith(ReportMainMenuOption.Settings) &&
-          !active?.startsWith(ReportSettingsMenuOption.Subscribers)
-        }
-      >
+      <Show visible={active?.startsWith(ReportMainMenuOption.Settings)}>
         <Col flex="1" alignItems="flex-start">
           <ReportExporter />
         </Col>
@@ -159,9 +154,8 @@ export const ReportEditActions = ({
       </Show>
       <Show
         visible={
-          (active?.startsWith(ReportMainMenuOption.Settings) ||
-            active?.startsWith(ReportMainMenuOption.Content)) &&
-          !active?.startsWith(ReportSettingsMenuOption.Subscribers)
+          active?.startsWith(ReportMainMenuOption.Settings) ||
+          active?.startsWith(ReportMainMenuOption.Content)
         }
       >
         <Button
@@ -174,6 +168,8 @@ export const ReportEditActions = ({
             else if (active === ReportSettingsMenuOption.DataSources)
               navigate(`/reports/${values.id}/${ReportSettingsMenuOption.Preferences}`);
             else if (active === ReportSettingsMenuOption.Preferences)
+              navigate(`/reports/${values.id}/${ReportSettingsMenuOption.Subscribers}`);
+            else if (active === ReportSettingsMenuOption.Subscribers)
               navigate(`/reports/${values.id}/${ReportSettingsMenuOption.Send}`);
             else if (active === ReportSettingsMenuOption.Send)
               navigate(`/reports/${values.id}/${ReportMainMenuOption.Content}`);

--- a/app/subscriber/src/features/my-reports/edit/ReportEditForm.tsx
+++ b/app/subscriber/src/features/my-reports/edit/ReportEditForm.tsx
@@ -256,7 +256,6 @@ export const ReportEditForm = React.forwardRef<HTMLDivElement | null, IReportEdi
               if (instance) {
                 const result = await updateReportInstance({
                   ...instance,
-                  sentOn: undefined,
                   status: ReportStatusName.Reopen,
                 });
                 const updatedInstance = { ...result, content: instance.content };

--- a/app/subscriber/src/features/my-reports/edit/view/styled/ReportViewForm.tsx
+++ b/app/subscriber/src/features/my-reports/edit/view/styled/ReportViewForm.tsx
@@ -5,6 +5,7 @@ export const ReportViewForm = styled.div`
   flex-direction: column;
   margin: 1rem;
   gap: 1rem;
+
   .send-test-button {
     margin-left: 1rem;
   }
@@ -14,8 +15,8 @@ export const ReportViewForm = styled.div`
   }
   .preview-send-details-row {
     margin-left: 1.5rem;
+    gap: 1rem;
   }
-
   .hide {
     display: none;
   }

--- a/app/subscriber/src/features/my-reports/index.ts
+++ b/app/subscriber/src/features/my-reports/index.ts
@@ -1,4 +1,5 @@
 export * from './edit';
 export * from './MyReports';
 export * from './ReportInstanceView';
+export * from './ReportStatus';
 export * from './ReportView';

--- a/app/subscriber/src/features/my-reports/styled/ReportStatus.tsx
+++ b/app/subscriber/src/features/my-reports/styled/ReportStatus.tsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+export const ReportStatus = styled.div`
+  display: flex;
+  flex: column;
+  align-items: center;
+  padding: 0 0.5rem;
+  border-radius: 0.5rem;
+
+  &.Failed {
+    background: ${(props) => props.theme.css.btnBkError};
+    color: ${(props) => props.theme.css.btnErrorColor};
+  }
+
+  &.Cancelled {
+    background: ${(props) => props.theme.css.btnBkWarn};
+    color: ${(props) => props.theme.css.btnWarnColor};
+  }
+
+  &.Completed {
+    background: ${(props) => props.theme.css.btnBkSuccess};
+    color: ${(props) => props.theme.css.btnSuccessColor};
+  }
+`;

--- a/app/subscriber/src/features/my-reports/styled/index.ts
+++ b/app/subscriber/src/features/my-reports/styled/index.ts
@@ -1,2 +1,3 @@
 export * from './MyReports';
 export * from './ReportInstanceView';
+export * from './ReportStatus';


### PR DESCRIPTION
A failed report status is more visible.  We also now have a way to retry sending a failed report (both Editor and Subscriber apps).  This will only attempt to resend to users who have not yet received it.

The Reporting Service will now retry X times to send an email.  Each time it will wait X milliseconds before the next attempt.  A failure to send to any subscriber will place the report back in the queue to retry automatically X times.

## Summary

- Updated Editor app
- Updated Subscriber app
- Updated Reporting Service
- Fixed a few UI bugs

## Subscriber Retry Send

![image](https://github.com/user-attachments/assets/608f6d28-5fb4-42f5-b8b0-b412710edbda)
