### PR TITLE
override script to backup to s3 in dev

### DIFF
--- a/openshift/kustomize/cron/backup/overlays/dev/kustomization.yaml
+++ b/openshift/kustomize/cron/backup/overlays/dev/kustomization.yaml
@@ -23,3 +23,63 @@ patches:
       - op: replace
         path: /spec/jobTemplate/spec/template/spec/containers/0/resources/limits/memory
         value: 250Mi
+      - op: add
+        path: /spec/jobTemplate/spec/template/spec/containers/0/env
+        value:
+          - name: S3_ENDPOINT
+            valueFrom:
+              secretKeyRef:
+                name: s3-backup-credentials-dev
+                key: S3_ENDPOINT
+          - name: S3_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: s3-backup-credentials-dev
+                key: S3_ACCESS_KEY
+          - name: S3_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: s3-backup-credentials-dev
+                key: S3_SECRET_KEY
+          - name: S3_BUCKET
+            valueFrom:
+              secretKeyRef:
+                name: s3-backup-credentials-dev
+                key: S3_BUCKET
+
+  - target:
+      kind: ConfigMap
+      name: backup-service
+    patch: |-
+      - op: replace
+        path: /data/entrypoint.sh
+        value: |
+          #!/bin/bash
+          cd /mnt/backup
+
+          # Zip up all files in the specified directories.
+          DATE=$(date +"%Y-%m-%d-%T")
+          tar -zcvf $DATE-ingest.tar.gz /mnt/ingest
+          tar -zcvf $DATE-storage.tar.gz /mnt/data
+
+          # Delete older backups.
+          find . -type f -name "*.tar.gz" -mindepth 1 -mtime +2 -delete
+
+          echo "API storage backup to s3 started"
+
+          # install mc
+          curl https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc
+          chmod +x /usr/local/bin/mc
+          
+          # set minio client
+          mc alias set mys3 $S3_ENDPOINT $S3_ACCESS_KEY $S3_SECRET_KEY
+          
+          # define source and destination directory
+          SOURCE_DIR="/mnt/data"
+          DEST_DIR="backups"
+          
+          # backup with mc mirror
+          mc mirror --overwrite --preserve $SOURCE_DIR mys3/$S3_BUCKET/$DEST_DIR
+          
+          echo "API storage backup to s3 completed"
+


### PR DESCRIPTION
It is similar to local process, but happens in dev namespace 

I have `s3-backup-credentials-dev` in dev secrete.

One thing I would like to double check, 

` 
SOURCE_DIR="/mnt/data"
`

and I saw 
```
  - name: api-storage
     mountPath: /mnt/data
```
Is this one correct that we want to backup?