### PR TITLE
MMI-3095 cleanup junk upload files and prevent stream old file in editor

### DIFF
--- a/api/net/Areas/Editor/Controllers/ContentController.cs
+++ b/api/net/Areas/Editor/Controllers/ContentController.cs
@@ -531,7 +531,7 @@ public class ContentController : ControllerBase
         // If the content has a file reference, then update it.  Otherwise, add one.
         content.Version = version; // TODO: Handle concurrency before uploading the file as it will result in an orphaned file.
         if (content.FileReferences.Any()) await _fileReferenceService.UploadAsync(content, files.First(), _storageOptions.GetUploadPath());
-        else await _fileReferenceService.UploadAsync(new ContentFileReference(content, files.First()), _storageOptions.GetUploadPath());
+        else await _fileReferenceService.UploadCleanUpAsync(new ContentFileReference(content, files.First()), _storageOptions.GetUploadPath());
 
         if (_workOrderHelper.ShouldAutoTranscribe(content.Id)) await _workOrderHelper.RequestTranscriptionAsync(content.Id);
 

--- a/app/editor/src/features/content/form/hooks/useContentForm.ts
+++ b/app/editor/src/features/content/form/hooks/useContentForm.ts
@@ -209,7 +209,9 @@ export const useContentForm = ({
 
   const setAvStream = React.useCallback(() => {
     if (!!path) {
-      getStream(path)
+      const encodedPath = encodeURIComponent(path);
+
+      getStream(encodedPath)
         .then((result) => {
           setStream(
             !!result
@@ -223,6 +225,14 @@ export const useContentForm = ({
         .catch(() => {});
     }
   }, [getStream, fileReference?.contentType, path]);
+
+  React.useEffect(() => {
+    if (path && fileReference) {
+      setAvStream();
+    } else {
+      setStream(undefined);
+    }
+  }, [fileReference, path, setAvStream]);
 
   const handleSubmit = React.useCallback(
     async (
@@ -247,7 +257,6 @@ export const useContentForm = ({
           // TODO: Make it possible to upload on the initial save instead of a separate request.
           // Upload the file if one has been added.
           const content = await upload(contentResult, values.file);
-          setAvStream();
           result = toForm({ ...content, tonePools: values.tonePools });
         } else if (
           !originalId &&

--- a/app/editor/src/features/content/form/hooks/useContentForm.ts
+++ b/app/editor/src/features/content/form/hooks/useContentForm.ts
@@ -305,7 +305,6 @@ export const useContentForm = ({
       getSeries,
       navigate,
       series,
-      setAvStream,
       updateContent,
       upload,
       userId,

--- a/app/editor/src/features/content/form/hooks/useContentForm.ts
+++ b/app/editor/src/features/content/form/hooks/useContentForm.ts
@@ -224,15 +224,7 @@ export const useContentForm = ({
         })
         .catch(() => {});
     }
-  }, [getStream, fileReference?.contentType, path]);
-
-  React.useEffect(() => {
-    if (path && fileReference) {
-      setAvStream();
-    } else {
-      setStream(undefined);
-    }
-  }, [fileReference, path, setAvStream]);
+  }, [getStream, fileReference, path]);
 
   const handleSubmit = React.useCallback(
     async (

--- a/libs/net/dal/Services/FileReferenceService.cs
+++ b/libs/net/dal/Services/FileReferenceService.cs
@@ -118,7 +118,6 @@ public class FileReferenceService : BaseService<FileReference, long>, IFileRefer
                 var filesToDelete = Directory.GetFiles(directoryPath, $"{filePrefix}*", SearchOption.TopDirectoryOnly)
                 .Where(file => Path.GetFileNameWithoutExtension(file) == filePrefix);// find all files with the exact same prefix in the same directory
 
-                var deleteErrors = new List<string>();
 
                 // delete all files with the same prefix in the same directory
                 foreach (var file in filesToDelete)
@@ -130,16 +129,10 @@ public class FileReferenceService : BaseService<FileReference, long>, IFileRefer
                     catch (Exception ex)
                     {
                         // record error but continue
-                        deleteErrors.Add($"Failed to delete file {file}: {ex.Message}");
                         Logger.LogError(ex, "Failed to delete file {file}", file);
                     }
                 }
 
-                // if there are deletion errors, record a warning
-                if (deleteErrors.Any())
-                {
-                    Logger.LogWarning("Some files could not be deleted: {errors}", string.Join("; ", deleteErrors));
-                }
             }
         }
 

--- a/libs/net/dal/Services/Interfaces/IFileReferenceService.cs
+++ b/libs/net/dal/Services/Interfaces/IFileReferenceService.cs
@@ -12,6 +12,8 @@ public interface IFileReferenceService : IBaseService<FileReference, long>
 
     Task<FileReference> UploadAsync(Content content, IFormFile file, string folderPath);
 
+    Task<FileReference> UploadCleanUpAsync(ContentFileReference model, string folderPath);
+
     FileStream Download(FileReference entity, string folderPath);
 
     FileReference Attach(ContentFileReference model, string folderPath);


### PR DESCRIPTION
The Editors continuously creates junk files, sometimes uploading 8-10 GB in a week. Currently, my s3 moving system cannot track these files because their fileReference has already been deleted. If we don't control it, disk space will still be consumed and the purge program will be triggered. 
They will be like this
![image](https://github.com/user-attachments/assets/776986e7-a925-4a49-a7f6-15a2424711c6)

Here’s an explanation of my modifications and the root cause of the issue:
When uploading a new file and clicking "publish", in ContentService we delete the previous fileReference during this process, 

    oFileReferences.Except(updated.FileReferences).ForEach(a =>
        {
            context.Entry(a).State = EntityState.Deleted;
        });


we’re unable to remove the associated attachments. However, at this point, we haven’t yet uploaded the new file, so there’s no new fileReference either.

Afterward, in the content controller, there’s a check (`content.FileReferences.Any()`), which obviously will never be true in this scenario. Therefore, we go to enter the else logic that creates a new fileReference and file. So, I updated the method there to clean up junk files here, restricting it to a specific prefix in `UploadCleanUpAsync`
After thorough testing, we’ve been able to prevent the creation of junk files, and now each content item only have one attachment, this process is like replacing the file each time.
now we only have one file for each content
![image](https://github.com/user-attachments/assets/e028132f-ffb4-4aff-bea4-1a6512c6774e)

Additionally, during front-end testing, I noticed that the old code would immediately stream AV file after uploading, which introduced a delay. After publishing, it would also send a stream request for the old `fileReference` make a file not found message. Now, this has been only stream the new file.