### PR TITLE
Fix advanced search

### DIFF
--- a/app/subscriber/src/features/search-page/PreviousResults.tsx
+++ b/app/subscriber/src/features/search-page/PreviousResults.tsx
@@ -1,5 +1,5 @@
 import { IContentSearchResult } from 'features/utils/interfaces';
-import moment from 'moment';
+import moment, { Moment } from 'moment';
 import React from 'react';
 import { useContent } from 'store/hooks';
 import { Row } from 'tno-core';
@@ -11,7 +11,7 @@ export interface IPreviousResultsProps {
   currDateResults: IContentSearchResult[];
   prevDateResults: IContentSearchResult[];
   setResults: React.Dispatch<React.SetStateAction<IContentSearchResult[]>>;
-  startDate: Date;
+  startDate: Moment;
   executeSearch: Function;
 }
 export const PreviousResults: React.FC<IPreviousResultsProps> = ({
@@ -29,6 +29,34 @@ export const PreviousResults: React.FC<IPreviousResultsProps> = ({
 
   const [prevResults, setPrevResults] = React.useState<IPreviousDate[]>([]);
 
+  const createDateRanges = React.useCallback(
+    (startDate: Moment) => {
+      if (!prevDateResults.length) return setPrevResults([]);
+      const date = moment(startDate).startOf('day');
+      const dateRanges: IPreviousDate[] = [];
+      for (let i = 1; i < 9; i++) {
+        const endOfDay = moment(date).endOf('day');
+        dateRanges.push({
+          startDate: date,
+          endDate: endOfDay,
+          hits: 0,
+        });
+        date.add(-1, 'day');
+      }
+
+      for (let i = 0; i < prevDateResults.length; i++) {
+        const content = prevDateResults[i];
+        const range = dateRanges.find((r) => {
+          const publishedOn = moment(content.publishedOn);
+          return publishedOn >= r.startDate && publishedOn <= r.endDate;
+        });
+        if (range) range.hits++;
+      }
+      setPrevResults(dateRanges);
+    },
+    [prevDateResults],
+  );
+
   React.useEffect(() => {
     // wait for startDate, and also do not want to fetch if results are returned
     if (!startDate || currDateResults.length) return;
@@ -36,46 +64,6 @@ export const PreviousResults: React.FC<IPreviousResultsProps> = ({
     // only want to run when start date or source ids change
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filter.startDate, currDateResults, prevDateResults]);
-
-  const createDateRanges = React.useCallback(
-    (startDate: Date) => {
-      if (!prevDateResults.length) return setPrevResults([]);
-      const dayInMs = 24 * 60 * 60 * 1000; // Hours*Minutes*Seconds*Milliseconds
-      // Previous 7 days that will be used to fetch in a filter
-      let dateRanges: IPreviousDate[] = [];
-      const days =
-        moment(startDate)
-          .startOf('day')
-          .diff(
-            moment(prevDateResults[prevDateResults.length - 1].publishedOn).endOf('day'),
-            'days',
-          ) + 1;
-
-      // Generate the previous 7 days from the read date
-      for (let i = 1; i <= days; i++) {
-        const currStartDate = new Date(startDate.getTime() - i * dayInMs);
-        const currEndDate = new Date(currStartDate.getTime() + dayInMs - 1);
-        const currResults = prevDateResults.filter((res) => {
-          const resDate = new Date(res.publishedOn);
-          if (
-            resDate.getTime() >= currStartDate.getTime() &&
-            resDate.getTime() <= currEndDate.getTime()
-          ) {
-            return true;
-          }
-          return false;
-        });
-
-        dateRanges.push({
-          startDate: currStartDate.toISOString(),
-          endDate: currEndDate.toISOString(),
-          hits: currResults.length,
-        });
-      }
-      setPrevResults(dateRanges);
-    },
-    [prevDateResults],
-  );
 
   return (
     <styled.PreviousResults>
@@ -88,10 +76,14 @@ export const PreviousResults: React.FC<IPreviousResultsProps> = ({
         .map((x) => {
           return (
             <Row
-              key={x.startDate}
+              key={x.startDate.toISOString()}
               className="prev-result-row"
               onClick={() => {
-                const newFilter = { ...filter, startDate: x.startDate, endDate: x.endDate };
+                const newFilter = {
+                  ...filter,
+                  startDate: x.startDate.toISOString(),
+                  endDate: x.endDate.toISOString(),
+                };
                 storeFilter(newFilter);
                 executeSearch(newFilter);
               }}

--- a/app/subscriber/src/features/search-page/interfaces/IPreviousDate.ts
+++ b/app/subscriber/src/features/search-page/interfaces/IPreviousDate.ts
@@ -1,5 +1,7 @@
+import { Moment } from 'moment';
+
 export interface IPreviousDate {
-  startDate: string;
-  endDate: string;
+  startDate: Moment;
+  endDate: Moment;
   hits: number;
 }


### PR DESCRIPTION
There were additional issues discovered with displaying results with the advanced search and grouping by prior date.  This should now correctly display all results in the correct groups.