### PR TITLE
MMI-3111 fix Enhance Summary method 

### DIFF
--- a/libs/net/template/ReportExtensions.cs
+++ b/libs/net/template/ReportExtensions.cs
@@ -83,21 +83,22 @@ public static partial class ReportExtensions
     }
 
     /// <summary>
-    /// Get the summary for the specified 'content' or external story(if ownerId is null).
+    /// Get the summary for the specified 'content' or external story(if content is private and sourceId is null).
     /// </summary>
     /// <param name="content"></param>
     /// <param name="context"></param>
     /// <returns></returns>
     public static string GetSummaryWithExternalStory(ContentModel content, ReportEngineContentModel context)
     {
-        string summary;
+        string summary = "";
         if (context.OwnerId.HasValue && content.Versions?.ContainsKey(context.OwnerId.Value) == true)
         {
             summary = content.Versions[context.OwnerId.Value].Summary;
         }
-        else
+        else if (content.IsPrivate && string.IsNullOrEmpty(content.SourceId?.ToString()))
         {
-            summary = content.Summary ?? "";
+
+            summary = content.Summary;
         }
         return summary;
     }


### PR DESCRIPTION
After change, summary in ToC can be displayed with private = true and the sourceId is empty. 

For non-private content, the behavior remains unchanged. They have two types of summaries: one in the content summary field and another in the value found in the versions field. A previous modification caused all content to display summaries in the Table of Contents while versions is empty. 

I just had Scott review the changes on the Test Server by modifying the template (using the same logic).

The method should work the same after the update. I’ll test it later.