### PR TITLE
Add date navigation

### DIFF
--- a/app/subscriber/src/components/date-filter/DateFilter.tsx
+++ b/app/subscriber/src/components/date-filter/DateFilter.tsx
@@ -1,78 +1,58 @@
-import moment from 'moment';
+import moment, { Moment } from 'moment';
 import React from 'react';
 import ReactDatePicker from 'react-datepicker';
 import { FaCalendarDay, FaCaretLeft, FaCaretRight } from 'react-icons/fa6';
-import { IFilterSettingsModel } from 'tno-core';
 
 import * as styled from './styled';
 
 export interface IDateFilterProps {
-  filter: IFilterSettingsModel;
-  storeFilter: (filter: IFilterSettingsModel) => void;
-  onChangeDate?: (filter: IFilterSettingsModel) => void;
+  date: string | Date | Moment | undefined;
+  onChangeDate?: (start: string, end: string) => void;
 }
 
 /** Custom date filter for the subscriber home page. Control the calendar state with custom button, custom styling also applied. Also allows user to navigate a day at a time via arrow buttons. */
-export const DateFilter: React.FC<IDateFilterProps> = ({ filter, storeFilter, onChangeDate }) => {
+export const DateFilter: React.FC<IDateFilterProps> = ({ date: initDate, onChangeDate }) => {
   /** control state of open calendar from outside components. i.e custom calendar button */
   const [open, setOpen] = React.useState(false);
+  const [date, setDate] = React.useState(initDate);
 
   // /** close calendar after a date has been selected, and fetch related content */
   React.useEffect(() => {
     setOpen(false);
-  }, [filter.startDate, setOpen]);
+  }, [date, setOpen]);
 
   const handleDateChange = React.useCallback(
-    ({ startDate, dateOffset }: { startDate?: string; dateOffset?: number }) => {
-      let newDate;
-      if (startDate && dateOffset === undefined) {
-        newDate = new Date(startDate);
-      } else if (startDate && dateOffset !== undefined) {
-        newDate = new Date(startDate);
-        newDate.setDate(newDate.getDate() + dateOffset);
-      }
-      const search = {
-        ...filter,
-        startDate: moment(newDate).startOf('day').toISOString(),
-        endDate: moment(newDate).endOf('day').toISOString(),
-        dateOffset: undefined,
-      };
-      storeFilter(search);
-      onChangeDate?.(search);
+    (date: string | Date | Moment | undefined) => {
+      setDate(date);
+      onChangeDate?.(
+        moment(date).startOf('day').toISOString(),
+        moment(date).endOf('day').toISOString(),
+      );
     },
-    [filter, onChangeDate, storeFilter],
+    [onChangeDate],
   );
 
   return (
     <styled.DateFilter alignItems="center" justifyContent="center" className="date-navigator">
       <FaCaretLeft
         className="caret"
-        onClick={() =>
-          handleDateChange({
-            startDate: filter.startDate ? filter.startDate : new Date().toISOString(),
-            dateOffset: -1,
-          })
-        }
+        onClick={() => handleDateChange(moment(date).add(-1, 'day'))}
       />
       <div className="date">
-        <FaCalendarDay className="calendar" onClick={() => setOpen(true)} />
+        <FaCalendarDay className="calendar" onClick={() => setOpen((value) => !value)} />
         <ReactDatePicker
           open={open}
           maxDate={new Date()}
           disabled
           dateFormat="dd-MMM-y"
-          onChange={(e) => handleDateChange({ startDate: e?.toISOString() })}
-          selected={!!filter.startDate ? new Date(filter.startDate) : new Date()}
+          onChange={(e) => handleDateChange(e?.toISOString())}
+          onChangeRaw={(e) => setOpen(false)}
+          selected={date ? moment(date).toDate() : new Date()}
         />
       </div>
       <FaCaretRight
         className="caret"
-        onClick={() =>
-          handleDateChange({
-            startDate: filter.startDate ? filter.startDate : new Date().toISOString(),
-            dateOffset: 1,
-          })
-        }
+        onClick={() => handleDateChange(moment(date).add(1, 'day'))}
       />
     </styled.DateFilter>
   );

--- a/app/subscriber/src/features/daily-overview/AVOverviewPreview.tsx
+++ b/app/subscriber/src/features/daily-overview/AVOverviewPreview.tsx
@@ -131,7 +131,17 @@ const AVOverviewPreview: React.FC = () => {
     <styled.AVOverviewPreview>
       <Loader visible={isLoading} />
       <Show visible={!isLoading}>
-        <DateFilter filter={avOverviewFilter} storeFilter={storeFilter} />
+        <DateFilter
+          date={avOverviewFilter.startDate}
+          onChangeDate={(start, end) =>
+            storeFilter({
+              ...avOverviewFilter,
+              startDate: start,
+              endDate: end,
+              dateOffset: undefined,
+            })
+          }
+        />
         <Show visible={!isLoading && !!isPublished && !!reactElements}>
           <Col className="preview-report">
             <div className="preview-body">{reactElements}</div>

--- a/app/subscriber/src/features/event-of-the-day/EventOfTheDayPreview.tsx
+++ b/app/subscriber/src/features/event-of-the-day/EventOfTheDayPreview.tsx
@@ -76,7 +76,17 @@ const EventOfTheDayPreview: React.FC = () => {
     <styled.EventOfTheDayPreview>
       <Loader visible={isLoading} />
       <Show visible={!isLoading}>
-        <DateFilter filter={eventOfTheDayFilter} storeFilter={storeFilter} />
+        <DateFilter
+          date={eventOfTheDayFilter.startDate}
+          onChangeDate={(start, end) =>
+            storeFilter({
+              ...eventOfTheDayFilter,
+              startDate: start,
+              endDate: end,
+              dateOffset: undefined,
+            })
+          }
+        />
         <Show visible={!isLoading && !!preview}>
           <Col className="preview-report">
             <div

--- a/app/subscriber/src/features/filter-media/FilterMedia.tsx
+++ b/app/subscriber/src/features/filter-media/FilterMedia.tsx
@@ -116,7 +116,12 @@ export const FilterMedia: React.FC<IFilterMediaProps> = ({
         isSelectAllChecked={currentIsSelectAllChecked}
         onReset={onReset}
       />
-      <DateFilter filter={filter} storeFilter={storeFilter} />
+      <DateFilter
+        date={filter.startDate}
+        onChangeDate={(start, end) =>
+          storeFilter({ ...filter, startDate: start, endDate: end, dateOffset: undefined })
+        }
+      />
       <ContentList
         onContentSelected={handleContentSelected}
         content={currDateResults}

--- a/app/subscriber/src/features/home/Home.tsx
+++ b/app/subscriber/src/features/home/Home.tsx
@@ -134,7 +134,12 @@ export const Home: React.FC = () => {
           onReset={handleReset}
         />
       </Row>
-      <DateFilter filter={filter} storeFilter={storeFilter} />
+      <DateFilter
+        date={filter.startDate}
+        onChangeDate={(start, end) =>
+          storeFilter({ ...filter, startDate: start, endDate: end, dateOffset: undefined })
+        }
+      />
       <ContentList
         onContentSelected={handleContentSelected}
         showDate

--- a/app/subscriber/src/features/my-minister/MyMinister.tsx
+++ b/app/subscriber/src/features/my-minister/MyMinister.tsx
@@ -193,7 +193,12 @@ export const MyMinister: React.FC = () => {
         onClear={() => setSelected([])}
         onSelectAll={(e) => (e.target.checked ? setSelected(content) : setSelected([]))}
       />
-      <DateFilter filter={filter} storeFilter={storeFilter} />
+      <DateFilter
+        date={filter.startDate}
+        onChangeDate={(start, end) =>
+          storeFilter({ ...filter, startDate: start, endDate: end, dateOffset: undefined })
+        }
+      />
       <div className="ministerCheckboxes">
         <span className="option">SHOW:</span>
         {userMinisters.map((m) => {

--- a/app/subscriber/src/features/router/AppRouter.tsx
+++ b/app/subscriber/src/features/router/AppRouter.tsx
@@ -89,7 +89,7 @@ export const AppRouter: React.FC = () => {
           element={
             <PrivateRoute
               claims={Claim.subscriber}
-              element={<SearchPage showAdvanced={false} />}
+              element={<SearchPage showAdvanced={false} showDate />}
             ></PrivateRoute>
           }
         />
@@ -98,7 +98,7 @@ export const AppRouter: React.FC = () => {
           element={
             <PrivateRoute
               claims={Claim.subscriber}
-              element={<SearchPage showAdvanced={false} />}
+              element={<SearchPage showAdvanced={false} showDate />}
             ></PrivateRoute>
           }
         />
@@ -107,7 +107,7 @@ export const AppRouter: React.FC = () => {
           element={
             <PrivateRoute
               claims={Claim.subscriber}
-              element={<SearchPage showAdvanced={true} />}
+              element={<SearchPage showAdvanced showDate />}
             ></PrivateRoute>
           }
         />
@@ -116,7 +116,7 @@ export const AppRouter: React.FC = () => {
           element={
             <PrivateRoute
               claims={Claim.subscriber}
-              element={<SearchPage showAdvanced={true} />}
+              element={<SearchPage showAdvanced showDate />}
             ></PrivateRoute>
           }
         />

--- a/app/subscriber/src/features/search-page/SearchPage.tsx
+++ b/app/subscriber/src/features/search-page/SearchPage.tsx
@@ -33,10 +33,11 @@ import { filterFormat } from './utils';
 
 export interface ISearchType {
   showAdvanced?: boolean;
+  showDate?: boolean;
 }
 
 // Simple component to display users search results
-export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
+export const SearchPage: React.FC<ISearchType> = ({ showAdvanced, showDate: initShowDate }) => {
   const { id } = useParams();
   const [
     {
@@ -63,7 +64,9 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
   const [filterId, setFilterId] = React.useState(0);
   const [searchFilter, setSearchFilter] = React.useState<IFilterSettingsModel | null>(null);
   const [showResults, setShowResults] = React.useState(false);
-  const [dateVisible, setDateVisible] = React.useState(true);
+
+  const [dateVisible, setDateVisible] = React.useState(initShowDate); // show/hide the date navigation component.
+  const [selectedDate, setSelectedDate] = React.useState<string | undefined>(); // The selected date for the navigation component.
 
   React.useEffect(() => {
     const parsedId = id ? parseInt(id) : 0;
@@ -81,6 +84,10 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
       storeFilter(undefined);
     }
   }, [activeFilter, getFilter, filterId, init, storeFilter, storeSearchFilter, id]);
+
+  React.useEffect(() => {
+    setDateVisible(initShowDate);
+  }, [initShowDate]);
 
   const groupResults = React.useCallback(
     (res: KnnSearchResponse<IContentModel>, currStartDate: Moment, groupStoredContent: boolean) => {
@@ -149,7 +156,11 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
   );
 
   const fetchResults = React.useCallback(
-    async (filter: IFilterSettingsModel, storedContent?: KnnSearchResponse<IContentModel>) => {
+    async (
+      filter: IFilterSettingsModel,
+      storedContent?: KnnSearchResponse<IContentModel>,
+      oneDay: boolean = false,
+    ) => {
       try {
         setShowResults(false);
         let newFilter = filter;
@@ -160,7 +171,6 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
           };
         }
         const offset = filter.dateOffset ?? 0;
-        setDateVisible(offset === 0);
 
         const offsetDate =
           offset <= 2 ? moment().add(offset * 24 * -1, 'hour') : moment().add(offset * -1, 'day');
@@ -183,7 +193,7 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
           newFilter = {
             ...filter,
             dateOffset: undefined,
-            startDate: prevStartDate.toISOString(),
+            startDate: oneDay ? currStartDate.toISOString() : prevStartDate.toISOString(),
             endDate: currEndDate.toISOString(),
           };
         }
@@ -209,12 +219,6 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
   );
 
   React.useEffect(() => {
-    storeSearchResultsFilter(secondaryFilter);
-    fetchResults(filter);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [secondaryFilter]);
-
-  React.useEffect(() => {
     // only fetch this when there's no call to the elastic search
     if (id && !activeFilter) return;
     fetchResults(filter, content);
@@ -222,9 +226,11 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [content, fetchResults, id]);
 
-  const handleContentSelected = React.useCallback((content: IContentModel[]) => {
-    setSelected(content);
-  }, []);
+  React.useEffect(() => {
+    storeSearchResultsFilter(secondaryFilter);
+    fetchResults(filter);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [secondaryFilter]);
 
   React.useEffect(() => {
     // Do not want it to fire on initial load of a user clicking "go advanced"
@@ -236,16 +242,9 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [frontPageImagesMediaTypeId]);
 
-  const handleSearch = React.useCallback(async () => {
-    fetchResults(filter);
-  }, [fetchResults, filter]);
-
-  const executeSearch = React.useCallback(
-    async (filter: IFilterSettingsModel) => {
-      fetchResults(filter);
-    },
-    [fetchResults],
-  );
+  const handleContentSelected = React.useCallback((content: IContentModel[]) => {
+    setSelected(content);
+  }, []);
 
   return (
     <styled.SearchPage expanded={expanded}>
@@ -253,13 +252,13 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
         {/* LEFT SIDE */}
         <Show visible={showAdvanced}>
           <Col className="adv-search-container">
-            <AdvancedSearch onSearch={executeSearch} setSearchFilter={setSearchFilter} />
+            <AdvancedSearch onSearch={fetchResults} setSearchFilter={setSearchFilter} />
           </Col>
         </Show>
         {/* RIGHT SIDE */}
         <Col className={showAdvanced ? 'result-container' : 'result-container-full'}>
           <Show visible={!showAdvanced && !!width && width > 900}>
-            <BasicSearch onSearch={() => handleSearch()} />
+            <BasicSearch onSearch={() => fetchResults(filter)} />
           </Show>
           <PageSection
             header={
@@ -285,9 +284,15 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
             />
             <Show visible={dateVisible}>
               <DateFilter
-                filter={filter}
-                storeFilter={storeSearchFilter}
-                onChangeDate={executeSearch}
+                date={selectedDate}
+                onChangeDate={(start, end) => {
+                  setSelectedDate(start);
+                  fetchResults(
+                    { ...filter, startDate: start, endDate: end, dateOffset: undefined },
+                    undefined,
+                    true,
+                  );
+                }}
               />
             </Show>
             <br />
@@ -315,7 +320,7 @@ export const SearchPage: React.FC<ISearchType> = ({ showAdvanced }) => {
                 prevDateResults={prevDateResults}
                 startDate={startDate}
                 setResults={setPrevDateResults}
-                executeSearch={executeSearch}
+                executeSearch={fetchResults}
               />
             </Show>
             <Loader visible={requests.some((r) => r.url === 'find-contents-with-elasticsearch')} />

--- a/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
+++ b/app/subscriber/src/features/todays-commentary/TodaysCommentary.tsx
@@ -131,7 +131,12 @@ export const TodaysCommentary: React.FC = () => {
         isSelectAllChecked={currentIsSelectAllChecked}
         onReset={handleReset}
       />
-      <DateFilter filter={filter} storeFilter={storeFilter} />
+      <DateFilter
+        date={filter.startDate}
+        onChangeDate={(start, end) =>
+          storeFilter({ ...filter, startDate: start, endDate: end, dateOffset: undefined })
+        }
+      />
       <ContentList
         content={currDateResults}
         selected={currentSelected}

--- a/app/subscriber/src/features/todays-front-pages/TodaysFrontPages.tsx
+++ b/app/subscriber/src/features/todays-front-pages/TodaysFrontPages.tsx
@@ -70,7 +70,12 @@ export const TodaysFrontPages: React.FC = () => {
 
   return (
     <styled.TodaysFrontPages>
-      <DateFilter filter={frontPageFilter} storeFilter={storeFilter} />
+      <DateFilter
+        date={frontPageFilter.startDate}
+        onChangeDate={(start, end) =>
+          storeFilter({ ...frontPageFilter, startDate: start, endDate: end, dateOffset: undefined })
+        }
+      />
       <Loader visible={requests.some((r) => r.url === 'find-contents-with-elasticsearch')} />
       <FrontPageGallery frontpages={frontPages} />
     </styled.TodaysFrontPages>

--- a/app/subscriber/src/features/top-stories/TopStories.tsx
+++ b/app/subscriber/src/features/top-stories/TopStories.tsx
@@ -134,7 +134,12 @@ export const TopStories: React.FC = () => {
         isSelectAllChecked={currentIsSelectAllChecked}
         onReset={handleReset}
       />
-      <DateFilter filter={filter} storeFilter={storeFilter} />
+      <DateFilter
+        date={filter.startDate}
+        onChangeDate={(start, end) =>
+          storeFilter({ ...filter, startDate: start, endDate: end, dateOffset: undefined })
+        }
+      />
       <ContentList
         content={currDateResults}
         onContentSelected={handleContentSelected}


### PR DESCRIPTION
The date navigation component is now displayed on all search result pages.  This date picker does not mutate the current filter.  This however, does currently mean that when returning to the page it may not return to the original date on some pages.

I have also cleaned up the implementation to make the date navigation component more generic.  I have resolved implementation issues that resulted in multiple search requests when they were not needed.  

Basic testing appears positive, but there are a lot of pages that have been touched by this change.

![image](https://github.com/user-attachments/assets/bfa3cfa7-99de-4704-b778-c1eef674d075)
