### PR TITLE
MMI 1815 option omit BCupdates

### DIFF
--- a/app/editor/src/features/admin/reports/components/ReportContentOptions.tsx
+++ b/app/editor/src/features/admin/reports/components/ReportContentOptions.tsx
@@ -73,6 +73,11 @@ export const ReportContentOptions = () => {
               name="settings.content.clearFolders"
               tooltip="Clears all content from all folders in this report after this report is run"
             />
+            <FormikCheckbox
+              label="Omit 'BC Updates' and 'BC Calendar' from the report"
+              name="settings.content.omitBCUpdates"
+              tooltip="Omits 'BC Updates' and 'BC Calendar' from the report"
+            />
           </Col>
         </Row>
       </Col>

--- a/app/subscriber/src/features/my-reports/edit/settings/ReportEditPreferencesForm.tsx
+++ b/app/subscriber/src/features/my-reports/edit/settings/ReportEditPreferencesForm.tsx
@@ -87,7 +87,6 @@ export const ReportEditPreferencesForm = () => {
         <FormikCheckbox
           name="settings.content.omitBCUpdates"
           label="Omit all BC Updates and BC Calendars from report"
-          disabled
         />
         <Row>
           <FormikCheckbox

--- a/libs/net/dal/Extensions/JsonDocumentExtensions.cs
+++ b/libs/net/dal/Extensions/JsonDocumentExtensions.cs
@@ -254,23 +254,47 @@ public static class JsonDocumentExtensions
             ((JsonObject)boolNode!)["must_not"] = mustNotNode;
         }
 
-        // Add first query_string to exclude "BC Update"
+        // Add a bool query to combine mediaType and content conditions
         ((JsonArray)mustNotNode!).Add(new JsonObject
         {
-            ["query_string"] = new JsonObject
+            ["bool"] = new JsonObject
             {
-                ["query"] = "\"BC Updates\"",
-                ["fields"] = new JsonArray { "headline" }
-            }
-        });
-
-        // Add second query_string to exclude "BC Calendar"
-        ((JsonArray)mustNotNode!).Add(new JsonObject
-        {
-            ["query_string"] = new JsonObject
-            {
-                ["query"] = "\"BC Calendar\"",
-                ["fields"] = new JsonArray { "body" }
+                ["must"] = new JsonArray
+                {
+                    new JsonObject
+                    {
+                        ["term"] = new JsonObject
+                        {
+                            ["mediaType.name.keyword"] = "CP Wire"
+                        }
+                    },
+                    new JsonObject
+                    {
+                        ["bool"] = new JsonObject
+                        {
+                            ["should"] = new JsonArray
+                            {
+                                new JsonObject
+                                {
+                                    ["query_string"] = new JsonObject
+                                    {
+                                        ["query"] = "\"BC Updates\"",
+                                        ["fields"] = new JsonArray { "headline" }
+                                    }
+                                },
+                                new JsonObject
+                                {
+                                    ["query_string"] = new JsonObject
+                                    {
+                                        ["query"] = "\"BC Calendar\"",
+                                        ["fields"] = new JsonArray { "body" }
+                                    }
+                                }
+                            },
+                            ["minimum_should_match"] = 1
+                        }
+                    }
+                }
             }
         });
 

--- a/libs/net/dal/Extensions/JsonDocumentExtensions.cs
+++ b/libs/net/dal/Extensions/JsonDocumentExtensions.cs
@@ -230,11 +230,21 @@ public static class JsonDocumentExtensions
     /// <returns></returns>
     public static JsonDocument ExcludeBCUpdates(this JsonDocument query)
     {
-        var json = JsonNode.Parse(query.ToJson())?.AsObject();
+        JsonNode? jsonNode;
+        try
+        {
+            jsonNode = JsonNode.Parse(query.ToJson());
+        }
+        catch (JsonException)
+        {
+            return query;
+        }
+
+        var json = jsonNode?.AsObject();
         if (json == null) return query;
 
-        // Get the query object
-        if (!json.TryGetPropertyValue("query", out var queryNode))
+        // Get or create the query object
+        if (!json.TryGetPropertyValue("query", out var queryNode) || queryNode == null)
         {
             queryNode = new JsonObject();
             json["query"] = queryNode;

--- a/libs/net/dal/Extensions/JsonDocumentExtensions.cs
+++ b/libs/net/dal/Extensions/JsonDocumentExtensions.cs
@@ -259,8 +259,8 @@ public static class JsonDocumentExtensions
         {
             ["query_string"] = new JsonObject
             {
-                ["query"] = "\"BC Update\"",
-                ["fields"] = new JsonArray { "body" }
+                ["query"] = "\"BC Updates\"",
+                ["fields"] = new JsonArray { "headline" }
             }
         });
 
@@ -270,7 +270,7 @@ public static class JsonDocumentExtensions
             ["query_string"] = new JsonObject
             {
                 ["query"] = "\"BC Calendar\"",
-                ["fields"] = new JsonArray { "headline" }
+                ["fields"] = new JsonArray { "body" }
             }
         });
 

