### PR TITLE
Fix chart options

### DIFF
--- a/libs/net/template/Models/Charts/Options/ChartOptionsModel.cs
+++ b/libs/net/template/Models/Charts/Options/ChartOptionsModel.cs
@@ -36,6 +36,6 @@ public class ChartOptionsModel
     /// get/set -
     /// </summary>
     [JsonPropertyName("maintainAspectRatio")]
-    public string? MaintainAspectRatio { get; set; }
+    public bool? MaintainAspectRatio { get; set; }
     #endregion
 }

--- a/libs/net/template/Models/Charts/Options/ChartOptionsPluginModel.cs
+++ b/libs/net/template/Models/Charts/Options/ChartOptionsPluginModel.cs
@@ -36,6 +36,6 @@ public class ChartOptionsPluginModel
     /// get/set -
     /// </summary>
     [JsonPropertyName("datalabels")]
-    public ChartOptionsPluginDataLabelsModel? Datalabels { get; set; }
+    public ChartOptionsPluginDataLabelsModel? DataLabels { get; set; }
     #endregion
 }


### PR DESCRIPTION
For some reason `maintainAspectRatio` was failing to deserialize boolean values.  However, this has not occurred in the past.  I'm not confident this will work either 100%.