### PR TITLE
Hide CBRA unqualified

### DIFF
--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -678,11 +678,12 @@ const ContentForm: React.FC<IContentFormProps> = ({
                                       }
                                     />
                                   </div>
-                                  <FormikCheckbox
+                                  {/* Temporarily hidden to avoid confusing Editors */}
+                                  {/* <FormikCheckbox
                                     label="Is CBRA Unqualified"
                                     name="isCBRAUnqualified"
                                     className="checkbox-cbra"
-                                  />
+                                  /> */}
                                 </Row>
                               </Show>
                             </Row>


### PR DESCRIPTION
We need to temporarily remove the new checkbox so that we don't cause confusion to Editors.  This was merged by me into PROD prematurely due to a bug fix with export report.