### PR TITLE
MMI-3091 storage API cleanup

### DIFF
--- a/api/net/Areas/Editor/Controllers/StorageController.cs
+++ b/api/net/Areas/Editor/Controllers/StorageController.cs
@@ -546,7 +546,6 @@ public class StorageController : ControllerBase
         var fileReferences = await _fileReferenceService.GetFiles(publishedAfter, publishedBefore, limit ?? 100, force);
         var uploadedFiles = new List<string>();
         var failedUploads = new List<string>();
-        var deletedReferences = new List<string>();
         // check if s3 credentials are set
         if (!_s3Options.IsS3Enabled )
         {
@@ -594,9 +593,8 @@ public class StorageController : ControllerBase
                 }
                 else
                 {
-                    failedUploads.Add($"{fileReference.Path} (file not found)");
                     _fileReferenceService.DeleteAndSave(fileReference);
-                    deletedReferences.Add($"{fileReference.Path} (Broken reference deleted)");
+                    failedUploads.Add($"{fileReference.Path} (file not found, broken reference deleted)");
                 }
             }
             catch (Exception ex)
@@ -610,7 +608,6 @@ public class StorageController : ControllerBase
         {
             UploadedFiles = uploadedFiles,
             FailedUploads = failedUploads,
-            DeletedReferences = deletedReferences,
         });
     }
 

--- a/api/net/Areas/Editor/Controllers/StorageController.cs
+++ b/api/net/Areas/Editor/Controllers/StorageController.cs
@@ -546,6 +546,7 @@ public class StorageController : ControllerBase
         var fileReferences = await _fileReferenceService.GetFiles(publishedAfter, publishedBefore, limit ?? 100, force);
         var uploadedFiles = new List<string>();
         var failedUploads = new List<string>();
+        var deletedReferences = new List<string>();
         // check if s3 credentials are set
         if (!_s3Options.IsS3Enabled )
         {
@@ -597,6 +598,8 @@ public class StorageController : ControllerBase
                 else
                 {
                     failedUploads.Add($"{fileReference.Path} (file not found)");
+                    _fileReferenceService.DeleteAndSave(fileReference);
+                    deletedReferences.Add($"{fileReference.Path} (Broken reference deleted)");
                 }
             }
             catch (Exception ex)
@@ -610,6 +613,7 @@ public class StorageController : ControllerBase
         {
             UploadedFiles = uploadedFiles,
             FailedUploads = failedUploads,
+            DeletedReferences = deletedReferences,
         });
     }
 

--- a/api/net/Areas/Editor/Controllers/StorageController.cs
+++ b/api/net/Areas/Editor/Controllers/StorageController.cs
@@ -577,17 +577,14 @@ public class StorageController : ControllerBase
 
                         uploadedFiles.Add(s3Key);
 
-                        if (fileReference.ContentType.StartsWith("video/") || fileReference.ContentType.StartsWith("audio/"))
+                        try
                         {
-                            try
-                            {
-                                System.IO.File.Delete(filePath);
-                                _logger.LogInformation("deleted local file: {FilePath}", filePath);
-                            }
-                            catch (Exception ex)
-                            {
-                                _logger.LogError(ex, "failed to delete local file: {FilePath}", filePath);
-                            }
+                            System.IO.File.Delete(filePath);
+                            _logger.LogInformation("deleted local file: {FilePath}", filePath);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "failed to delete local file: {FilePath}", filePath);
                         }
                     }
                     else

--- a/api/net/Areas/Editor/Controllers/StorageController.cs
+++ b/api/net/Areas/Editor/Controllers/StorageController.cs
@@ -593,8 +593,14 @@ public class StorageController : ControllerBase
                 }
                 else
                 {
-                    _fileReferenceService.DeleteAndSave(fileReference);
-                    failedUploads.Add($"{fileReference.Path} (file not found, broken reference deleted)");
+                    if (!fileReference.IsSyncedToS3)
+                    {
+                        // GetFiles method will return fileReference that is not synced to S3 normally, for extra safety, we double check here fileReference.IsSyncedToS3
+                        // if file not found, and file was not synced to S3, then it is a broken reference, we delete it
+                        _logger.LogInformation("File not found, broken reference deleted: {Path}", fileReference.Path);
+                        _fileReferenceService.DeleteAndSave(fileReference);
+                        failedUploads.Add($"{fileReference.Path} (file not found, broken reference deleted)");
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
fix two parts:

A. Before modification, we move files actually only delete AV files, editors always upload everything. Since we already set up to move all files we can find. We need to delete any kind of files locally. otherwise we would have another place to create junk files(like *.PDF, *.txt, etc.).

B. Remove broken FileReferences if we found file not exist and was not moved to s3.This June, we lost some files, and then these files' FileReferences became broken, not necessary to keep them and this also make API call possesses slower when we selected the date range include June. 