### PR TITLE
Replace CrunchyDB

### DIFF
--- a/db/postgres/docker/Dockerfile.prod
+++ b/db/postgres/docker/Dockerfile.prod
@@ -1,0 +1,3 @@
+FROM postgres:15.6
+
+COPY ./scripts /docker-entrypoint-initdb.d/

--- a/openshift/kustomize/api-services/base/deploy.yaml
+++ b/openshift/kustomize/api-services/base/deploy.yaml
@@ -70,9 +70,6 @@ spec:
             - name: ingest-storage
               mountPath: /mnt/ingest
           resources:
-            limits:
-              cpu: 500m
-              memory: 1536Mi
             requests:
               cpu: 100m
               memory: 350Mi
@@ -140,13 +137,13 @@ spec:
             - name: DB_POSTGRES_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: crunchy-pguser-admin
-                  key: user
+                  name: database
+                  key: USERNAME
             - name: DB_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: crunchy-pguser-admin
-                  key: password
+                  name: database
+                  key: PASSWORD
 
             - name: Elastic__Url
               valueFrom:
@@ -179,7 +176,7 @@ spec:
                 configMapKeyRef:
                   name: reporting-shared
                   key: REPORTING_REQUEST_TRANSCRIPT_URL
-            
+
             # S3 Configuration
             - name: S3_ACCESS_KEY
               valueFrom:

--- a/openshift/kustomize/api/base/deploy.yaml
+++ b/openshift/kustomize/api/base/deploy.yaml
@@ -70,9 +70,6 @@ spec:
             - name: ingest-storage
               mountPath: /mnt/ingest
           resources:
-            limits:
-              cpu: 500m
-              memory: 1536Mi
             requests:
               cpu: 100m
               memory: 350Mi
@@ -137,13 +134,13 @@ spec:
             - name: DB_POSTGRES_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: crunchy-pguser-admin
-                  key: user
+                  name: database
+                  key: USERNAME
             - name: DB_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: crunchy-pguser-admin
-                  key: password
+                  name: database
+                  key: PASSWORD
 
             - name: Elastic__Url
               valueFrom:
@@ -176,7 +173,7 @@ spec:
                 configMapKeyRef:
                   name: reporting-shared
                   key: REPORTING_REQUEST_TRANSCRIPT_URL
-                  
+
             # S3 Configuration
             - name: S3_ACCESS_KEY
               valueFrom:

--- a/openshift/kustomize/api/base/statefulset.yaml
+++ b/openshift/kustomize/api/base/statefulset.yaml
@@ -86,9 +86,6 @@ spec:
             - name: ingest-storage
               mountPath: /mnt/ingest
           resources:
-            limits:
-              cpu: 500m
-              memory: 1536Mi
             requests:
               cpu: 100m
               memory: 350Mi
@@ -150,13 +147,13 @@ spec:
             - name: DB_POSTGRES_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: crunchy-pguser-admin
-                  key: user
+                  name: database
+                  key: USERNAME
             - name: DB_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: crunchy-pguser-admin
-                  key: password
+                  name: database
+                  key: PASSWORD
 
             - name: Elastic__Url
               valueFrom:

--- a/openshift/kustomize/elastic/base/statefulset.yaml
+++ b/openshift/kustomize/elastic/base/statefulset.yaml
@@ -63,9 +63,6 @@ spec:
             requests:
               cpu: 100m
               memory: 850Mi
-            limits:
-              cpu: 200m
-              memory: 1500Mi
           ports:
             - containerPort: 9200
               name: 9200-tcp

--- a/openshift/kustomize/kafka/broker/base/statefulset.yaml
+++ b/openshift/kustomize/kafka/broker/base/statefulset.yaml
@@ -81,9 +81,6 @@ spec:
             requests:
               cpu: 50m
               memory: 3Gi
-            limits:
-              cpu: 100m
-              memory: 5Gi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           env:

