### PR TITLE
Add CRON job to restart pods

### DIFF
--- a/openshift/kustomize/cron/restart/base/cron-job.yaml
+++ b/openshift/kustomize/cron/restart/base/cron-job.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: restart-service
+  namespace: default
+  annotations:
+    description: CronJob service to restart services.
+  labels:
+    name: restart-service
+    part-of: tno
+    version: 1.0.0
+    component: restart-service
+    managed-by: kustomize
+    created-by: jeremy.foster
+spec:
+  # ttlSecondsAfterFinished: 100
+  schedule: "0 2 * * *" # 2AM every day
+  # schedule: "*/5 * * * *" # Every 5 minutes
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: pipeline
+          restartPolicy: OnFailure
+          containers:
+            - name: restart-service
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 20m
+                  memory: 50Mi
+                limits:
+                  cpu: 150m
+                  memory: 250Mi
+              command:
+                - /bin/sh
+                - "-c"
+                - >-
+                  oc rollout latest dc/api-services &&
+                  oc rollout status dc/api-services &&
+                  oc rollout latest dc/reporting-service &&
+                  oc rollout status dc/reporting-service

--- a/openshift/kustomize/cron/restart/base/kustomization.yaml
+++ b/openshift/kustomize/cron/restart/base/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cron-job.yaml

--- a/openshift/kustomize/cron/restart/overlays/dev/kustomization.yaml
+++ b/openshift/kustomize/cron/restart/overlays/dev/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-dev
+
+resources:
+  - ../../base
+
+patches:

--- a/openshift/kustomize/cron/restart/overlays/prod/kustomization.yaml
+++ b/openshift/kustomize/cron/restart/overlays/prod/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-prod
+
+resources:
+  - ../../base
+
+patches:

--- a/openshift/kustomize/cron/restart/overlays/test/kustomization.yaml
+++ b/openshift/kustomize/cron/restart/overlays/test/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-test
+
+resources:
+  - ../../base
+
+patches:

--- a/openshift/kustomize/services/reporting/base/config-map.yaml
+++ b/openshift/kustomize/services/reporting/base/config-map.yaml
@@ -21,3 +21,4 @@ data:
   CHES_EMAIL_AUTHORIZED: "true"
   CHARTS_URL: http://charts-api:8080
   RESEND_ON_FAILURE: "true"
+  SEND_TO_ALL_BEFORE_FAILING: "false"

--- a/openshift/kustomize/services/reporting/base/deploy.yaml
+++ b/openshift/kustomize/services/reporting/base/deploy.yaml
@@ -155,6 +155,11 @@ spec:
                 configMapKeyRef:
                   name: reporting-service
                   key: RESEND_ON_FAILURE
+            - name: Service__SendToAllSubscribersBeforeFailing
+              valueFrom:
+                configMapKeyRef:
+                  name: reporting-service
+                  key: SEND_TO_ALL_BEFORE_FAILING
             - name: Service__Topics
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
This CRON job will restart the api-services and reporting-services at 2 AM every night.  This is to reduce the chance of the Out of Memory leak we have.

The restart is a rolling release, so there should be no down time.