### PR TITLE
Fix keycloak sync issue

### DIFF
--- a/api/net/Areas/Admin/Controllers/UserController.cs
+++ b/api/net/Areas/Admin/Controllers/UserController.cs
@@ -132,12 +132,13 @@ public class UserController : ControllerBase
     [SwaggerOperation(Tags = new[] { "User" })]
     public async Task<IActionResult> UpdateAsync(UserModel model)
     {
-        if (!Guid.TryParse(model.Key, out Guid key)) throw new InvalidOperationException($"User key must be a guid: {model.Key}");
-
-        var kUser = await _keycloakService.GetUserAsync(key);
-        if (kUser != null)
+        if (Guid.TryParse(model.Key, out Guid key))
         {
-            await _keycloakHelper.UpdateUserRolesAsync(key, model.Roles.ToArray());
+            var kUser = await _keycloakService.GetUserAsync(key);
+            if (kUser != null)
+            {
+                await _keycloakHelper.UpdateUserRolesAsync(key, model.Roles.ToArray());
+            }
         }
 
         var user = _userService.UpdateDistributionList((Entities.User)model);

--- a/libs/net/keycloak/Partials/KeycloakServiceUsers.cs
+++ b/libs/net/keycloak/Partials/KeycloakServiceUsers.cs
@@ -1,11 +1,11 @@
-using TNO.Core.Extensions;
-using TNO.Keycloak.Extensions;
 using System;
 using System.Net.Http;
+using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
-using System.Net.Mime;
 using System.Web;
+using TNO.Core.Extensions;
+using TNO.Keycloak.Extensions;
 using TNO.Keycloak.Models;
 
 namespace TNO.Keycloak


### PR DESCRIPTION
Presently if a user account was originally created in the shared Keycloak realm it will have an invalid `key`.  The first time a user logs in that should automatically be resolved.  However, there are accounts that have not logged in since we migrated to the custom Keycloak realm.

When editing users in this state, it results in an error because their `key` is not a GUID.  The temporary fix is to simply not update keycloak when updating the user record.  When the user does login finally, it should sync correctly.

One new issue that doesn't makes sense is the user account `MMINDP1` with the email  `mmindp1@gov.bc.ca` doesn't exist in our custom Keycloak realm, yet Scott has said he has successfully logged in today...  I don't know how that can be, as there are no errors in the logs associated with this activity.