--- a/openshift/kustomize/postgres/crunchy/README.md
+++ b/openshift/kustomize/postgres/crunchy/README.md
@@ -11,14 +11,14 @@ To install the CrunchyDB HA Cluster in the **dev** namespace, run the following 
 To perform an adhoc backup of the database run the following command.
 
 ```bash
-oc annotate -n 9b301c-test postgrescluster postgres-cluster \
+oc annotate -n 9b301c-prod postgrescluster crunchy \
   postgres-operator.crunchydata.com/pgbackrest-backup="$( date '+%F_%H:%M:%S' )"
 ```
 
 Subsequent runs will require the `--overwrite` attribute.
 
 ```bash
-oc annotate -n 9b301c-test postgrescluster postgres-cluster --overwrite \
+oc annotate -n 9b301c-prod postgrescluster crunchy --overwrite \
   postgres-operator.crunchydata.com/pgbackrest-backup="$( date '+%F_%H:%M:%S' )"
 ```
 
@@ -56,7 +56,7 @@ oc kustomize openshift/kustomize/postgres/crunchy/overlays/dev | oc apply -f -
 You will need to wait and confirm the backup has been completed, as this is just a request for it do it when it can.
 
 ```bash
-oc annotate -n 9b301c-test postgrescluster postgres-cluster \
+oc annotate -n 9b301c-test postgrescluster crunchy \
   postgres-operator.crunchydata.com/pgbackrest-backup="$( date '+%F_%H:%M:%S' )"
 ```
 
@@ -79,13 +79,13 @@ Link the cluster to the update.
 
 ```bash
 # Annotate the cluster
-oc -n 9b301c-dev annotate postgrescluster crunchy postgres-operator.crunchydata.com/allow-upgrade="crunchy-upgrade"
+oc -n 9b301c-prod annotate postgrescluster crunchy postgres-operator.crunchydata.com/allow-upgrade="crunchy-upgrade"
 ```
 
 Shutdown the cluster.
 
 ```bash
-oc patch postgrescluster/crunchy -n 9b301c-dev --type merge --patch '{"spec":{"shutdown": true}}'
+oc patch postgrescluster/crunchy -n 9b301c-prod --type merge --patch '{"spec":{"shutdown": true}}'
 ```
 
 ### Step 6: Watch and Wait
@@ -93,7 +93,7 @@ oc patch postgrescluster/crunchy -n 9b301c-dev --type merge --patch '{"spec":{"s
 Check on status.
 
 ```bash
-oc describe pgupgrade -n 9b301c-dev
+oc describe pgupgrade -n 9b301c-prod
 ```
 
 ### Step 7: Restart
@@ -101,10 +101,10 @@ oc describe pgupgrade -n 9b301c-dev
 Update `PostgresCluster` object with `spec.postgresVersion: 15`.
 
 ```bash
-oc patch postgrescluster/crunchy -n 9b301c-dev --type merge --patch '{"spec":{"postgresVersion": 15}}'
+oc patch postgrescluster/crunchy -n 9b301c-prod --type merge --patch '{"spec":{"postgresVersion": 15}}'
 
 # Start up again
-oc patch postgrescluster/crunchy -n 9b301c-dev --type merge --patch '{"spec":{"shutdown": false}}'
+oc patch postgrescluster/crunchy -n 9b301c-prod --type merge --patch '{"spec":{"shutdown": false}}'
 ```
 
 ### Other Commands
@@ -113,4 +113,10 @@ If you need to restart.
 
 ```bash
 oc patch postgrescluster/crunchy -n 9b301c-dev --type merge --patch '{"spec":{"metadata":{"annotations":{"restarted":"'"$(date)"'"}}}}'
+```
+
+### Restore
+
+```bash
+oc annotate -n 9b301c-dev postgrescluster crunchy --overwrite postgres-operator.crunchydata.com/pgbackrest-restore="$(date)"
 ```

