### PR TITLE
MMI-3212 Fix Scheduler Service Issue

### DIFF
--- a/app/subscriber/src/components/layout/DefaultLayout.tsx
+++ b/app/subscriber/src/components/layout/DefaultLayout.tsx
@@ -68,12 +68,14 @@ export const DefaultLayout: React.FC<ILayoutProps> = ({ children, ...rest }) => 
   hub.useHubEffect(MessageTargetKey.ReportStatus, async (message: IReportMessageModel) => {
     // Report has been updated, go fetch latest.
     try {
-      if (message.status === ReportStatusName.Accepted)
-        toast.info(`Report "${message.subject}" has been generated and email requested.`);
-      else if (message.status === ReportStatusName.Completed)
-        toast.info(`Report "${message.subject}" has been sent out by email.`);
-      else if (message.status === ReportStatusName.Failed)
-        toast.error(`Report "${message.subject}" failed to be sent out by email.`);
+      if (message.message === 'status') {
+        if (message.status === ReportStatusName.Accepted)
+          toast.info(`Report "${message.subject}" has been generated and email requested.`);
+        else if (message.status === ReportStatusName.Completed)
+          toast.info(`Report "${message.subject}" has been sent out by email.`);
+        else if (message.status === ReportStatusName.Failed)
+          toast.error(`Report "${message.subject}" failed to be sent out by email.`);
+      }
     } catch {}
   });
 

--- a/app/subscriber/src/features/my-reports/MyReports.tsx
+++ b/app/subscriber/src/features/my-reports/MyReports.tsx
@@ -22,7 +22,7 @@ import { ReportPreview } from './ReportPreview';
 import * as styled from './styled';
 
 export const MyReports: React.FC = () => {
-  const [{ myReports, reportsFilter }, { findMyReports, deleteReport }] = useReports();
+  const [{ myReports, reportsFilter }, { findMyReports, deleteReport, getReport }] = useReports();
   const [{ getReportInstance }] = useReportInstances();
   const { toggle, isShowing } = useModal();
   const navigate = useNavigate();
@@ -53,6 +53,14 @@ export const MyReports: React.FC = () => {
               i.id === message.id ? { ...i, status: message.status, version: message.version } : i,
             ),
           });
+        } else if (message.message === 'event') {
+          const updateReport = await getReport(report.id, false);
+          if (updateReport) {
+            setReport({
+              ...report,
+              events: updateReport.events,
+            });
+          }
         } else {
           const instance = await getReportInstance(message.id, false);
           if (instance) {

--- a/app/subscriber/src/features/my-reports/edit/ReportEditPage.tsx
+++ b/app/subscriber/src/features/my-reports/edit/ReportEditPage.tsx
@@ -168,6 +168,14 @@ export const ReportEditPage = () => {
               i.id === message.id ? { ...i, status: message.status, version: message.version } : i,
             ),
           });
+        } else if (message.message === 'event') {
+          const updateReport = await getReport(report.id, false);
+          if (updateReport) {
+            setReport({
+              ...report,
+              events: updateReport.events,
+            });
+          }
         } else {
           const instance = await getReportInstance(message.id, true);
           if (instance) {

--- a/libs/net/dal/Services/ContentService.cs
+++ b/libs/net/dal/Services/ContentService.cs
@@ -297,7 +297,7 @@ public class ContentService : BaseService<Content, long>, IContentService
     private Dictionary<string, object> GetChangedProperties(Microsoft.EntityFrameworkCore.ChangeTracking.PropertyValues currentValues,
     Microsoft.EntityFrameworkCore.ChangeTracking.PropertyValues? databaseValues)
     {
-        // Fields to ignore: system fields 
+        // Fields to ignore: system fields
         var ignoreFields = new HashSet<string> {
             nameof(Content.Versions),
             nameof(Content.UpdatedBy),
@@ -402,8 +402,8 @@ public class ContentService : BaseService<Content, long>, IContentService
                 var contentConflictEx = new ContentConflictException($"FIELDS:{changedFields}");
                 throw new DbUpdateConcurrencyException(contentConflictEx.Message, contentConflictEx);
             }
-            
-            throw ex;
+
+            throw;
         }
     }
 

--- a/libs/net/reports/TNO.Reports.csproj
+++ b/libs/net/reports/TNO.Reports.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="NPOI" Version="2.7.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
It appears that the root issue with the Scheduler Service was that if the user had a stale version of the report and was editing it when an event fired, they would override the last run time of the report.  Which then would cause the Scheduler Service to request the report to regenerate again.  This fix should update the local copy of the report so that the next save does not overwrite the last run time.