### PR TITLE
Elastic Info - Small Bug

### DIFF
--- a/app/subscriber/src/features/search-page/components/advanced-search/components/ElasticQueryHelp.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/components/ElasticQueryHelp.tsx
@@ -27,10 +27,10 @@ export const ElasticQueryHelp: React.FC<IElasticQueryHelpProps> = ({
       <Show visible={show}>
         <Draggable nodeRef={nodeRef}>
           <div ref={nodeRef}>
+            <Row>
+              <FaX onClick={() => setShow(false)} className="close-icon" />
+            </Row>
             <Show visible={queryType === 'simple-query-string'}>
-              <Row>
-                <FaX onClick={() => setShow(false)} className="close-icon" />
-              </Row>
               <Col>
                 The keywords query supports the following operators:
                 <ul>


### PR DESCRIPTION
Had the exit button as a child of the `<Show>` for Simple Query, the exit button would not show for an Advanced Query. This fixes that.