### PR TITLE
Fix select content

### DIFF
--- a/app/subscriber/src/components/content-list/ContentList.tsx
+++ b/app/subscriber/src/components/content-list/ContentList.tsx
@@ -1,11 +1,14 @@
 import { AxiosError } from 'axios';
+import { castToSearchResult } from 'features/utils';
 import { IContentSearchResult } from 'features/utils/interfaces';
+import _ from 'lodash';
 import React from 'react';
 import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useApp, useContent, useLookup } from 'store/hooks';
 import {
+  generateQuery,
   IContentModel,
   IFileReferenceModel,
   IFilterSettingsModel,
@@ -71,6 +74,7 @@ export const ContentList: React.FC<IContentListProps> = ({
   const [, { streamSilent }] = useContent();
   const [{ settings }] = useLookup();
   const [{ requests }] = useApp();
+  const [, { findContentWithElasticsearch }] = useContent();
 
   const [activeStream, setActiveStream] = React.useState<{ source: string; id: number }>({
     id: 0,
@@ -88,7 +92,30 @@ export const ContentList: React.FC<IContentListProps> = ({
     };
     window.addEventListener('beforeunload', handleBeforeUnload);
     if (existing) {
-      onContentSelected(JSON.parse(existing));
+      const selected: number[] = JSON.parse(existing);
+      const selectedContent = content.filter((c) => selected.includes(c.id));
+      const missingContent = selected.filter((s) => !selectedContent.some((c) => c.id === s));
+      if (missingContent.length) {
+        // Need to fetch any content currently not in memory.
+        findContentWithElasticsearch(
+          generateQuery({
+            contentIds: missingContent,
+            searchUnpublished: true,
+            size: missingContent.length,
+          }),
+          true,
+        )
+          .then((data) => {
+            onContentSelected([
+              ...selectedContent,
+              ...data.hits.hits.map((r) => {
+                const content = r._source as IContentModel;
+                return castToSearchResult(content);
+              }),
+            ]);
+          })
+          .catch(() => {});
+      } else onContentSelected(selectedContent);
     }
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
@@ -101,16 +128,18 @@ export const ContentList: React.FC<IContentListProps> = ({
   React.useEffect(() => {
     if (!cacheCheck) return;
     const existing = localStorage.getItem('selected');
-    let array;
+    let array: number[];
     if (existing) {
       array = JSON.parse(existing);
     } else {
       array = [];
     }
     if (array.length !== selected?.length) {
-      array = selected;
+      array = _.uniq([...array, ...selected.map((i) => i.id)]);
+      localStorage.setItem('selected', JSON.stringify(array));
+    } else if (!existing) {
+      localStorage.setItem('selected', JSON.stringify(array));
     }
-    localStorage.setItem('selected', JSON.stringify(array));
     // only want to fire when selected changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selected]);

--- a/openshift/kustomize/api/base/statefulset.yaml
+++ b/openshift/kustomize/api/base/statefulset.yaml
@@ -192,7 +192,7 @@ spec:
                 configMapKeyRef:
                   name: reporting-shared
                   key: REPORTING_REQUEST_TRANSCRIPT_URL
-            
+
             # S3 Configuration
             - name: S3_ACCESS_KEY
               valueFrom:
@@ -214,7 +214,6 @@ spec:
                 secretKeyRef:
                   name: s3-backup-credentials
                   key: S3_SERVICE_URL
-
 
             # CHES Configuration
             - name: CHES__From


### PR DESCRIPTION
The page would crash when selecting a lot of content.  This would occur because the implementation would store all the content information into local storage.

This update only stores the content Id values.  However, this does request adding a way to fetch content that was selected but is not currently in memory.

![image](https://github.com/user-attachments/assets/a891d2b3-ca1b-4aaa-b5b1-03e9426e8477)
