### PR TITLE
MMI-3091 cleanup missing files' FileReference

### DIFF
--- a/api/net/Areas/Editor/Controllers/StorageController.cs
+++ b/api/net/Areas/Editor/Controllers/StorageController.cs
@@ -591,7 +591,14 @@ public class StorageController : ControllerBase
                     }
                     else
                     {
-                        failedUploads.Add($"{fileReference.Path} (upload failed)");
+                        if (!fileReference.IsSyncedToS3)
+                        {
+                            // GetFiles method will return fileReference that is not synced to S3 normally, for extra safety, we double check here fileReference.IsSyncedToS3
+                            // if file not found, and file was not synced to S3, then it is a broken reference, we delete it
+                            _logger.LogInformation("File not found, broken reference deleted: {Path}", fileReference.Path);
+                            _fileReferenceService.DeleteAndSave(fileReference);
+                            failedUploads.Add($"{fileReference.Path} (file not found, broken reference deleted)");
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
Cleanup missing fileReference speed up API call. 

If we choose to move files to s3 because there are missing files in June, these references won't be cleared, they will be in the query results (like filter files before sept ), causing  a long delay as the system checks and tries to move them one by one  in every API call.