### PR TITLE
Fix report section

### DIFF
--- a/app/editor/src/features/admin/report-templates/templates/body/CustomReport.cshtml
+++ b/app/editor/src/features/admin/report-templates/templates/body/CustomReport.cshtml
@@ -20,7 +20,7 @@
 <center><div style="margin-bottom: 25px; color:#FFFFF6;"><img src="@($"{SubscriberAppUrl}assets/reports/MMI_logo_white.png")" width="600"></div></center>
 
 @* This is the Do Not Forward disclaimer *@
-<div><p style="background-color: #FFF7E1; color: #876503; text-align: center; font-size: 1em; font-weight: 700; line-height: 1.1em; letter-spacing: 0.08px; padding: 10px 0px; margin: 6px 0px 20px 0px;">DO NOT FORWARD THIS EMAIL TO ANYONE</p></div>
+<div><p style="background-color: #FFF7E1; color: #876503; text-align: center; font-size: 1em; font-weight: 700; line-height: 1.1em; letter-spacing: 0.08px; padding: 10px 0px; margin: 6px 0px 20px 0px;">Reading this report on your phone? Struggling with navigation? Email <a href="mailto:scott.ryckman@gov.bc.ca">Scott Ryckman</a> to switch to the iPhone friendly version. </p></div>
 
 <a id="top" name="top">
   <h1 style="color: #971D29; font-size: 30px; line-height: 34px; margin: 0px; border-bottom: #971D29 1px solid;">@Settings.Subject.Text</h1>
@@ -83,7 +83,7 @@
       var tocCount = 0;
       @foreach (var tableSection in Sections.Where(s => new [] {ReportSectionType.Content, ReportSectionType.Gallery}.Contains(s.Value.SectionType)))
       {
-        if (!tableSection.Value.Settings.HideEmpty || tableSection.Value.Content.Any())
+        if ((!tableSection.Value.Settings.HideEmpty || tableSection.Value.Content.Any()) && tableSection.Value.IsEnabled)
         {
           <div id="toc" name="toc">
             <div style="border-bottom:1px solid #675f62; margin: 2px 0 4px 0;">

--- a/app/subscriber/src/features/my-reports/edit/settings/template/ReportSectionContent.tsx
+++ b/app/subscriber/src/features/my-reports/edit/settings/template/ReportSectionContent.tsx
@@ -25,6 +25,13 @@ export const ReportSectionContent = React.forwardRef<HTMLDivElement, IReportSect
         <Col className="frm-in">
           <label>Report Section Options</label>
           <Row>
+            <FormikCheckbox name={`sections.${index}.isEnabled`} label="Section is visible" />
+            <span className="info">
+              When hidden the content is still part of the report, but the stories are not displayed
+              in the table of contents, or in their own section.
+            </span>
+          </Row>
+          <Row>
             <FormikCheckbox
               name={`sections.${index}.settings.removeDuplicates`}
               label="Remove duplicate stories"

--- a/app/subscriber/src/features/my-reports/edit/settings/template/ReportSectionGallery.tsx
+++ b/app/subscriber/src/features/my-reports/edit/settings/template/ReportSectionGallery.tsx
@@ -25,6 +25,13 @@ export const ReportSectionGallery = React.forwardRef<HTMLDivElement, IReportSect
           <Col className="frm-in" flex="1">
             <label>Report Section Options</label>
             <Row>
+              <FormikCheckbox name={`sections.${index}.isEnabled`} label="Section is visible" />
+              <span className="info">
+                When hidden the content is still part of the report, but the stories are not
+                displayed in the table of contents, or in their own section.
+              </span>
+            </Row>
+            <Row>
               <FormikCheckbox
                 name={`sections.${index}.settings.removeDuplicates`}
                 label="Remove duplicate stories"

--- a/app/subscriber/src/features/my-reports/edit/settings/template/ReportSectionMediaAnalytics.tsx
+++ b/app/subscriber/src/features/my-reports/edit/settings/template/ReportSectionMediaAnalytics.tsx
@@ -128,6 +128,13 @@ export const ReportSectionMediaAnalytics = React.forwardRef<
             </Col>
             <Col className="frm-in">
               <label>Report Section Options</label>
+              <Row>
+                <FormikCheckbox name={`sections.${index}.isEnabled`} label="Section is visible" />
+                <span className="info">
+                  When hidden the content is still part of the report, but the stories are not
+                  displayed in the table of contents, or in their own section.
+                </span>
+              </Row>
               <Show visible={!section.settings.useAllContent}>
                 <Row>
                   <FormikCheckbox

--- a/app/subscriber/src/features/my-reports/edit/settings/template/ReportSectionText.tsx
+++ b/app/subscriber/src/features/my-reports/edit/settings/template/ReportSectionText.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormikText, FormikWysiwyg } from 'tno-core';
+import { FormikCheckbox, FormikText, FormikWysiwyg, Row } from 'tno-core';
 
 export interface IReportSectionTextProps {
   index: number;
@@ -11,6 +11,13 @@ export const ReportSectionText = React.forwardRef<HTMLDivElement, IReportSection
       <>
         <FormikText name={`sections.${index}.settings.label`} label="Section heading:" />
         <FormikWysiwyg name={`sections.${index}.description`} label="Summary text:" />
+        <Row>
+          <FormikCheckbox name={`sections.${index}.isEnabled`} label="Section is visible" />
+          <span className="info">
+            When hidden the content is still part of the report, but the stories are not displayed
+            in the table of contents, or in their own section.
+          </span>
+        </Row>
       </>
     );
   },


### PR DESCRIPTION
When a report section was disabled in the Editor Admin it hid the section when generating the report.  However, the section still was visible in the Table of Contents, and also there was no way to edit that property in the Subscriber app.

## Summary

- Updated Subscriber app
- Provided way for users to hide/show report sections
- When section is hidden it will also not show up in the table of contents

## Subscriber Report Admin

![image](https://github.com/user-attachments/assets/1d44473d-0e39-4f02-831a-3251183382a0)