--- a/openshift/kustomize/postgres/crunchy/base/deploy.yaml
+++ b/openshift/kustomize/postgres/crunchy/base/deploy.yaml
@@ -11,9 +11,8 @@ metadata:
     component: postgres
     managed-by: kustomize
     created-by: jeremy.foster
-    updated-by: kulpree
 spec:
-  postgresVersion: 14
+  postgresVersion: 15
   users:
     - name: postgres
     - name: admin
@@ -26,9 +25,6 @@ spec:
           requests:
             cpu: 25m
             memory: 100Mi
-          limits:
-            cpu: 50m
-            memory: 250Mi
   instances:
     - name: postgres
       replicas: 3
@@ -36,9 +32,6 @@ spec:
         requests:
           cpu: 50m
           memory: 250Mi
-        limits:
-          cpu: 250m
-          memory: 2Gi
       dataVolumeClaimSpec:
         accessModes:
           - ReadWriteOnce
@@ -69,11 +62,14 @@ spec:
             requests:
               cpu: 25m
               memory: 100Mi
-            limits:
-              cpu: 100m
-              memory: 250Mi
   backups:
     pgbackrest:
+      # restore:
+      #   enabled: true
+      #   repoName: repo1
+      #   options:
+      #     - --type=time
+      #     - --target="2024-01-04 12:00:00-00"
       global:
         repo1-retention-full: "1"
       repoHost:
@@ -81,9 +77,6 @@ spec:
           requests:
             cpu: 50m
             memory: 100Mi
-          limits:
-            cpu: 250m
-            memory: 1Gi
       jobs:
         ttlSecondsAfterFinished: 100
       repos:
@@ -111,17 +104,11 @@ spec:
             requests:
               cpu: 50m
               memory: 50Mi
-            limits:
-              cpu: 250m
-              memory: 500Mi
         pgbackrestConfig:
           resources:
             requests:
               cpu: 25m
               memory: 50Mi
-            limits:
-              cpu: 100m
-              memory: 500Mi
   proxy:
     pgBouncer:
       config:
@@ -132,9 +119,6 @@ spec:
         requests:
           cpu: 25m
           memory: 100Mi
-        limits:
-          cpu: 50m
-          memory: 250Mi
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/openshift/kustomize/postgres/crunchy/base/upgrade.yaml
+++ b/openshift/kustomize/postgres/crunchy/base/upgrade.yaml
@@ -1,0 +1,8 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: crunchy-upgrade
+spec:
+  postgresClusterName: crunchy
+  fromPostgresVersion: 14
+  toPostgresVersion: 15

--- a/openshift/kustomize/postgres/crunchy/overlays/prod/kustomization.yaml
+++ b/openshift/kustomize/postgres/crunchy/overlays/prod/kustomization.yaml
@@ -16,6 +16,6 @@ patches:
         value: 3
       - op: replace
         path: /spec/instances/0/dataVolumeClaimSpec/resources/requests/storage
-        value: 28Gi
+        value: 37Gi
         path: /spec/backups/pgbackrest/repos/0/volume/volumeClaimSpec/resources/requests/storage
         value: 65Gi

--- a/openshift/kustomize/postgres/standalone/README.md
+++ b/openshift/kustomize/postgres/standalone/README.md
@@ -1,0 +1,49 @@
+# Postgres
+
+Connect to remote database.
+
+```bash
+# Connect to remote Azure database.
+psql -h mmi-prod.postgres.database.azure.com -p 5432 -U mmi mmi-prod
+
+# Connect to Openshift database within Openshift
+psql -h crunchy-primary -p 5432 -U admin tno
+```
+
+Create a backup.
+
+```bash
+# Create a backup of the production database by a pod in Openshift.
+PGPASSWORD=""
+pg_dump --column-inserts -d tno -h crunchy-primary -p 5432 -U admin -W -v > full-backup.sql
+```
+
+Restore the backup.
+
+```bash
+# Run SQL and restore the database.
+psql -h postgres -p 5432 -U admin -f full-backup.sql -d tno
+psql -h localhost -p 5432 -U postgres -f full-backup.sql -d tno
+psql -h localhost -p 5432 -U admin -f full-backup.sql -d tno
+psql -h mmi-prod.postgres.database.azure.com -p 5432 -U mmi -f full-backup.sql -d mmi-prod
+```
+
+```bash
+#!/bin/bash
+OUTPUT_FILE="./trace.out"
+
+nohup psql -h localhost -p 5432 -U admin -d tno -a -f full-backup.sql >> ${OUTPUT_FILE} 2>&1 < /dev/null &
+```
+
+```bash
+#!/bin/sh
+while true
+do
+  > trace.out
+  sleep 10m
+done
+```
+
+```bash
+nohup ./clear.sh 2>&1 < /dev/null &
+```

