### PR TITLE
Prevent multiple notification in indexing service.

### DIFF
--- a/services/net/indexing/IndexingManager.cs
+++ b/services/net/indexing/IndexingManager.cs
@@ -46,7 +46,7 @@ public class IndexingManager : ServiceManager<IndexingOptions>
     protected ElasticsearchClient Client { get; private set; }
 
     private readonly IMemoryCache _cache;
-    private const string CacheKeyPrefix = "IndexedContent_";
+    private const string CacheKeyPrefix = "NotificationContent_";
     private const int CacheExpirationSecond = 5;
     #endregion
 

--- a/services/net/indexing/IndexingManager.cs
+++ b/services/net/indexing/IndexingManager.cs
@@ -47,7 +47,8 @@ public class IndexingManager : ServiceManager<IndexingOptions>
 
     private readonly IMemoryCache _cache;
     private const string CacheKeyPrefix = "NotificationContent_";
-    private const int CacheExpirationSecond = 5;
+    private const int CacheExpirationSeconds = 5;
+
     #endregion
 
     #region Constructors
@@ -482,8 +483,12 @@ public class IndexingManager : ServiceManager<IndexingOptions>
                 _ = await this.Api.SendMessageAsync(notification)
                     ?? throw new HttpClientRequestException($"Failed to receive result from Kafka when sending message.  Topic: {this.Options.NotificationTopic}, Content ID: {content.Id}");
 
+                var cacheEntryOptions = new MemoryCacheEntryOptions()
+                    .SetAbsoluteExpiration(TimeSpan.FromSeconds(CacheExpirationSeconds))
+                    .SetSize(1);
+
                 // add to cache
-                _cache.Set(cacheKey, true, TimeSpan.FromSeconds(CacheExpirationSecond));
+                _cache.Set(cacheKey, true, cacheEntryOptions);
                 this.Logger.LogInformation($"Notification for Content {content.Id} was sent, added to cache.");
             }
         }

--- a/services/net/indexing/IndexingService.cs
+++ b/services/net/indexing/IndexingService.cs
@@ -46,7 +46,12 @@ public class IndexingService : KafkaConsumerService
             .AddSingleton<IKafkaAdmin, KafkaAdmin>()
             .AddTransient<IKafkaListener<string, IndexRequestModel>, KafkaListener<string, IndexRequestModel>>()
             .AddSingleton<IServiceManager, IndexingManager>()
-            .AddMemoryCache(); //  MemoryCache 
+            .AddMemoryCache(
+                options =>
+                {
+                    options.SizeLimit = 100;
+                }
+            ); //  MemoryCache
 
         // TODO: Figure out how to validate without resulting in aggregating the config values.
         // services.AddOptions<IndexingOptions>()

--- a/services/net/indexing/IndexingService.cs
+++ b/services/net/indexing/IndexingService.cs
@@ -1,5 +1,6 @@
 using Confluent.Kafka;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Caching.Memory;
 using TNO.Kafka;
 using TNO.Kafka.Models;
 using TNO.Services.Indexing.Config;
@@ -44,7 +45,8 @@ public class IndexingService : KafkaConsumerService
             .Configure<AdminClientConfig>(this.Configuration.GetSection("Kafka:Admin"))
             .AddSingleton<IKafkaAdmin, KafkaAdmin>()
             .AddTransient<IKafkaListener<string, IndexRequestModel>, KafkaListener<string, IndexRequestModel>>()
-            .AddSingleton<IServiceManager, IndexingManager>();
+            .AddSingleton<IServiceManager, IndexingManager>()
+            .AddMemoryCache(); //  MemoryCache 
 
         // TODO: Figure out how to validate without resulting in aggregating the config values.
         // services.AddOptions<IndexingOptions>()


### PR DESCRIPTION
In 5 seconds not send a same notification.
Test that it works according to the logic that was designed.

some logs:

```
2024-09-04 00:11:48 dbug: TNO.Core.Http.OpenIdConnectRequestClient[0]
2024-09-04 00:11:48       HTTP request made: POST:http://host.docker.internal:40010/api/kafka/producers/notification (User-Agent: TNO)
2024-09-04 00:11:48 info: TNO.Services.Indexing.IndexingManager[0]
2024-09-04 00:11:48       Notification for Content 1061 was sent, added to cache.
.....
2024-09-04 00:11:52 info: TNO.Services.Indexing.IndexingManager[0]
2024-09-04 00:11:52       Notification for Content 1061 was recently sent, skipping this notification request.
2024-09-04 00:11:52 dbug: TNO.Services.Indexing.IndexingManager[0]
```