### PR TITLE
MMI-3063 better UX for concurrency errors

### DIFF
--- a/api/net/Middleware/ErrorHandlingMiddleware.cs
+++ b/api/net/Middleware/ErrorHandlingMiddleware.cs
@@ -167,6 +167,13 @@ namespace TNO.API.Middleware
 
                 _logger.LogError(ex, "Configuration error.  {error}", ex.Message);
             }
+            else if (ex is ContentConflictException contentConflictEx)
+            {
+                code = HttpStatusCode.Conflict;
+                message = contentConflictEx.Message;
+
+                _logger.LogWarning(ex, "Content conflict detected: {error}", ex.Message);
+            }
             else
             {
                 _logger.LogError(ex, "Middleware caught unhandled exception. {error}", ex.GetAllMessages());

--- a/api/net/Middleware/ErrorHandlingMiddleware.cs
+++ b/api/net/Middleware/ErrorHandlingMiddleware.cs
@@ -109,7 +109,16 @@ namespace TNO.API.Middleware
             else if (ex is DbUpdateConcurrencyException)
             {
                 code = HttpStatusCode.BadRequest;
-                message = "Data may have been modified or deleted since item was loaded.  Refresh your data and reapply your changes.";
+                if (ex.InnerException is ContentConflictException)
+                {
+                    message = ex.InnerException.GetTypeName();
+                    details = ex.InnerException.Message;
+
+                }
+                else
+                {
+                    message = "Data may have been modified or deleted since item was loaded.  Refresh your data and reapply your changes.";
+                }
 
                 _logger.LogError(ex,
                     "Optimistic concurrency error (user agent: {userAgent})",

--- a/api/net/Middleware/ErrorHandlingMiddleware.cs
+++ b/api/net/Middleware/ErrorHandlingMiddleware.cs
@@ -172,7 +172,7 @@ namespace TNO.API.Middleware
                 code = HttpStatusCode.Conflict;
                 message = contentConflictEx.Message;
 
-                _logger.LogWarning(ex, "Content conflict detected: {error}", ex.Message);
+                _logger.LogError(ex, "Content conflict detected: {error}", ex.Message);
             }
             else
             {

--- a/app/editor/src/store/hooks/app/useToastError.tsx
+++ b/app/editor/src/store/hooks/app/useToastError.tsx
@@ -59,7 +59,7 @@ export const useToastError = () => {
               </div>
               {modifiedFields && (
                 <p style={styles.container}>
-                  Modified fields: <span style={styles.title}>{modifiedFields}</span>
+                  Different fields: <span style={styles.title}>{modifiedFields}</span>
                 </p>
               )}
               <p style={styles.message}>

--- a/app/editor/src/store/hooks/app/useToastError.tsx
+++ b/app/editor/src/store/hooks/app/useToastError.tsx
@@ -53,7 +53,9 @@ export const useToastError = () => {
           <Col className="concurrency-conflict-message">
             <div>
               <div style={styles.container}>
-                <p style={styles.title}>Content has been modified by another user</p>
+                <p style={styles.title}>
+                  Your changes could not be saved. Updates from another user could not be loaded.
+                </p>
               </div>
               {modifiedFields && (
                 <p style={styles.container}>

--- a/app/editor/src/store/hooks/app/useToastError.tsx
+++ b/app/editor/src/store/hooks/app/useToastError.tsx
@@ -1,12 +1,27 @@
 import React from 'react';
-import { toast } from 'react-toastify';
+import { toast, ToastOptions } from 'react-toastify';
 import { Col } from 'tno-core';
 
 import { useApp } from './useApp';
 
+// Constants for error codes
+const EXCEPTION_TEXT = {
+  CONTENT_CONFLICT: 'ContentConflictException',
+};
+
+const HTTP_STATUS = {
+  CONFLICT: 409,
+};
+
+// Common styles
+const styles = {
+  message: { margin: '0' },
+  title: { margin: '0', fontWeight: 'bold' },
+  container: { marginBottom: '8px' },
+} as const;
+
 export const useToastError = () => {
   const [state, api] = useApp();
-
   const [errors, setErrors] = React.useState(state.errors);
 
   React.useEffect(() => {
@@ -20,13 +35,47 @@ export const useToastError = () => {
 
   React.useEffect(() => {
     errors.forEach((e) => {
-      toast.error(
-        <Col>
-          <p>{e.message}</p>
-          <p>{e.detail}</p>
-        </Col>,
-        {},
-      );
+      const toastOptions: ToastOptions = {
+        position: 'top-right',
+      };
+
+      // content conflict
+      if (e.data?.type === EXCEPTION_TEXT.CONTENT_CONFLICT && e.status === HTTP_STATUS.CONFLICT) {
+        toastOptions.autoClose = false;
+        toastOptions.closeButton = true;
+        toastOptions.className = 'concurrency-conflict-toast';
+
+        // extract modified fields from error message
+        const fieldsMatch = e.message.match(/^FIELDS:(.+)$/);
+        const modifiedFields = fieldsMatch ? fieldsMatch[1].split(',').join(', ') : '';
+
+        toast.error(
+          <Col className="concurrency-conflict-message">
+            <div>
+              <div style={styles.container}>
+                <p style={styles.title}>Content has been modified by another user</p>
+              </div>
+              {modifiedFields && (
+                <p style={styles.container}>
+                  Modified fields: <span style={styles.title}>{modifiedFields}</span>
+                </p>
+              )}
+              <p style={styles.message}>
+                Please copy your changes elsewhere, then refresh the page to apply the updates.
+              </p>
+            </div>
+          </Col>,
+          toastOptions,
+        );
+      } else {
+        toast.error(
+          <Col>
+            <p style={styles.message}>{e.message}</p>
+            <p style={styles.message}>{e.detail}</p>
+          </Col>,
+          toastOptions,
+        );
+      }
     });
   }, [errors]);
 };

--- a/app/editor/src/store/hooks/app/useToastError.tsx
+++ b/app/editor/src/store/hooks/app/useToastError.tsx
@@ -7,10 +7,7 @@ import { useApp } from './useApp';
 // Constants for error codes
 const EXCEPTION_TEXT = {
   CONTENT_CONFLICT: 'ContentConflictException',
-};
-
-const HTTP_STATUS = {
-  CONFLICT: 409,
+  DB_UPDATE_CONCURRENCY: 'DbUpdateConcurrencyException',
 };
 
 // Common styles
@@ -40,13 +37,16 @@ export const useToastError = () => {
       };
 
       // content conflict
-      if (e.data?.type === EXCEPTION_TEXT.CONTENT_CONFLICT && e.status === HTTP_STATUS.CONFLICT) {
+      if (
+        e.data?.type === EXCEPTION_TEXT.DB_UPDATE_CONCURRENCY &&
+        e.message === EXCEPTION_TEXT.CONTENT_CONFLICT
+      ) {
         toastOptions.autoClose = false;
         toastOptions.closeButton = true;
         toastOptions.className = 'concurrency-conflict-toast';
 
         // extract modified fields from error message
-        const fieldsMatch = e.message.match(/^FIELDS:(.+)$/);
+        const fieldsMatch = e.detail?.match(/^FIELDS:(.+)$/);
         const modifiedFields = fieldsMatch ? fieldsMatch[1].split(',').join(', ') : '';
 
         toast.error(

--- a/libs/net/core/Exceptions/ContentConflictException.cs
+++ b/libs/net/core/Exceptions/ContentConflictException.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace TNO.Core.Exceptions
+{
+    /// <summary>
+    /// Exception thrown when content is modified by another user during update.
+    /// </summary>
+    public class ContentConflictException : Exception
+    {
+        /// <summary>
+        /// Creates a new instance of a ContentConflictException object.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="innerException"></param>
+        public ContentConflictException(string message, Exception? innerException = null)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/libs/net/core/Extensions/ExceptionExtensions.cs
+++ b/libs/net/core/Extensions/ExceptionExtensions.cs
@@ -15,6 +15,17 @@ public static class ExceptionExtensions
         return $"{ex.Message} {ex.InnerException?.GetAllMessages()}";
     }
 
+
+    /// <summary>
+    /// Get full exception type name
+    /// </summary>
+    /// <param name="ex"></param>
+    /// <returns></returns>
+    public static string GetTypeName(this Exception ex)
+    {
+        return ex.GetType().Name;
+    }
+
     /// <summary>
     /// Throw an ArgumentNullException if the value is null.
     /// </summary>

--- a/libs/net/dal/Services/ContentService.cs
+++ b/libs/net/dal/Services/ContentService.cs
@@ -299,13 +299,13 @@ public class ContentService : BaseService<Content, long>, IContentService
     {
         // Fields to ignore: system fields 
         var ignoreFields = new HashSet<string> {
-            "Versions",
-            "UpdatedBy",
-            "UpdatedOn",
-            "Version",
-            "CreatedBy",
-            "CreatedOn",
-            "PostedOn",
+            nameof(Content.Versions),
+            nameof(Content.UpdatedBy),
+            nameof(Content.UpdatedOn),
+            nameof(Content.Version),
+            nameof(Content.CreatedBy),
+            nameof(Content.CreatedOn),
+            nameof(Content.PostedOn),
         };
 
         var propertyNames = currentValues.Properties

--- a/libs/net/dal/Services/ContentService.cs
+++ b/libs/net/dal/Services/ContentService.cs
@@ -384,22 +384,18 @@ public class ContentService : BaseService<Content, long>, IContentService
 
             if (databaseValues == null)
             {
-                var errorMessage = "Unable to retrieve latest content. Please refresh the page and try again. If the issue persists, contact support.";
-                this.Logger.LogError(errorMessage);
-                throw new DbUpdateConcurrencyException(errorMessage);
+                var errorMessage = "Unable to retrieve latest content.";
+                this.Logger.LogError(ex, errorMessage);
+                throw new NoContentException(errorMessage, ex);
             }
 
             // Get changed properties and log details
             var changedProperties = GetChangedProperties(currentValues, databaseValues);
             LogFieldChanges(changedProperties);
 
-            var changedFields = string.Join("', '", changedProperties.Keys);
+            var changedFields = string.Join(",", changedProperties.Keys);
 
-            // Throw user-friendly message with better formatting
-            var userMessage = $"Content has been modified by another user. Modified fields: '{changedFields}'. " +
-                            "Please save your changes, refresh page, and reapply your updates.";
-
-            throw new DbUpdateConcurrencyException(userMessage);
+            throw new ContentConflictException($"FIELDS:{changedFields}", ex);
         }
     }
 

--- a/libs/net/dal/Services/ContentService.cs
+++ b/libs/net/dal/Services/ContentService.cs
@@ -302,7 +302,10 @@ public class ContentService : BaseService<Content, long>, IContentService
             "Versions",
             "UpdatedBy",
             "UpdatedOn",
-            "Version"
+            "Version",
+            "CreatedBy",
+            "CreatedOn",
+            "PostedOn",
         };
 
         var propertyNames = currentValues.Properties

--- a/libs/net/dal/Services/ContentService.cs
+++ b/libs/net/dal/Services/ContentService.cs
@@ -288,17 +288,119 @@ public class ContentService : BaseService<Content, long>, IContentService
     }
 
     /// <summary>
-    /// Update the specified 'entity' in the database.
+    /// Get the changed properties between current values and database values, display to users .
+    /// Ignores system fields type fields to focus on business-relevant changes.
     /// </summary>
-    /// <param name="entity"></param>
-    /// <returns></returns>
-    /// <exception cref="NoContentException"></exception>
+    /// <param name="currentValues">Current property values from the entity being saved</param>
+    /// <param name="databaseValues">Current property values from the database</param>
+    /// <returns>Dictionary of changed properties with their current and database values</returns>
+    private Dictionary<string, object> GetChangedProperties(Microsoft.EntityFrameworkCore.ChangeTracking.PropertyValues currentValues,
+    Microsoft.EntityFrameworkCore.ChangeTracking.PropertyValues? databaseValues)
+    {
+        // Fields to ignore: system fields 
+        var ignoreFields = new HashSet<string> {
+            "Versions",
+            "UpdatedBy",
+            "UpdatedOn",
+            "Version"
+        };
+
+        var propertyNames = currentValues.Properties
+            .Select(p => p.Name)
+            .Where(name => !ignoreFields.Contains(name));  // Filter out ignored fields
+
+        var valueComparison = propertyNames.ToDictionary(
+            name => name,
+            name => new
+            {
+                Current = currentValues[name],
+                Database = databaseValues?[name]
+            }
+        );
+
+        return valueComparison
+            .Where(kvp => !Equals(kvp.Value.Current, kvp.Value.Database))
+            .ToDictionary(
+                kvp => kvp.Key,
+                kvp => new
+                {
+                    CurrentValue = kvp.Value.Current?.ToString() ?? "null",
+                    DatabaseValue = kvp.Value.Database?.ToString() ?? "null"
+                } as object
+            );
+    }
+
+    /// <summary>
+    /// Log the detailed changes between current and database values for each changed field.
+    /// </summary>
+    /// <param name="changedProperties">Dictionary containing the changed properties and their values</param>
+    private void LogFieldChanges(Dictionary<string, object> changedProperties)
+    {
+        var changes = changedProperties.ToDictionary(
+            kvp => kvp.Key,
+            kvp =>
+            {
+                var values = (dynamic)kvp.Value;
+                return new
+                {
+                    Previous = values.DatabaseValue,
+                    Current = values.CurrentValue
+                };
+            }
+        );
+
+        this.Logger.LogInformation("Field changes detected:\n" +
+            string.Join("\n", changes.Select(c =>
+                $"Field: {c.Key}\n" +
+                $"  - Previous: {c.Value.Previous}\n" +
+                $"  - Current:  {c.Value.Current}"
+            ))
+        );
+    }
+
+    /// <summary>
+    /// Update and save the content entity. Handles concurrency conflicts by providing detailed information about changes.
+    /// </summary>
+    /// <param name="entity">The content entity to update</param>
+    /// <returns>The updated content entity</returns>
+    /// <exception cref="NoContentException">Thrown when the entity does not exist</exception>
+    /// <exception cref="DbUpdateConcurrencyException">Thrown when a concurrency conflict is detected</exception>
     public override Content UpdateAndSave(Content entity)
     {
-        var original = FindById(entity.Id) ?? throw new NoContentException("Entity does not exist");
-        this.Context.UpdateContext(original, entity);
-        if (entity.GuaranteeUid() && original.Uid != entity.Uid) original.Uid = entity.Uid;
-        return base.UpdateAndSave(original);
+        try
+        {
+            var original = FindById(entity.Id) ?? throw new NoContentException("Entity does not exist");
+            this.Context.UpdateContext(original, entity);
+            if (entity.GuaranteeUid() && original.Uid != entity.Uid) original.Uid = entity.Uid;
+            return base.UpdateAndSave(original);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            this.Logger.LogInformation("Concurrency conflict detected - ContentId: {ContentId}", entity.Id);
+
+            var entry = ex.Entries.Single();
+            var currentValues = entry.CurrentValues;
+            var databaseValues = entry.GetDatabaseValues();
+
+            if (databaseValues == null)
+            {
+                var errorMessage = "Unable to retrieve latest content. Please refresh the page and try again. If the issue persists, contact support.";
+                this.Logger.LogError(errorMessage);
+                throw new DbUpdateConcurrencyException(errorMessage);
+            }
+
+            // Get changed properties and log details
+            var changedProperties = GetChangedProperties(currentValues, databaseValues);
+            LogFieldChanges(changedProperties);
+
+            var changedFields = string.Join("', '", changedProperties.Keys);
+
+            // Throw user-friendly message with better formatting
+            var userMessage = $"Content has been modified by another user. Modified fields: '{changedFields}'. " +
+                            "Please save your changes, refresh page, and reapply your updates.";
+
+            throw new DbUpdateConcurrencyException(userMessage);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
In the past, it was monitored that there were some concurrency errors in the API during content editing. After a long period of comparison, I found that most of it was actually harmless. 
Some of it was caused by the request for a transcript. I tried automatic merging, but it turned out to be unsafe, as there were too many factors to consider. 
So, I changed it to display the modified fields on the frontend, giving users a prompt, and logging some detailed content on the backend for debugging purposes.

![image](https://github.com/user-attachments/assets/6350d41f-b080-441c-ae4e-b40c0eee2b32)
