### PR TITLE
[READY] TNO-2987: Rearragne View Content Header

### DIFF
--- a/app/subscriber/src/components/section/PageSection.tsx
+++ b/app/subscriber/src/components/section/PageSection.tsx
@@ -1,5 +1,4 @@
 import { navbarOptions } from 'components/navbar/NavbarItems';
-import { ContentActionBar } from 'components/tool-bar';
 import { useLocation } from 'react-router-dom';
 import { IContentModel, Row } from 'tno-core';
 

--- a/app/subscriber/src/components/section/PageSection.tsx
+++ b/app/subscriber/src/components/section/PageSection.tsx
@@ -54,10 +54,6 @@ export const PageSection: React.FC<IPageSectionProps> = ({
       onKeyDownCapture={onKeyDownCapture}
       {...rest}
     >
-      {/* TODO: This component is polluting the generic implementation.  It should be a separate component which include content related functionality */}
-      {includeContentActions && !!activeContent && (
-        <ContentActionBar className="content-actions" content={activeContent} viewingContent />
-      )}
       {header && (
         <Row className="page-section-title">
           {includeHeaderIcon && icon && <div className="page-icon">{icon}</div>}

--- a/app/subscriber/src/components/section/styled/PageSection.tsx
+++ b/app/subscriber/src/components/section/styled/PageSection.tsx
@@ -8,6 +8,17 @@ export const PageSection = styled.div<{ $ignoreMinWidth?: boolean; $ignoreLastCh
   align-self: stretch;
   min-width: ${(props) => (props.$ignoreMinWidth ? 'unset' : 'fit-content')};
 
+  .back-button {
+    margin-right: 1rem;
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  .content-headline {
+    margin-bottom: 0.25rem;
+  }
+
   @media (min-width: 500px) {
     margin: 0 0.75rem 0.75rem 0.75rem;
   }

--- a/app/subscriber/src/components/tool-bar/ContentActionBar.tsx
+++ b/app/subscriber/src/components/tool-bar/ContentActionBar.tsx
@@ -80,25 +80,6 @@ export const ContentActionBar: React.FC<IContentActionBarProps> = ({
 
   return (
     <styled.ContentActionBar className={className}>
-      <Show visible={viewingContent}>
-        <div className="action left-side-items" onClick={() => (onBack ? onBack() : navigate(-1))}>
-          <img
-            className="back-button"
-            src={'/assets/back-button.svg'}
-            alt="Back"
-            data-tooltip-id="back-button"
-          />
-          <Tooltip
-            clickable={false}
-            className="back-tooltip"
-            classNameArrow="back-tooltip-arrow"
-            id="back-button"
-            place="top"
-            noArrow={false}
-            content="Back"
-          />
-        </div>
-      </Show>
       <Show visible={!!onSelectAll}>
         <Row className="select-all">
           <div className="check-area">
@@ -113,16 +94,17 @@ export const ContentActionBar: React.FC<IContentActionBarProps> = ({
         <div className="arrow" />
       </Show>
       {showActionsItems && (
-        <div className="right-side-items">
+        <div className="content-buttons">
           <Row>
             {onReset && <ResetFilters onReset={onReset} />}
             <ShareMenu content={content} />
             {disableAddToFolder ? null : <AddToFolderMenu onClear={onClear} content={content} />}
             <AddToReportMenu content={content} onClear={onClear} />
             {!!removeFolderItem && <RemoveFromFolder onClick={removeFolderItem} />}
-            {viewingContent &&
+            {(viewingContent &&
               (userInfo?.roles.includes(Claim.administrator) ||
-                userInfo?.roles.includes(Claim.editor)) && (
+                userInfo?.roles.includes(Claim.editor))) ||
+              (true && (
                 <button
                   className="editor-button"
                   onClick={() => {
@@ -136,7 +118,7 @@ export const ContentActionBar: React.FC<IContentActionBarProps> = ({
                   <FaArrowUpRightFromSquare />
                   Edit Story
                 </button>
-              )}
+              ))}
           </Row>
         </div>
       )}

--- a/app/subscriber/src/components/tool-bar/ContentActionBar.tsx
+++ b/app/subscriber/src/components/tool-bar/ContentActionBar.tsx
@@ -1,9 +1,7 @@
 import { ShareMenu } from 'components/share-menu';
 import React, { useState } from 'react';
 import { FaArrowUpRightFromSquare } from 'react-icons/fa6';
-import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
-import { Tooltip } from 'react-tooltip';
 import { useLookup, useSettings } from 'store/hooks';
 import { useAppStore } from 'store/slices';
 import { Checkbox, Claim, IContentModel, Row, Settings, Show } from 'tno-core';
@@ -41,7 +39,6 @@ export const ContentActionBar: React.FC<IContentActionBarProps> = ({
   className,
   content,
   viewingContent,
-  onBack,
   onSelectAll,
   isSelectAllChecked,
   onClear,
@@ -49,7 +46,6 @@ export const ContentActionBar: React.FC<IContentActionBarProps> = ({
   removeFolderItem,
   disableAddToFolder,
 }) => {
-  const navigate = useNavigate();
   const [{ frontPageImagesMediaTypeId, settings, isReady }] = useLookup();
   const { editorUrl } = useSettings();
   const [{ userInfo }] = useAppStore();
@@ -101,10 +97,9 @@ export const ContentActionBar: React.FC<IContentActionBarProps> = ({
             {disableAddToFolder ? null : <AddToFolderMenu onClear={onClear} content={content} />}
             <AddToReportMenu content={content} onClear={onClear} />
             {!!removeFolderItem && <RemoveFromFolder onClick={removeFolderItem} />}
-            {(viewingContent &&
+            {viewingContent &&
               (userInfo?.roles.includes(Claim.administrator) ||
-                userInfo?.roles.includes(Claim.editor))) ||
-              (true && (
+                userInfo?.roles.includes(Claim.editor)) && (
                 <button
                   className="editor-button"
                   onClick={() => {
@@ -118,7 +113,7 @@ export const ContentActionBar: React.FC<IContentActionBarProps> = ({
                   <FaArrowUpRightFromSquare />
                   Edit Story
                 </button>
-              ))}
+              )}
           </Row>
         </div>
       )}

--- a/app/subscriber/src/components/tool-bar/ContentActionBar.tsx
+++ b/app/subscriber/src/components/tool-bar/ContentActionBar.tsx
@@ -75,7 +75,7 @@ export const ContentActionBar: React.FC<IContentActionBarProps> = ({
   }, [frontPageImagesMediaTypeId, settings, isReady, content]);
 
   return (
-    <styled.ContentActionBar className={className}>
+    <styled.ContentActionBar viewingContent={viewingContent} className={className}>
       <Show visible={!!onSelectAll}>
         <Row className="select-all">
           <div className="check-area">

--- a/app/subscriber/src/components/tool-bar/styled/ContentActionBar.tsx
+++ b/app/subscriber/src/components/tool-bar/styled/ContentActionBar.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { Row } from 'tno-core';
 
-export const ContentActionBar = styled(Row)`
+export const ContentActionBar = styled(Row)<{ viewingContent?: boolean }>`
   &.search {
     .check-area {
       margin-left: 1em;
@@ -45,7 +45,7 @@ export const ContentActionBar = styled(Row)`
 
   .content-buttons {
     color: ${(props) => props.theme.css.btnBkPrimary};
-    width: 100%;
+    width: ${(props) => (props.viewingContent ? '100%' : 'auto')};
     @media (max-width: 768px) {
       span {
         display: none;

--- a/app/subscriber/src/components/tool-bar/styled/ContentActionBar.tsx
+++ b/app/subscriber/src/components/tool-bar/styled/ContentActionBar.tsx
@@ -43,8 +43,9 @@ export const ContentActionBar = styled(Row)`
     }
   }
 
-  .right-side-items {
+  .content-buttons {
     color: ${(props) => props.theme.css.btnBkPrimary};
+    width: 100%;
     @media (max-width: 768px) {
       span {
         display: none;
@@ -53,13 +54,13 @@ export const ContentActionBar = styled(Row)`
     animation: fade-in 0.5s linear;
   }
   .editor-button {
+    margin-left: auto;
     display: flex;
     svg {
       height: 12px;
       width: 12px;
     }
     align-items: center;
-    margin-right: 1em;
     svg {
       margin-right: 0.25em;
     }

--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -267,10 +267,8 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent, act
   //Remove HTML tags, square brackets and line breaks before comparison.
   const cleanString = (str: string | undefined) => str?.replace(/<[^>]*>?|\[|\]|\n/gm, '').trim();
 
-  const formattedHeadline = React.useMemo(
-    () => formatSearch(content?.headline ?? '', filter),
-    [content?.headline, filter],
-  );
+  console.log(activeContent);
+
   const formattedBody = React.useMemo(
     () => formatSearch(content?.body?.replace(/\n+/g, '<br><br>') ?? '', filter),
     [content?.body, filter],
@@ -323,7 +321,7 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent, act
           )}
         </Row>
       </Bar>
-      <ContentActionBar className="actions" content={activeContent ?? []} viewingContent />
+      {!!content && <ContentActionBar className="actions" content={[content]} viewingContent />}
       <Show visible={!!avStream && isAV}>
         <Row justifyContent="center">
           <Show visible={isProcessing}>

--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -294,7 +294,6 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent, act
 
   return (
     <styled.ViewContent className={`${!!popout && 'popout'}`}>
-      <div className="headline">{formattedHeadline}</div>
       <Bar className="info-bar" vanilla>
         <Show visible={!!content?.byline}>
           <div className="byline">{`BY ${content?.byline}`}</div>
@@ -324,6 +323,7 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent, act
           )}
         </Row>
       </Bar>
+      <ContentActionBar className="actions" content={activeContent ?? []} viewingContent />
       <Show visible={!!avStream && isAV}>
         <Row justifyContent="center">
           <Show visible={isProcessing}>

--- a/app/subscriber/src/features/content/view-content/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/ViewContent.tsx
@@ -267,8 +267,6 @@ export const ViewContent: React.FC<IViewContentProps> = ({ setActiveContent, act
   //Remove HTML tags, square brackets and line breaks before comparison.
   const cleanString = (str: string | undefined) => str?.replace(/<[^>]*>?|\[|\]|\n/gm, '').trim();
 
-  console.log(activeContent);
-
   const formattedBody = React.useMemo(
     () => formatSearch(content?.body?.replace(/\n+/g, '<br><br>') ?? '', filter),
     [content?.body, filter],

--- a/app/subscriber/src/features/content/view-content/styled/ViewContent.tsx
+++ b/app/subscriber/src/features/content/view-content/styled/ViewContent.tsx
@@ -44,9 +44,6 @@ export const ViewContent = styled.div`
     }
   }
   .info-bar {
-    /* negative margins to bypass parent padding (PageSection) */
-    margin-left: -1.25em;
-    margin-right: -1.25em;
     padding-left: 1.25em;
     padding-right: 1.25em;
     font-size: 0.9rem;

--- a/app/subscriber/src/features/landing/Landing.tsx
+++ b/app/subscriber/src/features/landing/Landing.tsx
@@ -13,12 +13,14 @@ import { MyMinister } from 'features/my-minister/MyMinister';
 import { MyProducts } from 'features/my-products';
 import { MySearches } from 'features/my-searches';
 import { PressGallery } from 'features/press-gallery';
+import { formatSearch } from 'features/search-page/utils';
 import { MyMinisterSettings } from 'features/settings';
 import { TodaysCommentary } from 'features/todays-commentary';
 import { TodaysFrontPages } from 'features/todays-front-pages';
 import { TopStories } from 'features/top-stories';
 import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useContent } from 'store/hooks';
 import useMobile from 'store/hooks/app/useMobile';
 import { Col, IContentModel, Row, Show } from 'tno-core';
 
@@ -33,6 +35,11 @@ export const Landing: React.FC = () => {
   const [activeItem, setActiveItem] = React.useState<INavbarOptionItem | undefined>(
     NavbarOptions.home,
   );
+  const [
+    {
+      search: { filter },
+    },
+  ] = useContent();
   const isMobile = useMobile();
   const navigate = useNavigate();
   /* active content will be stored from this context in order to inject into subsequent components */
@@ -100,7 +107,7 @@ export const Landing: React.FC = () => {
                         onClick={() => navigate(-1)}
                       />
                       <span className="content-headline">
-                        {activeContent && activeContent[0]?.headline}
+                        {activeContent && formatSearch(activeContent[0].headline, filter)}
                       </span>
                     </Row>
                   </Show>

--- a/app/subscriber/src/features/landing/Landing.tsx
+++ b/app/subscriber/src/features/landing/Landing.tsx
@@ -18,7 +18,7 @@ import { TodaysCommentary } from 'features/todays-commentary';
 import { TodaysFrontPages } from 'features/todays-front-pages';
 import { TopStories } from 'features/top-stories';
 import React from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import useMobile from 'store/hooks/app/useMobile';
 import { Col, IContentModel, Row, Show } from 'tno-core';
 
@@ -34,6 +34,7 @@ export const Landing: React.FC = () => {
     NavbarOptions.home,
   );
   const isMobile = useMobile();
+  const navigate = useNavigate();
   /* active content will be stored from this context in order to inject into subsequent components */
   const [activeContent, setActiveContent] = React.useState<IContentModel[]>();
   const [isFullScreen, setIsFullScreen] = React.useState(false);
@@ -88,6 +89,20 @@ export const Landing: React.FC = () => {
                     {activeItem === NavbarOptions.settings
                       ? 'Settings | My Minister'
                       : activeItem?.label}
+                  </Show>
+                  <Show visible={!activeItem && !!activeContent}>
+                    <Row>
+                      <img
+                        className="back-button"
+                        src={'/assets/back-button.svg'}
+                        alt="Back"
+                        data-tooltip-id="back-button"
+                        onClick={() => navigate(-1)}
+                      />
+                      <span className="content-headline">
+                        {activeContent && activeContent[0]?.headline}
+                      </span>
+                    </Row>
                   </Show>
                   {!!activeItem?.reduxFilterStore && (
                     <>


### PR DESCRIPTION
Cleaned up the header of `ViewContent` to match Bobbi's mockup.

![image](https://github.com/user-attachments/assets/36df9678-4992-4bfc-a569-e25158bf37bf)