--- a/openshift/kustomize/postgres/standalone/base/kustomization.yaml
+++ b/openshift/kustomize/postgres/standalone/base/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - statefulset.yaml
+  - service.yaml

--- a/openshift/kustomize/postgres/standalone/base/service.yaml
+++ b/openshift/kustomize/postgres/standalone/base/service.yaml
@@ -1,0 +1,26 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: postgres
+  namespace: default
+  annotations:
+    description: Exposes and load balances the postgres pods.
+  labels:
+    name: postgres
+    part-of: tno
+    version: 1.0.0
+    component: database
+    managed-by: kustomize
+    created-by: jeremy.foster
+spec:
+  ports:
+    - name: 5432-tcp
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    part-of: tno
+    component: database
+  sessionAffinity: None
+  type: ClusterIP

--- a/openshift/kustomize/postgres/standalone/base/statefulset.yaml
+++ b/openshift/kustomize/postgres/standalone/base/statefulset.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: default
+  annotations:
+    description: Deploy PostgeSQL database
+  labels:
+    name: postgres
+    part-of: tno
+    version: 1.0.0
+    component: database
+    managed-by: kustomize
+    created-by: jeremy.foster
+    DataClass: Low
+spec:
+  serviceName: postgres
+  replicas: 1
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      statefulset: postgres
+  template:
+    metadata:
+      labels:
+        part-of: tno
+        component: database
+        statefulset: postgres
+        DataClass: Low
+    spec:
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 0
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: statefulset
+                    operator: In
+                    values:
+                      - postgres
+              topologyKey: "kubernetes.io/hostname"
+      volumes:
+        - name: postgres
+          persistentVolumeClaim:
+            claimName: postgres
+      containers:
+        - name: api
+          image: registry.redhat.io/rhel8/postgresql-15
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          volumeMounts:
+            - name: postgres
+              mountPath: /var/lib/pgsql/data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 2Gi
+          env:
+            - name: POSTGRESQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: crunchy-pguser-admin
+                  key: dbname
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: crunchy-pguser-admin
+                  key: user
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: crunchy-pguser-admin
+                  key: password
+
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres
+        labels:
+          name: postgres
+          part-of: tno
+          component: database
+          DataClass: Low
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: netapp-block-standard
+        resources:
+          requests:
+            storage: 20Gi

--- a/openshift/kustomize/postgres/standalone/overlays/dev/kustomization.yaml
+++ b/openshift/kustomize/postgres/standalone/overlays/dev/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-dev
+
+resources:
+  - ../../base
+
+patches:

--- a/openshift/kustomize/postgres/standalone/overlays/prod/kustomization.yaml
+++ b/openshift/kustomize/postgres/standalone/overlays/prod/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-prod
+
+resources:
+  - ../../base
+
+patches:

--- a/openshift/kustomize/postgres/standalone/overlays/test/kustomization.yaml
+++ b/openshift/kustomize/postgres/standalone/overlays/test/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: 9b301c-test
+
+resources:
+  - ../../base
+
+patches:

