### PR TITLE
Allow redirects

### DIFF
--- a/libs/net/services/Runners/BaseService.cs
+++ b/libs/net/services/Runners/BaseService.cs
@@ -140,7 +140,12 @@ public abstract class BaseService
         //     .Bind(this.Configuration.GetSection("Service"))
         //     .ValidateDataAnnotations();
 
-        services.AddHttpClient(typeof(BaseService).FullName ?? nameof(BaseService), client => { });
+        services.AddHttpClient(typeof(BaseService).FullName ?? nameof(BaseService), client => { })
+            .UseSocketsHttpHandler((handler, services) =>
+            {
+                handler.AllowAutoRedirect = true;
+                handler.ConnectTimeout = TimeSpan.FromMinutes(5);
+            });
 
         // API services
         services.AddMvcCore()

--- a/services/net/syndication/SyndicationAction.cs
+++ b/services/net/syndication/SyndicationAction.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using System.Net;
 using System.Net.Http.Headers;
 using System.ServiceModel.Syndication;
 using System.Text;


### PR DESCRIPTION
It appears the HttpClient doesn't follow redirects by default.  However, the issue with iPolitics is they redirect from HTTPS to HTTP.  Which isn't allowed.  We would need to manually handle the redirect.  I think having this config is still useful.

This is difficult to test because our IP is whitelisted.