### PR TITLE
File copy didn't exist. Fix broken pipeline.

### DIFF
--- a/openshift/kustomize/tekton/base/tasks/deploy-all.yaml
+++ b/openshift/kustomize/tekton/base/tasks/deploy-all.yaml
@@ -168,16 +168,6 @@ spec:
         )
 
         declare -A COMPONENT10=(
-          [id]="filecopy"
-          [name]="filecopy-service"
-          [type]="dc"
-          [replicas]="1"
-          [action]="stop"
-          [build]="yes"
-          [env]="dev test prod"
-        )
-
-        declare -A COMPONENT11=(
           [id]="reporting"
           [name]="reporting-service"
           [type]="dc"
@@ -187,7 +177,7 @@ spec:
           [env]="dev test prod"
         )
 
-        declare -A COMPONENT12=(
+        declare -A COMPONENT11=(
           [id]="notification"
           [name]="notification-service"
           [type]="dc"
@@ -197,7 +187,7 @@ spec:
           [env]="dev test prod"
         )
 
-        declare -A COMPONENT13=(
+        declare -A COMPONENT12=(
           [id]="scheduler"
           [name]="scheduler-service"
           [type]="dc"
@@ -207,7 +197,7 @@ spec:
           [env]="dev test prod"
         )
 
-        declare -A COMPONENT14=(
+        declare -A COMPONENT13=(
           [id]="folder-collection"
           [name]="folder-collection-service"
           [type]="dc"
@@ -217,7 +207,7 @@ spec:
           [env]="dev test prod"
         )
 
-        declare -A COMPONENT15=(
+        declare -A COMPONENT14=(
           [id]="ffmpeg"
           [name]="ffmpeg-service"
           [type]="dc"
@@ -227,7 +217,7 @@ spec:
           [env]="dev test prod"
         )
 
-        declare -A COMPONENT16=(
+        declare -A COMPONENT15=(
           [id]="event-handler"
           [name]="event-handler-service"
           [type]="dc"
@@ -239,7 +229,7 @@ spec:
 
         # Ingest Services
 
-        declare -A COMPONENT17=(
+        declare -A COMPONENT16=(
           [id]="syndication"
           [name]="syndication-service"
           [type]="dc"
@@ -249,7 +239,7 @@ spec:
           [env]="dev test prod"
         )
 
-        declare -A COMPONENT18=(
+        declare -A COMPONENT17=(
           [id]="filemonitor"
           [name]="filemonitor-service"
           [type]="dc"
@@ -259,7 +249,7 @@ spec:
           [env]="dev test prod"
         )
 
-        declare -A COMPONENT19=(
+        declare -A COMPONENT18=(
           [id]="image"
           [name]="image-service"
           [type]="dc"
@@ -269,7 +259,7 @@ spec:
           [env]="dev test prod"
         )
 
-        declare -A COMPONENT20=(
+        declare -A COMPONENT19=(
           [id]="capture"
           [name]="capture-service"
           [type]="dc"
@@ -279,7 +269,7 @@ spec:
           [env]="dev test prod"
         )
 
-        declare -A COMPONENT21=(
+        declare -A COMPONENT20=(
           [id]="clip"
           [name]="clip-service"
           [type]="dc"
@@ -289,7 +279,7 @@ spec:
           [env]="dev test prod"
         )
 
-        declare -A COMPONENT22=(
+        declare -A COMPONENT21=(
           [id]="contentmigration"
           [name]="contentmigration-service"
           [type]="dc"
@@ -299,7 +289,7 @@ spec:
           [env]="dev test prod"
         )
 
-        declare -A COMPONENT23=(
+        declare -A COMPONENT22=(  
           [id]="contentmigration"
           [name]="contentmigration-historic-service"
           [type]="dc"

--- a/openshift/scripts/deploy.sh
+++ b/openshift/scripts/deploy.sh
@@ -42,7 +42,6 @@ podsIndexing=$(getPods indexing-service dc $env)
 podsContent=$(getPods content-service dc $env)
 podsContentTNOHistoric=$(getPods content-historic-service dc $env)
 
-podsFileCopy=$(getPods filecopy-service dc $env)
 podsFolderCollection=$(getPods folder-collection-service dc $env)
 
 # podsClip=$(getPods clip-service dc $env)
@@ -85,7 +84,6 @@ oc tag indexing-service:$tag indexing-service:$env
 oc tag content-service:$tag content-service:$env
 
 # Utility Services
-oc tag filecopy-service:$tag filecopy-service:$env
 oc tag folder-collection-service:$tag folder-collection-service:$env
 
 # Transform Services
@@ -119,7 +117,6 @@ scale indexing-service $podsIndexing dc $env
 scale content-service $podsContent dc $env
 scale content-historic-service $podsContentTNOHistoric dc $env
 
-scale filecopy-service $podsFileCopy dc $env
 scale folder-collection-service $podsFolderCollection dc $env
 
 # scale clip-service $podsClip dc $env


### PR DESCRIPTION
I saw this from pipeline. 

I think scale filecopy cause this erorr.
```

step-deploy

Stopping extract-quotes
Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
Warning: extensions/v1beta1 Scale is deprecated in v1.2+, unavailable in v1.16+
deploymentconfig.apps.openshift.io/extract-quotes-service scaled
Stopping filecopy
Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
error: no objects passed to scale
```