--- a/openshift/kustomize/services/content-historic/base/deploy.yaml
+++ b/openshift/kustomize/services/content-historic/base/deploy.yaml
@@ -51,9 +51,6 @@ spec:
             - name: ingest-storage
               mountPath: /data
           resources:
-            limits:
-              cpu: 125m
-              memory: 350Mi
             requests:
               cpu: 25m
               memory: 100Mi

--- a/openshift/kustomize/services/content/base/deploy.yaml
+++ b/openshift/kustomize/services/content/base/deploy.yaml
@@ -51,12 +51,9 @@ spec:
             - name: ingest-storage
               mountPath: /data
           resources:
-            limits:
-              cpu: 50m
-              memory: 256Mi
             requests:
               cpu: 25m
-              memory: 128Mi
+              memory: 150Mi
           env:
             # .NET Configuration
             - name: ASPNETCORE_ENVIRONMENT

--- a/openshift/kustomize/services/indexing/base/deploy.yaml
+++ b/openshift/kustomize/services/indexing/base/deploy.yaml
@@ -44,9 +44,6 @@ spec:
             - containerPort: 8080
               protocol: TCP
           resources:
-            limits:
-              cpu: 50m
-              memory: 256Mi
             requests:
               cpu: 25m
               memory: 80Mi

--- a/openshift/kustomize/services/notification/base/deploy.yaml
+++ b/openshift/kustomize/services/notification/base/deploy.yaml
@@ -47,9 +47,6 @@ spec:
             requests:
               cpu: 20m
               memory: 80Mi
-            limits:
-              cpu: 100m
-              memory: 200Mi
           env:
             # .NET Configuration
             - name: ASPNETCORE_ENVIRONMENT

--- a/openshift/kustomize/services/reporting/base/deploy.yaml
+++ b/openshift/kustomize/services/reporting/base/deploy.yaml
@@ -47,9 +47,6 @@ spec:
             requests:
               cpu: 20m
               memory: 80Mi
-            limits:
-              cpu: 100m
-              memory: 200Mi
           env:
             # .NET Configuration
             - name: ASPNETCORE_ENVIRONMENT

--- a/openshift/kustomize/services/transcription/base/deploy.yaml
+++ b/openshift/kustomize/services/transcription/base/deploy.yaml
@@ -54,9 +54,6 @@ spec:
             requests:
               cpu: 20m
               memory: 80Mi
-            limits:
-              cpu: 75m
-              memory: 300Mi
           env:
             # .NET Configuration
             - name: ASPNETCORE_ENVIRONMENT

--- a/openshift/kustomize/shared_resources/overlays/dev/kustomization.yaml
+++ b/openshift/kustomize/shared_resources/overlays/dev/kustomization.yaml
@@ -10,6 +10,9 @@ secretGenerator:
   - name: keycloak
     envs:
       - keycloak.env
+  - name: database
+    type: stringData
+    env: database.env
 
 resources:
   - ../../base

--- a/openshift/kustomize/shared_resources/overlays/prod/kustomization.yaml
+++ b/openshift/kustomize/shared_resources/overlays/prod/kustomization.yaml
@@ -10,6 +10,9 @@ secretGenerator:
   - name: keycloak
     envs:
       - keycloak.env
+  - name: database
+    type: stringData
+    env: database.env
 
 resources:
   - ../../base

--- a/openshift/kustomize/shared_resources/overlays/test/kustomization.yaml
+++ b/openshift/kustomize/shared_resources/overlays/test/kustomization.yaml
@@ -10,6 +10,9 @@ secretGenerator:
   - name: keycloak
     envs:
       - keycloak.env
+  - name: database
+    type: stringData
+    env: database.env
 
 resources:
   - ../../base


### PR DESCRIPTION
Due to the performance issue of the CrunchyDB v15 in Openshift, I had to migrate to a single Postgres database in Openshift.  I've updated our Infrastructure as Code to reflect this change.  This solution is temporary and puts us at risk due to the single database does not have HA or backups.