### PR TITLE
Fix linked reports

### DIFF
--- a/api/net/Areas/Subscriber/Controllers/ReportController.cs
+++ b/api/net/Areas/Subscriber/Controllers/ReportController.cs
@@ -472,6 +472,7 @@ public class ReportController : ControllerBase
         var result = _reportService.GetAllContentInMyReports(user.Id);
         return new JsonResult(result);
     }
+
     /// <summary>
     /// send a notification to the subscription manager.
     /// </summary>
@@ -490,7 +491,7 @@ public class ReportController : ControllerBase
         var isSubscribed = report.SubscribersManyToMany.Any(s => s.IsSubscribed && s.UserId == user.Id);
         if (isSubscribed)
         {
-            _logger.LogInformation($"User is already subscribed to this report {report.Id}, no need to send a subscription request.");
+            _logger.LogInformation("User is already subscribed to this report {reportId}, no need to send a subscription request.", report.Id);
             return Ok();
         }
 
@@ -517,7 +518,7 @@ public class ReportController : ControllerBase
                 var email = new TNO.Ches.Models.EmailModel(_chesOptions.From, emailAddresses, subject, message.ToString());
                 var emailRequest = await _ches.SendEmailAsync(email);
 
-                _logger.LogInformation($"report subscription request email to [${productSubscriptionManagerEmail.Value}] queued: ${emailRequest.TransactionId}");
+                _logger.LogInformation("report subscription request email to [{email}] queued: {txtId}", productSubscriptionManagerEmail.Value, emailRequest.TransactionId);
 
             }
             else
@@ -554,11 +555,10 @@ public class ReportController : ControllerBase
         var isSubscribed = report.SubscribersManyToMany.Any(s => s.IsSubscribed && s.UserId == user.Id);
         if (!isSubscribed)
         {
-            _logger.LogInformation($"User is not subscribed to report {report.Id}, no need to send an unsubscription request.");
+            _logger.LogInformation("User is not subscribed to report {reportId}, no need to send an unsubscription request.", report.Id);
             return Ok();
 
         }
-
 
         StringBuilder message = new StringBuilder();
         message.AppendLine("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">");
@@ -582,7 +582,7 @@ public class ReportController : ControllerBase
                 var email = new TNO.Ches.Models.EmailModel(_chesOptions.From, emailAddresses, subject, message.ToString());
                 var emailRequest = await _ches.SendEmailAsync(email);
 
-                _logger.LogInformation($"Report unsubscription request email to [{productSubscriptionManagerEmail.Value}] queued: {emailRequest.TransactionId}");
+                _logger.LogInformation("Report unsubscription request email to [{email}] queued: {txtId}", productSubscriptionManagerEmail.Value, emailRequest.TransactionId);
             }
             else
             {
@@ -596,9 +596,5 @@ public class ReportController : ControllerBase
 
         return Ok();
     }
-
-
-
-
     #endregion
 }

--- a/app/subscriber/src/features/my-reports/edit/ReportEditContext.tsx
+++ b/app/subscriber/src/features/my-reports/edit/ReportEditContext.tsx
@@ -60,6 +60,10 @@ export interface IReportEditContext {
   setPreviewLastUpdatedOn: React.Dispatch<React.SetStateAction<string | undefined>>;
   testData: IReportInstanceContentModel[];
   regenerateTestData: () => void;
+  linkedReportContent: Record<string, IReportInstanceContentModel[]>;
+  setLinkedReportContent: React.Dispatch<
+    React.SetStateAction<Record<string, IReportInstanceContentModel[]>>
+  >;
 }
 
 /**
@@ -84,6 +88,8 @@ export const ReportEditContext = React.createContext<IReportEditContext>({
   setPreviewLastUpdatedOn: () => {},
   testData: [],
   regenerateTestData: () => {},
+  linkedReportContent: {},
+  setLinkedReportContent: () => {},
 });
 
 /**
@@ -133,6 +139,7 @@ export const ReportEditContextProvider: React.FC<IReportEditContextProviderProps
 
   const [active, setActive] = React.useState<string>();
   const [activeRow, setActiveRow] = React.useState<IReportInstanceContentForm>();
+  const [linkedReportContent, setLinkedReportContent] = React.useState({});
 
   const instance = values.instances.length ? values.instances[0] : undefined;
   const [activeInstance, setActiveInstance] = React.useState<IReportInstanceModel>();
@@ -279,6 +286,8 @@ export const ReportEditContextProvider: React.FC<IReportEditContextProviderProps
         setPreviewLastUpdatedOn,
         testData,
         regenerateTestData,
+        linkedReportContent,
+        setLinkedReportContent,
       }}
     >
       {children}


### PR DESCRIPTION
Report charts that use a linked report for data, can now fetch that data in the UI.

## Subscriber Report Charts

![image](https://github.com/user-attachments/assets/797c7776-8194-4cae-9a27-7476add136cf)
