### PR TITLE
TNO-3016 Fix exclude content filters

### DIFF
--- a/libs/net/dal/Services/ReportService.cs
+++ b/libs/net/dal/Services/ReportService.cs
@@ -827,7 +827,7 @@ public class ReportService : BaseService<Report, int>, IReportService
                 if (sectionSettings.RemoveDuplicates)
                     query = query.Where(fc => !excludeAboveSectionContentIds.Contains(fc.ContentId));
 
-                if (excludeContentIds.Any() && !sectionSettings.OverrideExcludeHistorical)
+                if (excludeContentIds.Any())
                     query = query.Where(fc => !excludeContentIds.Contains(fc.ContentId));
 
                 var content = query
@@ -851,9 +851,9 @@ public class ReportService : BaseService<Report, int>, IReportService
 
                 // Modify the query to exclude content.
                 var excludeOnlyTheseContentIds = excludeContentIds.Any() && !sectionSettings.OverrideExcludeHistorical ? excludeContentIds : Array.Empty<long>();
-                var excludeAboveAndHistorical = sectionSettings.RemoveDuplicates
+                var excludeAboveAndHistorical = sectionSettings.OverrideExcludeHistorical
                     ? excludeOnlyTheseContentIds.AppendRange(excludeAboveSectionContentIds).Distinct().ToArray()
-                    : Array.Empty<long>();
+                    : excludeOnlyTheseContentIds;
                 var query = excludeAboveAndHistorical.Any()
                     ? section.Filter.Query.AddExcludeContent(excludeAboveAndHistorical)
                     : section.Filter.Query;


### PR DESCRIPTION
There are two fixes:
On line 830 there's a check on the section setting OverrideExcludeHistorical, when there's nothing to do with the exclude report content. So the feature is controlled only by the content setting ExcludeReports.
This fixes the reports using folders as data source.

On the line 854, there was a check that I believe was include by mistake on sectionSettings.RemoveDuplicates, that should be sectionSettings.OverrideExcludeHistorical (since the array is called excludeAboveAndHistorical), and also another problem that the on false was returning an empty array, and was overwriting the content that should be excluded by the excludeOnlyTheseContentIds.
This fixes the reports using filters as data source.

![image](https://github.com/user-attachments/assets/c735fe33-407c-47e1-8e2a-e5fb17a2619f)
Report used to test content to be excluded.

![image](https://github.com/user-attachments/assets/55495790-334a-4e40-96de-6895f575d9bc)
Option to exclude report empty
![image](https://github.com/user-attachments/assets/5962a1e5-7c66-45ea-9fc6-8db582b243f7)
Content

![image](https://github.com/user-attachments/assets/d4885c16-a831-401a-a59a-07c4af8b548a)
Option to exclude report filled
![image](https://github.com/user-attachments/assets/b9e9f33a-b8fd-4345-b9a7-49947df3eabf)
Content