### PR TITLE
Config sticky sessions

### DIFF
--- a/network/reverse-proxy/editor/Dockerfile
+++ b/network/reverse-proxy/editor/Dockerfile
@@ -1,6 +1,7 @@
 FROM image-registry.openshift-image-registry.svc:5000/9b301c-tools/nginx-unprivileged:1.20
 
 COPY ./config /etc/nginx/conf.d
+COPY ./nginx.conf /etc/nginx/nginx.conf
 
 # Set permissions for conf.d directory
 # RUN chmod -R 777 /etc/nginx/conf.d

--- a/network/reverse-proxy/editor/config/default.conf
+++ b/network/reverse-proxy/editor/config/default.conf
@@ -17,17 +17,20 @@ server {
   location /api {
     client_max_body_size 5120M;
     rewrite /api(.*) $1 break;
+    proxy_pass http://backend;
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-Host $server_name;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $http_connection;
     proxy_set_header X-NginX-Proxy true;
     proxy_ssl_session_reuse off;
+    proxy_cache off;
     proxy_cache_bypass $http_upgrade;
-    proxy_pass http://api:8080;
+    proxy_buffering off;
     proxy_redirect off;
     proxy_connect_timeout 75;
     proxy_send_timeout 300;
@@ -36,6 +39,7 @@ server {
   }
 
   location / {
+    proxy_pass http://editor:8080;
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -43,7 +47,6 @@ server {
     proxy_set_header X-NginX-Proxy true;
     proxy_ssl_session_reuse off;
     proxy_cache_bypass $http_upgrade;
-    proxy_pass http://editor:8080;
     proxy_redirect off;
 
     proxy_set_header Upgrade $http_upgrade;

--- a/network/reverse-proxy/editor/nginx.conf
+++ b/network/reverse-proxy/editor/nginx.conf
@@ -1,0 +1,43 @@
+worker_processes auto;
+
+error_log /var/log/nginx/error.log notice;
+pid /tmp/nginx.pid;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  proxy_temp_path /tmp/proxy_temp;
+  client_body_temp_path /tmp/client_temp;
+  fastcgi_temp_path /tmp/fastcgi_temp;
+  uwsgi_temp_path /tmp/uwsgi_temp;
+  scgi_temp_path /tmp/scgi_temp;
+
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+  '$status $body_bytes_sent "$http_referer" '
+  '"$http_user_agent" "$http_x_forwarded_for"';
+
+  access_log /var/log/nginx/access.log main;
+
+  sendfile on;
+  #tcp_nopush     on;
+
+  keepalive_timeout 65;
+
+  upstream backend {
+    # App server 1
+    server api-1:8080;
+    # App server 2
+    server api-2:8080;
+
+    ip_hash;
+  }
+
+  #gzip  on;
+
+  include /etc/nginx/conf.d/*.conf;
+}

--- a/network/reverse-proxy/subscriber/Dockerfile
+++ b/network/reverse-proxy/subscriber/Dockerfile
@@ -1,5 +1,6 @@
 FROM image-registry.openshift-image-registry.svc:5000/9b301c-tools/nginx-unprivileged:1.20
 
 COPY ./config /etc/nginx/conf.d
+COPY ./nginx.conf /etc/nginx/nginx.conf
 
 EXPOSE 8080

--- a/network/reverse-proxy/subscriber/config/default.conf
+++ b/network/reverse-proxy/subscriber/config/default.conf
@@ -17,17 +17,20 @@ server {
   location /api {
     client_max_body_size 5120M;
     rewrite /api(.*) $1 break;
+    proxy_pass http://backend;
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-Host $server_name;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $http_connection;
     proxy_set_header X-NginX-Proxy true;
     proxy_ssl_session_reuse off;
+    proxy_cache off;
     proxy_cache_bypass $http_upgrade;
-    proxy_pass http://api:8080;
+    proxy_buffering off;
     proxy_redirect off;
     proxy_connect_timeout 75;
     proxy_send_timeout 300;
@@ -37,13 +40,13 @@ server {
 
   location / {
     proxy_http_version 1.1;
+    proxy_pass http://subscriber:8080;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-NginX-Proxy true;
     proxy_ssl_session_reuse off;
     proxy_cache_bypass $http_upgrade;
-    proxy_pass http://subscriber:8080;
     proxy_redirect off;
 
     proxy_set_header Upgrade $http_upgrade;

--- a/network/reverse-proxy/subscriber/nginx.conf
+++ b/network/reverse-proxy/subscriber/nginx.conf
@@ -1,0 +1,43 @@
+worker_processes auto;
+
+error_log /var/log/nginx/error.log notice;
+pid /tmp/nginx.pid;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  proxy_temp_path /tmp/proxy_temp;
+  client_body_temp_path /tmp/client_temp;
+  fastcgi_temp_path /tmp/fastcgi_temp;
+  uwsgi_temp_path /tmp/uwsgi_temp;
+  scgi_temp_path /tmp/scgi_temp;
+
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+  '$status $body_bytes_sent "$http_referer" '
+  '"$http_user_agent" "$http_x_forwarded_for"';
+
+  access_log /var/log/nginx/access.log main;
+
+  sendfile on;
+  #tcp_nopush     on;
+
+  keepalive_timeout 65;
+
+  upstream backend {
+    # App server 1
+    server api-1:8080;
+    # App server 2
+    server api-2:8080;
+
+    ip_hash;
+  }
+
+  #gzip  on;
+
+  include /etc/nginx/conf.d/*.conf;
+}

--- a/openshift/kustomize/api/base/route-editor.yaml
+++ b/openshift/kustomize/api/base/route-editor.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: default
   annotations:
     haproxy.router.openshift.io/rewrite-target: /
+    haproxy.router.openshift.io/balance: source
+    haproxy.router.openshift.io/cookie_name: mmi
     haproxy.router.openshift.io/timeout: 2m
   labels:
     name: api-editor
@@ -37,6 +39,8 @@ metadata:
   namespace: default
   annotations:
     haproxy.router.openshift.io/rewrite-target: /
+    haproxy.router.openshift.io/balance: source
+    haproxy.router.openshift.io/cookie_name: mmi
     haproxy.router.openshift.io/timeout: 2m
   labels:
     name: api-editor-tls
@@ -60,93 +64,3 @@ spec:
     kind: Service
     name: api
     weight: 100
-# ---
-# kind: Route
-# apiVersion: route.openshift.io/v1
-# metadata:
-#   name: api-editor-0
-#   namespace: default
-#   annotations:
-#     haproxy.router.openshift.io/rewrite-target: /
-#   labels:
-#     name: api-editor-0
-#     part-of: tno
-#     version: 1.0.0
-#     component: api
-#     managed-by: kustomize
-#     created-by: jeremy.foster
-# spec:
-#   host: tno-dev-0.apps.silver.devops.gov.bc.ca
-#   path: /api
-#   port:
-#     targetPort: 8080-tcp
-#   tls:
-#     insecureEdgeTerminationPolicy: Redirect
-#     termination: edge
-#     # caCertificate: ""
-#     # certificate: ""
-#     # key: ""
-#   to:
-#     kind: Service
-#     name: api-0
-#     weight: 100
-# ---
-# kind: Route
-# apiVersion: route.openshift.io/v1
-# metadata:
-#   name: api-editor-1
-#   namespace: default
-#   annotations:
-#     haproxy.router.openshift.io/rewrite-target: /
-#   labels:
-#     name: api-editor-1
-#     part-of: tno
-#     version: 1.0.0
-#     component: api
-#     managed-by: kustomize
-#     created-by: jeremy.foster
-# spec:
-#   host: tno-dev-1.apps.silver.devops.gov.bc.ca
-#   path: /api
-#   port:
-#     targetPort: 8080-tcp
-#   tls:
-#     insecureEdgeTerminationPolicy: Redirect
-#     termination: edge
-#     # caCertificate: ""
-#     # certificate: ""
-#     # key: ""
-#   to:
-#     kind: Service
-#     name: api-1
-#     weight: 100
-# ---
-# kind: Route
-# apiVersion: route.openshift.io/v1
-# metadata:
-#   name: api-editor-2
-#   namespace: default
-#   annotations:
-#     haproxy.router.openshift.io/rewrite-target: /
-#   labels:
-#     name: api-editor-2
-#     part-of: tno
-#     version: 1.0.0
-#     component: api
-#     managed-by: kustomize
-#     created-by: jeremy.foster
-# spec:
-#   host: tno-dev-2.apps.silver.devops.gov.bc.ca
-#   path: /api
-#   port:
-#     targetPort: 8080-tcp
-#   tls:
-#     insecureEdgeTerminationPolicy: Redirect
-#     termination: edge
-#     # caCertificate: ""
-#     # certificate: ""
-#     # key: ""
-#   to:
-#     kind: Service
-#     name: api-2
-#     weight: 100

--- a/openshift/kustomize/api/base/route-subscriber.yaml
+++ b/openshift/kustomize/api/base/route-subscriber.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: default
   annotations:
     haproxy.router.openshift.io/rewrite-target: /
+    haproxy.router.openshift.io/balance: source
+    haproxy.router.openshift.io/cookie_name: mmi
     haproxy.router.openshift.io/timeout: 2m
   labels:
     name: api-subscriber
@@ -37,6 +39,8 @@ metadata:
   namespace: default
   annotations:
     haproxy.router.openshift.io/rewrite-target: /
+    haproxy.router.openshift.io/balance: source
+    haproxy.router.openshift.io/cookie_name: mmi
     haproxy.router.openshift.io/timeout: 2m
   labels:
     name: api-subscriber-tls
@@ -60,93 +64,3 @@ spec:
     kind: Service
     name: api
     weight: 100
-# ---
-# kind: Route
-# apiVersion: route.openshift.io/v1
-# metadata:
-#   name: api-subscriber-0
-#   namespace: default
-#   annotations:
-#     haproxy.router.openshift.io/rewrite-target: /
-#   labels:
-#     name: api-subscriber-0
-#     part-of: tno
-#     version: 1.0.0
-#     component: api
-#     managed-by: kustomize
-#     created-by: jeremy.foster
-# spec:
-#   host: mmi-dev-0.apps.silver.devops.gov.bc.ca
-#   path: /api
-#   port:
-#     targetPort: 8080-tcp
-#   tls:
-#     insecureEdgeTerminationPolicy: Redirect
-#     termination: edge
-#     # caCertificate: ""
-#     # certificate: ""
-#     # key: ""
-#   to:
-#     kind: Service
-#     name: api-0
-#     weight: 100
-# ---
-# kind: Route
-# apiVersion: route.openshift.io/v1
-# metadata:
-#   name: api-subscriber-1
-#   namespace: default
-#   annotations:
-#     haproxy.router.openshift.io/rewrite-target: /
-#   labels:
-#     name: api-subscriber-1
-#     part-of: tno
-#     version: 1.0.0
-#     component: api
-#     managed-by: kustomize
-#     created-by: jeremy.foster
-# spec:
-#   host: mmi-dev-1.apps.silver.devops.gov.bc.ca
-#   path: /api
-#   port:
-#     targetPort: 8080-tcp
-#   tls:
-#     insecureEdgeTerminationPolicy: Redirect
-#     termination: edge
-#     # caCertificate: ""
-#     # certificate: ""
-#     # key: ""
-#   to:
-#     kind: Service
-#     name: api-1
-#     weight: 100
-# ---
-# kind: Route
-# apiVersion: route.openshift.io/v1
-# metadata:
-#   name: api-subscriber-2
-#   namespace: default
-#   annotations:
-#     haproxy.router.openshift.io/rewrite-target: /
-#   labels:
-#     name: api-subscriber-2
-#     part-of: tno
-#     version: 1.0.0
-#     component: api
-#     managed-by: kustomize
-#     created-by: jeremy.foster
-# spec:
-#   host: mmi-dev-2.apps.silver.devops.gov.bc.ca
-#   path: /api
-#   port:
-#     targetPort: 8080-tcp
-#   tls:
-#     insecureEdgeTerminationPolicy: Redirect
-#     termination: edge
-#     # caCertificate: ""
-#     # certificate: ""
-#     # key: ""
-#   to:
-#     kind: Service
-#     name: api-2
-#     weight: 100

--- a/openshift/kustomize/app/editor/base/route.yaml
+++ b/openshift/kustomize/app/editor/base/route.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: default
   annotations:
     description: Route for editor application.
+    haproxy.router.openshift.io/balance: source
+    haproxy.router.openshift.io/cookie_name: mmi
+    haproxy.router.openshift.io/timeout: 2m
   labels:
     name: editor-app
     part-of: tno
@@ -32,100 +35,13 @@ spec:
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  name: editor-0
-  namespace: default
-  annotations:
-    description: Route for editor application.
-  labels:
-    name: editor-0
-    part-of: tno
-    version: 1.0.0
-    component: editor
-    managed-by: kustomize
-    created-by: jeremy.foster
-spec:
-  host: tno-dev-0.apps.silver.devops.gov.bc.ca
-  path: ""
-  port:
-    targetPort: 8080-tcp
-  tls:
-    insecureEdgeTerminationPolicy: Redirect
-    termination: edge
-    # caCertificate: ""
-    # certificate: ""
-    # key: ""
-  to:
-    kind: Service
-    name: editor
-    weight: 100
----
-kind: Route
-apiVersion: route.openshift.io/v1
-metadata:
-  name: editor-1
-  namespace: default
-  annotations:
-    description: Route for editor application.
-  labels:
-    name: editor-1
-    part-of: tno
-    version: 1.0.0
-    component: editor
-    managed-by: kustomize
-    created-by: jeremy.foster
-spec:
-  host: tno-dev-1.apps.silver.devops.gov.bc.ca
-  path: ""
-  port:
-    targetPort: 8080-tcp
-  tls:
-    insecureEdgeTerminationPolicy: Redirect
-    termination: edge
-    # caCertificate: ""
-    # certificate: ""
-    # key: ""
-  to:
-    kind: Service
-    name: editor
-    weight: 100
----
-kind: Route
-apiVersion: route.openshift.io/v1
-metadata:
-  name: editor-2
-  namespace: default
-  annotations:
-    description: Route for editor application.
-  labels:
-    name: editor-2
-    part-of: tno
-    version: 1.0.0
-    component: editor
-    managed-by: kustomize
-    created-by: jeremy.foster
-spec:
-  host: tno-dev-2.apps.silver.devops.gov.bc.ca
-  path: ""
-  port:
-    targetPort: 8080-tcp
-  tls:
-    insecureEdgeTerminationPolicy: Redirect
-    termination: edge
-    # caCertificate: ""
-    # certificate: ""
-    # key: ""
-  to:
-    kind: Service
-    name: editor
-    weight: 100
----
-kind: Route
-apiVersion: route.openshift.io/v1
-metadata:
   name: editor-tls
   namespace: default
   annotations:
     description: Route for editor application.
+    haproxy.router.openshift.io/balance: source
+    haproxy.router.openshift.io/cookie_name: mmi
+    haproxy.router.openshift.io/timeout: 2m
   labels:
     name: editor-tls
     part-of: tno

--- a/openshift/kustomize/app/subscriber/base/route.yaml
+++ b/openshift/kustomize/app/subscriber/base/route.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: default
   annotations:
     description: Route for subscriber application.
+    haproxy.router.openshift.io/balance: source
+    haproxy.router.openshift.io/cookie_name: mmi
+    haproxy.router.openshift.io/timeout: 2m
   labels:
     name: subscriber
     part-of: tno
@@ -32,100 +35,13 @@ spec:
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  name: subscriber-0
-  namespace: default
-  annotations:
-    description: Route for subscriber application.
-  labels:
-    name: subscriber-0
-    part-of: tno
-    version: 1.0.0
-    component: subscriber
-    managed-by: kustomize
-    created-by: jeremy.foster
-spec:
-  host: mmi-dev-0.apps.silver.devops.gov.bc.ca
-  path: ""
-  port:
-    targetPort: 8080-tcp
-  tls:
-    insecureEdgeTerminationPolicy: Redirect
-    termination: edge
-    # caCertificate: ""
-    # certificate: ""
-    # key: ""
-  to:
-    kind: Service
-    name: subscriber
-    weight: 100
----
-kind: Route
-apiVersion: route.openshift.io/v1
-metadata:
-  name: subscriber-1
-  namespace: default
-  annotations:
-    description: Route for subscriber application.
-  labels:
-    name: subscriber-1
-    part-of: tno
-    version: 1.0.0
-    component: subscriber
-    managed-by: kustomize
-    created-by: jeremy.foster
-spec:
-  host: mmi-dev-1.apps.silver.devops.gov.bc.ca
-  path: ""
-  port:
-    targetPort: 8080-tcp
-  tls:
-    insecureEdgeTerminationPolicy: Redirect
-    termination: edge
-    # caCertificate: ""
-    # certificate: ""
-    # key: ""
-  to:
-    kind: Service
-    name: subscriber
-    weight: 100
----
-kind: Route
-apiVersion: route.openshift.io/v1
-metadata:
-  name: subscriber-2
-  namespace: default
-  annotations:
-    description: Route for subscriber application.
-  labels:
-    name: subscriber-2
-    part-of: tno
-    version: 1.0.0
-    component: subscriber
-    managed-by: kustomize
-    created-by: jeremy.foster
-spec:
-  host: mmi-dev-2.apps.silver.devops.gov.bc.ca
-  path: ""
-  port:
-    targetPort: 8080-tcp
-  tls:
-    insecureEdgeTerminationPolicy: Redirect
-    termination: edge
-    # caCertificate: ""
-    # certificate: ""
-    # key: ""
-  to:
-    kind: Service
-    name: subscriber
-    weight: 100
----
-kind: Route
-apiVersion: route.openshift.io/v1
-metadata:
   name: subscriber-tls
   namespace: default
   annotations:
     description: Route for subscriber application.
+    haproxy.router.openshift.io/balance: source
+    haproxy.router.openshift.io/cookie_name: mmi
+    haproxy.router.openshift.io/timeout: 2m
   labels:
     name: subscriber-tls
     part-of: tno


### PR DESCRIPTION
Openshift routes will do their best to keep sticky sessions.  Nginx will also maintain sticky sessions.

There are some downsides that everyone should be aware of.

- If a pod dies there is nothing to handle the transition, so the client will throw an error
- I was unable to see the cookie to maintain the session, which could indicate another proxy layer involved
- I have limited ability to test and confirm all scenarios
- Nginx is hardcoded configuration to communicate with api-0 and api-1.  Which means we would need to update the config if we want to have more pods available.

The good that comes from this.

- We can have more than one api pod.  If the pod dies everything will automatically switch to the other pod.
- SignalR is getting a reliable connection as long as the api pods don't die
