### PR TITLE
Fix schedule concurrency errors

### DIFF
--- a/libs/net/services/Helpers/IApiService.cs
+++ b/libs/net/services/Helpers/IApiService.cs
@@ -15,7 +15,15 @@ public interface IApiService
     #endregion
 
     #region Helper Methods
-    public Task<T> HandleRequestFailure<T>(Func<Task<T>> callbackDelegate, bool ignoreError, T defaultResponse);
+    Task<T> HandleRequestFailure<T>(Func<Task<T>> callbackDelegate, bool ignoreError, T defaultResponse);
+
+    /// <summary>
+    /// Keep trying a request if the failure is caused by an optimistic concurrency error.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="callbackDelegate"></param>
+    /// <returns></returns>
+    Task<T> HandleConcurrencyAsync<T>(Func<Task<T>> callbackDelegate);
     #endregion
 
     #region Kafka
@@ -436,8 +444,9 @@ public interface IApiService
     /// Make a request to the API to update the event schedule for the specified 'model'.
     /// </summary>
     /// <param name="model"></param>
+    /// <param name="retry"></param>
     /// <returns></returns>
-    Task<API.Areas.Services.Models.EventSchedule.EventScheduleModel?> UpdateEventScheduleAsync(API.Areas.Services.Models.EventSchedule.EventScheduleModel model);
+    Task<API.Areas.Services.Models.EventSchedule.EventScheduleModel?> UpdateEventScheduleAsync(API.Areas.Services.Models.EventSchedule.EventScheduleModel model, bool retry = true);
     #endregion
 
     #region AV Overview


### PR DESCRIPTION
A common error is related to updated the schedule event.  It will often throw an optimistic concurrency error due to various race conditions.  This new code will attempt to resolve that type of issue by fetch the latest, reapplying changes and then saving.

## Summary

- Updated Scheduler Service
- Updated Event Handler Service (for clearing folders)
- Updated Reporting Service