### PR TITLE
Add local nuget to docker

### DIFF
--- a/services/net/contentmigration/Dockerfile
+++ b/services/net/contentmigration/Dockerfile
@@ -11,6 +11,7 @@ USER 0
 
 WORKDIR /src
 
+COPY ../../../libs/net/packages /root/.nuget/packages
 COPY services/net/contentmigration services/net/contentmigration
 COPY libs/net libs/net
 
@@ -18,6 +19,7 @@ RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u 
     fix_permissions "/tmp"
 
 WORKDIR /src/services/net/contentmigration
+RUN dotnet restore
 RUN dotnet build -c $ASPNETCORE_ENVIRONMENT -o /build
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 as deploy

--- a/services/net/contentmigration/NuGet.Config
+++ b/services/net/contentmigration/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="local-packages" value="/root/.nuget/packages" />
+  </packageSources>
+</configuration>

--- a/services/net/nlp/Dockerfile
+++ b/services/net/nlp/Dockerfile
@@ -11,6 +11,7 @@ USER 0
 
 WORKDIR /src
 
+COPY ../../../libs/net/packages /root/.nuget/packages
 COPY services/net/nlp services/net/nlp
 COPY libs/net libs/net
 

--- a/services/net/nlp/NuGet.Config
+++ b/services/net/nlp/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="local-packages" value="/root/.nuget/packages" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
The docker images that require local nuget packages need a few teaks so that they work.