### PR TITLE
MMI-3105 Add unique key and default value for media type select in ContentForm

### DIFF
--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -272,6 +272,13 @@ const ContentForm: React.FC<IContentFormProps> = ({
                                   width={FieldSize.Small}
                                   options={mediaTypeOptions}
                                   required
+                                  // Set a unique key for the component
+                                  // This ensures that the component is re-rendered when the mediaTypeId changes
+                                  key={`mediaType-${props.values.mediaTypeId}`}
+                                  // Set the default value for the media type select
+                                  defaultValue={mediaTypeOptions.find(
+                                    (mt) => mt.value === props.values.mediaTypeId,
+                                  )}
                                 />
                                 <FormikHidden name="otherSource" />
                                 <FormikText


### PR DESCRIPTION
Add unique key and default value for media type select in ContentForm.
fix missing mediaTypeId after click "x" button in this field , and causes error message in the form valiadtion.