### PR TITLE
Fix duplicate report content

### DIFF
--- a/app/subscriber/src/features/my-reports/edit/settings/data-sources/ReportSectionGallery.tsx
+++ b/app/subscriber/src/features/my-reports/edit/settings/data-sources/ReportSectionGallery.tsx
@@ -58,20 +58,18 @@ export const ReportSectionGallery = React.forwardRef<HTMLDivElement, IReportSect
               </span>
             </Row>
           </Show>
-          <Show visible={!!section.folderId || !!section.linkedReportId}>
-            <Row>
-              <FormikCheckbox
-                name={`sections.${index}.settings.overrideExcludeHistorical`}
-                label={`Include all content from linked ${
-                  section.folderId ? 'folder' : 'report'
-                } even if in prior report`}
-              />
-              <span className="info">
-                This overrides the report option "Exclude stories that have been sent out in
-                previous report" for this section only.
-              </span>
-            </Row>
-          </Show>
+          <Row>
+            <FormikCheckbox
+              name={`sections.${index}.settings.overrideExcludeHistorical`}
+              label={`Include all content from linked ${
+                section.folderId ? 'folder' : 'report'
+              } even if in prior report`}
+            />
+            <span className="info">
+              This overrides the report option "Exclude stories that have been sent out in previous
+              report" for this section only.
+            </span>
+          </Row>
           <FormikCheckbox
             name={`sections.${index}.settings.hideEmpty`}
             label="Hide this section in the report when empty"

--- a/app/subscriber/src/features/my-reports/edit/settings/data-sources/ReportSectionMediaAnalytics.tsx
+++ b/app/subscriber/src/features/my-reports/edit/settings/data-sources/ReportSectionMediaAnalytics.tsx
@@ -52,20 +52,18 @@ export const ReportSectionMediaAnalytics = React.forwardRef<
             </span>
           </Row>
         </Show>
-        <Show visible={!!section.folderId || !!section.linkedReportId}>
-          <Row>
-            <FormikCheckbox
-              name={`sections.${index}.settings.overrideExcludeHistorical`}
-              label={`Include all content from linked ${
-                section.folderId ? 'folder' : 'report'
-              } even if in prior report`}
-            />
-            <span className="info">
-              This overrides the report option "Exclude stories that have been sent out in previous
-              report" for this section only.
-            </span>
-          </Row>
-        </Show>
+        <Row>
+          <FormikCheckbox
+            name={`sections.${index}.settings.overrideExcludeHistorical`}
+            label={`Include all content from linked ${
+              section.folderId ? 'folder' : 'report'
+            } even if in prior report`}
+          />
+          <span className="info">
+            This overrides the report option "Exclude stories that have been sent out in previous
+            report" for this section only.
+          </span>
+        </Row>
         <FormikCheckbox
           name={`sections.${index}.settings.direction`}
           label="Horizontally align the next media analytic chart"

--- a/app/subscriber/src/features/my-reports/edit/settings/template/ReportSectionContent.tsx
+++ b/app/subscriber/src/features/my-reports/edit/settings/template/ReportSectionContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Col, FormikCheckbox, FormikText, Row, Show } from 'tno-core';
+import { Col, FormikCheckbox, FormikText, Row } from 'tno-core';
 
 import { useReportEditContext } from '../../ReportEditContext';
 
@@ -34,20 +34,18 @@ export const ReportSectionContent = React.forwardRef<HTMLDivElement, IReportSect
               not apply to charts that link to other reports)
             </span>
           </Row>
