### PR TITLE
Fix tab navigation

### DIFF
--- a/app/editor/src/features/content/form/ContentNavigation.tsx
+++ b/app/editor/src/features/content/form/ContentNavigation.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { FaChevronLeft, FaChevronRight, FaSpinner } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
 import { useLocalStorage } from 'store/hooks';
-import { IContentSearchResult } from 'store/slices';
 import { Button, ButtonVariant, Row, Show, Spinner } from 'tno-core';
 
 import { useContentForm } from './hooks';
@@ -31,7 +30,7 @@ export const ContentNavigation: React.FC<IContentNavigationProps> = ({
   const navigate = useNavigate();
   const { isProcessing } = useContentForm(values);
 
-  const [currentItems] = useLocalStorage<IContentSearchResult[] | null>('currentContent', null);
+  const [currentItems] = useLocalStorage<number[] | null>('currentContent', null);
   const [, setCurrentItemId] = useLocalStorage('currentContentItemId', -1);
 
   const [indexPosition, setIndexPosition] = React.useState(0);
@@ -40,7 +39,7 @@ export const ContentNavigation: React.FC<IContentNavigationProps> = ({
 
   React.useEffect(() => {
     if (currentItems != null) {
-      let index = !!values.id ? currentItems.findIndex((c) => c.id === +values.id) ?? -1 : -1;
+      let index = !!values.id ? currentItems.findIndex((c) => c === +values.id) ?? -1 : -1;
       setIndexPosition(index);
       setEnablePrev(index > 0);
       setEnableNext(index < (currentItems.length ?? 0) - 1);
@@ -49,7 +48,7 @@ export const ContentNavigation: React.FC<IContentNavigationProps> = ({
 
   const handleNavigate = (offset: number) => {
     if (currentItems != null) {
-      const targetId = currentItems[indexPosition + offset]?.id;
+      const targetId = currentItems[indexPosition + offset];
       if (!!targetId) {
         setCurrentItemId(targetId);
         navigate(getContentPath(targetId, values.contentType));

--- a/app/editor/src/features/content/list-view/ContentListView.tsx
+++ b/app/editor/src/features/content/list-view/ContentListView.tsx
@@ -71,7 +71,7 @@ const ContentListView: React.FC = () => {
   const [, { findWorkOrders }] = useWorkOrders();
   // This configures the shared storage between this list and any content tabs
   // that are opened.  Mainly used for navigation in the tab
-  const [, setCurrentItems] = useLocalStorage('currentContent', {} as IContentSearchResult[]);
+  const [, setCurrentItems] = useLocalStorage('currentContent', {} as number[]);
   const [currentItemId, setCurrentItemId] = useLocalStorage('currentContentItemId', -1);
 
   const [focusedRowIndex, setFocusedRowIndex] = React.useState(id);
@@ -80,7 +80,7 @@ const ContentListView: React.FC = () => {
   // Stores the current page
   const [currentResultsPage, setCurrentResultsPage] = React.useState(defaultPage);
   React.useEffect(() => {
-    setCurrentItems(currentResultsPage.items);
+    setCurrentItems(currentResultsPage.items.map((i) => i.id));
   }, [currentResultsPage, setCurrentItems]);
   // if the user navigates next/previous in another window change the highlighted row
   React.useEffect(() => {

--- a/app/editor/src/features/content/papers/Papers.tsx
+++ b/app/editor/src/features/content/papers/Papers.tsx
@@ -66,7 +66,7 @@ const Papers: React.FC<IPapersProps> = (props) => {
 
   // This configures the shared storage between this list and any content tabs
   // that are opened.  Mainly used for navigation in the tab
-  const [, setCurrentItems] = useLocalStorage('currentContent', {} as IContentSearchResult[]);
+  const [, setCurrentItems] = useLocalStorage('currentContent', {} as number[]);
   const [currentItemId, setCurrentItemId] = useLocalStorage('currentContentItemId', -1);
 
   const [isLoading, setIsLoading] = React.useState(false);
@@ -116,8 +116,8 @@ const Papers: React.FC<IPapersProps> = (props) => {
 
   // Stores the current page
   React.useEffect(() => {
-    setCurrentItems(currentResultsPage.items);
-  }, [currentResultsPage, setCurrentItems]);
+    setCurrentItems(currentResultsPage.items.map((i) => i.id));
+  }, [currentResultsPage.items, setCurrentItems]);
 
   // if the user navigates next/previous in another window change the highlighted row
   React.useEffect(() => {

--- a/app/editor/src/store/hooks/editor/usehooks-ts/useLocalStorage.ts
+++ b/app/editor/src/store/hooks/editor/usehooks-ts/useLocalStorage.ts
@@ -36,13 +36,6 @@ export function useLocalStorage<T>(key: string, initialValue: T): [T, SetValue<T
   // Return a wrapped version of useState's setter function that ...
   // ... persists the new value to localStorage.
   const setValue: SetValue<T> = useEventCallback((value) => {
-    // Prevent build error "window is undefined" but keeps working
-    if (typeof window === 'undefined') {
-      //   console.warn(
-      //     `Tried setting localStorage key “${key}” even though environment is not a client`,
-      //   );
-    }
-
     try {
       // Allow value to be a function so we have the same API as useState
       const newValue = value instanceof Function ? value(storedValue) : value;
@@ -56,7 +49,7 @@ export function useLocalStorage<T>(key: string, initialValue: T): [T, SetValue<T
       // We dispatch a custom event so every useLocalStorage hook are notified
       window.dispatchEvent(new Event('local-storage'));
     } catch (error) {
-      //   console.warn(`Error setting localStorage key “${key}”:`, error);
+      console.error(`Error setting localStorage key “${key}”:`, error);
     }
   });
 

--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -179,7 +179,6 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
         currEndDate.endOf('day');
 
         setStartDate(currStartDate);
-        console.debug('start', currStartDate.toString());
         if (filter.startDate && filter.endDate) {
           newFilter = {
             ...filter,

--- a/tools/mov-converter/README.md
+++ b/tools/mov-converter/README.md
@@ -29,7 +29,8 @@ The simple solution is to download and add the `ffmpeg` binary to the path.
 
 4. Fiddle with the Mac OS to allow execution of `ffmpeg`. Using Finder, open the file `/usr/local/ffmpeg` and allow it to run.
 5. Create folder `~/Movies/MMI-inbox`
-6. Create Automator script
+6. Create folder `~/Movies/MMI-outbox`
+7. Create Automator script
 
 Choose "Folder Action"
 Select the `~/Movies/MMI-inbox` folder
@@ -44,13 +45,13 @@ do
   name=${filename%.*}
 
   cd $path
-  /usr/local/bin/ffmpeg -y -hide_banner -loglevel error -i $f ${name}.mp4
+  /usr/local/bin/ffmpeg -y -hide_banner -loglevel error -i $f -c copy ../MMI-outbox/${name}.mp4
 done
 ```
 
 Save the Automator as "Auto Convert to mp4"
 
-7. Create Automator script
+8. Create Automator script
 
 Choose "Quick Actions"
 Select "Automatic (files or folders)" in "any application"


### PR DESCRIPTION
The implementation to store search results in local storage resulted in errors on the page once local storage filled up.  Once local storage fills up there are additional errors that occur related to authentication.

## Summary

- Only store content IDs in local storage for search results
- Update documentation to install OSX file converter

This will also fix the Editor navigation bug.

![image](https://github.com/user-attachments/assets/eb020d21-0caf-415b-82ce-b0f032d8a3e8)