--- a/libs/net/dal/Extensions/JsonDocumentExtensions.cs
+++ b/libs/net/dal/Extensions/JsonDocumentExtensions.cs
@@ -228,7 +228,7 @@ public static class JsonDocumentExtensions
     /// </summary>
     /// <param name="query"></param>
     /// <returns></returns>
-    public static JsonDocument ExcludeBCUpdate(this JsonDocument query)
+    public static JsonDocument ExcludeBCUpdates(this JsonDocument query)
     {
         var json = JsonNode.Parse(query.ToJson())?.AsObject();
         if (json == null) return query;

--- a/libs/net/dal/Services/ReportService.cs
+++ b/libs/net/dal/Services/ReportService.cs
@@ -878,6 +878,8 @@ public class ReportService : BaseService<Report, int>, IReportService
                 // Only include content that has been posted since the last report instance.
                 if (reportSettings.Content.OnlyNewContent)
                     query = query.IncludeOnlyLatestPosted(previousInstance?.PublishedOn);
+                if (reportSettings.Content.OmitBCUpdates)
+                    query = query.ExcludeBCUpdates();
 
                 // Determine index.
                 var defaultIndex = filterSettings.SearchUnpublished ? _elasticOptions.UnpublishedIndex : _elasticOptions.PublishedIndex;

--- a/libs/net/models/Settings/ReportContentSettingsModel.cs
+++ b/libs/net/models/Settings/ReportContentSettingsModel.cs
@@ -15,6 +15,7 @@ public class ReportContentSettingsModel
     public bool CopyPriorInstance { get; set; }
     public bool ClearOnStartNewReport { get; set; }
     public bool ExcludeContentInUnsentReport { get; set; }
+    public bool OmitBCUpdates { get; set; }
     #endregion
 
     #region Constructors
@@ -31,6 +32,7 @@ public class ReportContentSettingsModel
         this.CopyPriorInstance = settings.GetDictionaryJsonValue("copyPriorInstance", false, options)!;
         this.ClearOnStartNewReport = settings.GetDictionaryJsonValue("clearOnStartNewReport", false, options)!;
         this.ExcludeContentInUnsentReport = settings.GetDictionaryJsonValue("excludeContentInUnsentReport", true, options)!;
+        this.OmitBCUpdates = settings.GetDictionaryJsonValue("omitBCUpdates", false, options)!;
     }
     #endregion
 }

--- a/libs/net/models/Settings/ReportSettingsModel.cs
+++ b/libs/net/models/Settings/ReportSettingsModel.cs
@@ -30,6 +30,11 @@ public class ReportSettingsModel
     /// get/set - Treat the report as if it was sent, but do not email it out.
     /// </summary>
     public bool DoNotSendEmail { get; set; } = false;
+
+    /// <summary>
+    /// get/set - Omit BC Update content.
+    /// </summary>
+    public bool OmitBCUpdates { get; set; } = false;
     #endregion
 
     #region Constructors
@@ -42,6 +47,7 @@ public class ReportSettingsModel
         this.Content = settings.GetDictionaryJsonValue<ReportContentSettingsModel>("content", new(), options)!;
         this.Sections = settings.GetDictionaryJsonValue<ReportSectionsSettingsModel>("sections", new(), options)!;
         this.DoNotSendEmail = settings.GetDictionaryJsonValue<bool>("doNotSendEmail", false, options)!;
+        this.OmitBCUpdates = settings.GetDictionaryJsonValue<bool>("omitBCUpdates", false, options)!;
     }
     #endregion
 }


### PR DESCRIPTION
Add a ES search filter to excludes `BC updates` (headline) and `BC colander` (Body)

### `before switching on the filter`
![image](https://github.com/user-attachments/assets/c9effb84-3082-46b8-bb88-77c91f9e0026)


### `checked on`
![image](https://github.com/user-attachments/assets/fb4ba77c-6cec-42a9-9423-2ae5f0fecd35)


### `Omit BC updates and BC Calendar`
![image](https://github.com/user-attachments/assets/3eda5828-f9a3-410a-aca3-0b366dae52b5)
