### PR TITLE
Fix report issues

### DIFF
--- a/api/node/src/utils/applyChartJsOptions.ts
+++ b/api/node/src/utils/applyChartJsOptions.ts
@@ -13,11 +13,38 @@ export const applyChartJsOptions = (values: any) => {
         }
       }
     }
+    if (options.plugins.legend === undefined) {
+      options.plugins.legend = {};
+      if (options.plugins.legend.labels === undefined) {
+        options.plugins.legend.labels = {};
+      }
+      if (options.plugins.legend.title === undefined) {
+        options.plugins.legend.title = {};
+      }
+    }
+    if (options.plugins.title === undefined) {
+      options.plugins.title = {};
+    }
+    if (options.plugins.subtitle === undefined) {
+      options.plugins.subtitle = {};
+    }
   }
 
   if (options.plugins.datalabels.labels.title.display === undefined) {
     // Default this property.
     options.plugins.datalabels.labels.title.display = false;
+  }
+  if (options.plugins.legend.title.display === undefined) {
+    // Default this property.
+    options.plugins.legend.title.display = false;
+  }
+  if (options.plugins.title.display === undefined) {
+    // Default this property.
+    options.plugins.title.display = false;
+  }
+  if (options.plugins.subtitle.display === undefined) {
+    // Default this property.
+    options.plugins.subtitle.display = false;
   }
 
   if (options.plugins.datalabels.formatter) {

--- a/app/subscriber/src/features/my-reports/edit/ReportEditForm.tsx
+++ b/app/subscriber/src/features/my-reports/edit/ReportEditForm.tsx
@@ -257,6 +257,7 @@ export const ReportEditForm = React.forwardRef<HTMLDivElement | null, IReportEdi
               if (instance) {
                 const result = await updateReportInstance({
                   ...instance,
+                  body: '',
                   status: ReportStatusName.Reopen,
                 });
                 const updatedInstance = { ...result, content: instance.content };

--- a/app/subscriber/src/features/my-reports/edit/settings/template/utils/getDatasets.ts
+++ b/app/subscriber/src/features/my-reports/edit/settings/template/utils/getDatasets.ts
@@ -122,7 +122,5 @@ export const getDatasets = (
     });
   }
 
-  console.debug(results);
-
   return results;
 };

--- a/app/subscriber/src/features/my-reports/edit/settings/template/utils/groupData.ts
+++ b/app/subscriber/src/features/my-reports/edit/settings/template/utils/groupData.ts
@@ -132,22 +132,5 @@ export const groupData = (
     };
   }
 
-  // if (groupByOrder === 'desc' && groupBy !== '' && groupBy !== 'reportSection') {
-  //   result = {
-  //     labels: result.labels.sort((a, b) => {
-  //       console.debug(a, b);
-  //       if (a < b) return 1;
-  //       if (a > b) return -1;
-  //       return 0;
-  //     }),
-  //     datasets: result.datasets.sort((a, b) => {
-  //       console.debug(a, b);
-  //       if (a.label < b.label) return 1;
-  //       if (a.label > b.label) return -1;
-  //       return 0;
-  //     }),
-  //   };
-  // }
-
   return result;
 };


### PR DESCRIPTION
Some charts would throw errors if certain boolean values were `undefined`.  They will now default to false in the chart api.

When unlocking a report it will now remove the saved `report.instance.body` value so that changes can be detected and a new body can be generated.