-          <Show visible={!!section.folderId || !!section.linkedReportId}>
-            <Row>
-              <FormikCheckbox
-                name={`sections.${index}.settings.overrideExcludeHistorical`}
-                label={`Include all content from linked ${
-                  section.folderId ? 'folder' : 'report'
-                } even if in prior report`}
-              />
-              <span className="info">
-                This overrides the report option "Exclude stories that have been sent out in
-                previous report" for this section only.
-              </span>
-            </Row>
-          </Show>
+          <Row>
+            <FormikCheckbox
+              name={`sections.${index}.settings.overrideExcludeHistorical`}
+              label={`Include all content from linked ${
+                section.folderId ? 'folder' : 'report'
+              } even if in prior report`}
+            />
+            <span className="info">
+              This overrides the report option "Exclude stories that have been sent out in previous
+              report" for this section only.
+            </span>
+          </Row>
           <FormikCheckbox
             name={`sections.${index}.settings.hideEmpty`}
             label="Hide this section in the report when empty"

--- a/app/subscriber/src/features/my-reports/edit/settings/template/ReportSectionGallery.tsx
+++ b/app/subscriber/src/features/my-reports/edit/settings/template/ReportSectionGallery.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Col, FormikCheckbox, FormikSelect, FormikText, OptionItem, Row, Show } from 'tno-core';
+import { Col, FormikCheckbox, FormikSelect, FormikText, OptionItem, Row } from 'tno-core';
 
 import { useReportEditContext } from '../../ReportEditContext';
 
@@ -34,20 +34,18 @@ export const ReportSectionGallery = React.forwardRef<HTMLDivElement, IReportSect
                 (does not apply to charts that link to other reports)
               </span>
             </Row>
-            <Show visible={!!section.folderId || !!section.linkedReportId}>
-              <Row>
-                <FormikCheckbox
-                  name={`sections.${index}.settings.overrideExcludeHistorical`}
-                  label={`Include all content from linked ${
-                    section.folderId ? 'folder' : 'report'
-                  } even if in prior report`}
-                />
-                <span className="info">
-                  This overrides the report option "Exclude stories that have been sent out in
-                  previous report" for this section only.
-                </span>
-              </Row>
-            </Show>
+            <Row>
+              <FormikCheckbox
+                name={`sections.${index}.settings.overrideExcludeHistorical`}
+                label={`Include all content from linked ${
+                  section.folderId ? 'folder' : 'report'
+                } even if in prior report`}
+              />
+              <span className="info">
+                This overrides the report option "Exclude stories that have been sent out in
+                previous report" for this section only.
+              </span>
+            </Row>
             <FormikCheckbox
               name={`sections.${index}.settings.hideEmpty`}
               label="Hide this section in the report when empty"

--- a/app/subscriber/src/features/my-reports/edit/settings/template/ReportSectionMediaAnalytics.tsx
+++ b/app/subscriber/src/features/my-reports/edit/settings/template/ReportSectionMediaAnalytics.tsx
@@ -140,20 +140,18 @@ export const ReportSectionMediaAnalytics = React.forwardRef<
                   </span>
                 </Row>
               </Show>
-              <Show visible={!!section.folderId || !!section.linkedReportId}>
-                <Row>
-                  <FormikCheckbox
-                    name={`sections.${index}.settings.overrideExcludeHistorical`}
-                    label={`Include all content from linked ${
-                      section.folderId ? 'folder' : 'report'
-                    } even if in prior report`}
-                  />
-                  <span className="info">
-                    This overrides the report option "Exclude stories that have been sent out in
-                    previous report" for this section only.
-                  </span>
-                </Row>
-              </Show>
+              <Row>
+                <FormikCheckbox
+                  name={`sections.${index}.settings.overrideExcludeHistorical`}
+                  label={`Include all content from linked ${
+                    section.folderId ? 'folder' : 'report'
+                  } even if in prior report`}
+                />
+                <span className="info">
+                  This overrides the report option "Exclude stories that have been sent out in
+                  previous report" for this section only.
+                </span>
+              </Row>
               <FormikCheckbox
                 name={`sections.${index}.settings.direction`}
                 label="Horizontally align the next media analytic chart"


### PR DESCRIPTION
Reports will not include duplicate content, and they will also exclude linked report content when configured to do so.