### PR TITLE
MMI-3213 Fix Ingest Services & Transcript Work Queue

### DIFF
--- a/api/net/Areas/Editor/Controllers/WorkOrderController.cs
+++ b/api/net/Areas/Editor/Controllers/WorkOrderController.cs
@@ -100,7 +100,7 @@ public class WorkOrderController : ControllerBase
     {
         var uri = new Uri(this.Request.GetDisplayUrl());
         var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
-        var result = _workOrderService.FindDistinctWorkOrders(new WorkOrderFilter(query), this._serializerOptions);
+        var result = _workOrderService.FindDistinctWorkOrders(new WorkOrderFilter(query));
         var page = new Paged<WorkOrderModel>(result.Items.Select(i => i), result.Page, result.Quantity, result.Total);
         return new JsonResult(page);
     }

--- a/libs/net/dal/Services/Interfaces/IWorkOrderService.cs
+++ b/libs/net/dal/Services/Interfaces/IWorkOrderService.cs
@@ -21,7 +21,7 @@ public interface IWorkOrderService : IBaseService<WorkOrder, long>
     /// </summary>
     /// <param name="filter">Filter to apply to the query.</param>
     /// <returns>A page of work order items that match the filter.</returns>
-    IPaged<WorkOrderModel> FindDistinctWorkOrders(WorkOrderFilter filter, JsonSerializerOptions options);
+    IPaged<WorkOrderModel> FindDistinctWorkOrders(WorkOrderFilter filter);
 
     /// <summary>
     /// Find all work orders for the specified 'contentId'.

--- a/libs/net/dal/Services/WorkOrderService.cs
+++ b/libs/net/dal/Services/WorkOrderService.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using TNO.API.Areas.Editor.Models.WorkOrder;
 using TNO.DAL.Extensions;
 using TNO.Entities;
@@ -15,21 +16,29 @@ namespace TNO.DAL.Services;
 /// </summary>
 public class WorkOrderService : BaseService<WorkOrder, long>, IWorkOrderService
 {
+    #region Variables
+    private readonly JsonSerializerOptions _serializerOptions;
+    #endregion
+
     #region Properties
     #endregion
     /// <summary>
     /// Creates a new instance of a WorkOrderService object, initializes with specified parameters.
     /// </summary>
+    /// <param name="serializerOptions"></param>
     /// <param name="dbContext"></param>
     /// <param name="principal"></param>
     /// <param name="serviceProvider"></param>
     /// <param name="logger"></param>
     #region Constructors
-    public WorkOrderService(TNOContext dbContext,
+    public WorkOrderService(
+        IOptions<JsonSerializerOptions> serializerOptions,
+        TNOContext dbContext,
         ClaimsPrincipal principal,
         IServiceProvider serviceProvider,
         ILogger<WorkOrderService> logger) : base(dbContext, principal, serviceProvider, logger)
     {
+        _serializerOptions = serializerOptions.Value;
     }
     #endregion
 
@@ -116,7 +125,7 @@ public class WorkOrderService : BaseService<WorkOrder, long>, IWorkOrderService
     /// </summary>
     /// <param name="filter">Filter to apply to the query.</param>
     /// <returns>A page of work order items that match the filter.</returns>
-    public IPaged<WorkOrderModel> FindDistinctWorkOrders(WorkOrderFilter filter, JsonSerializerOptions options)
+    public IPaged<WorkOrderModel> FindDistinctWorkOrders(WorkOrderFilter filter)
     {
         var query =
         from t in
@@ -168,7 +177,7 @@ public class WorkOrderService : BaseService<WorkOrder, long>, IWorkOrderService
             Status = t.Status,
             Description = t.Description,
             Note = t.Note,
-            Configuration = JsonSerializer.Deserialize<Dictionary<string, object>>(t.Configuration, options) ?? new Dictionary<string, object>(),
+            Configuration = JsonSerializer.Deserialize<Dictionary<string, object>>(t.Configuration, _serializerOptions) ?? new Dictionary<string, object>(),
             RequestorId = t.RequestorId,
             Requestor = t.RequestorId != null ? new UserModel
             {

--- a/libs/net/dal/Services/WorkOrderService.cs
+++ b/libs/net/dal/Services/WorkOrderService.cs
@@ -127,96 +127,11 @@ public class WorkOrderService : BaseService<WorkOrder, long>, IWorkOrderService
     /// <returns>A page of work order items that match the filter.</returns>
     public IPaged<WorkOrderModel> FindDistinctWorkOrders(WorkOrderFilter filter)
     {
-        var query =
-        from t in
-            from w in this.Context.WorkOrders
-            join w2 in
-                from wo in this.Context.WorkOrders
-                group wo by wo.ContentId into g
-                select new
-                {
-                    ContentId = g.Key,
-                    LatestCreatedOn = g.Max(wo => wo.CreatedOn)
-                }
-            on new { w.ContentId, w.CreatedOn }
-            equals new { w2.ContentId, CreatedOn = w2.LatestCreatedOn }
-            select new
-            {
-                w.Id,
-                w.AssignedId,
-                w.Configuration,
-                w.ContentId,
-                w.CreatedBy,
-                w.CreatedOn,
-                w.Description,
-                w.Note,
-                w.RequestorId,
-                w.Status,
-                w.UpdatedBy,
-                w.UpdatedOn,
-                w.Version,
-                w.WorkType
-            }
-        join u in this.Context.Users on t.RequestorId equals u.Id into requestorJoin
-        from u in requestorJoin.DefaultIfEmpty()
-        join u0 in this.Context.Users on t.AssignedId equals u0.Id into assignedJoin
-        from u0 in assignedJoin.DefaultIfEmpty()
-        join c in this.Context.Contents on t.ContentId equals c.Id into contentJoin
-        from c in contentJoin.DefaultIfEmpty()
-        join m in this.Context.MediaTypes on c.MediaTypeId equals m.Id into mediaTypeJoin
-        from m in mediaTypeJoin.DefaultIfEmpty()
-        join s in this.Context.Series on c.SeriesId equals s.Id into seriesJoin
-        from s in seriesJoin.DefaultIfEmpty()
-        join s0 in this.Context.Sources on c.SourceId equals s0.Id into sourceJoin
-        from s0 in sourceJoin.DefaultIfEmpty()
-        orderby t.CreatedOn descending
-        select new WorkOrderModel
-        {
-            Id = t.Id,
-            WorkType = t.WorkType,
-            Status = t.Status,
-            Description = t.Description,
-            Note = t.Note,
-            Configuration = JsonSerializer.Deserialize<Dictionary<string, object>>(t.Configuration, _serializerOptions) ?? new Dictionary<string, object>(),
-            RequestorId = t.RequestorId,
-            Requestor = t.RequestorId != null ? new UserModel
-            {
-                Id = u.Id,
-                Username = u.Username,
-                Email = u.Email,
-                DisplayName = u.DisplayName,
-                FirstName = u.FirstName,
-                LastName = u.LastName
-            } : null,
-            AssignedId = t.AssignedId,
-            Assigned = t.AssignedId != null ? new UserModel
-            {
-                Id = u0.Id,
-                Username = u0.Username,
-                Email = u0.Email,
-                DisplayName = u0.DisplayName,
-                FirstName = u0.FirstName,
-                LastName = u0.LastName
-            } : null,
-            ContentId = t.ContentId,
-            Content = t.ContentId != null ? new ContentModel
-            {
-                Id = c.Id,
-                Headline = c.Headline,
-                OtherSource = c.OtherSource,
-                IsApproved = c.IsApproved,
-                MediaType = m.Name,
-                Series = s.Name,
-                SeriesId = s.Id,
-                SourceId = s0.Id,
-                MediaTypeId = m.Id,
-            } : null,
-            CreatedOn = t.CreatedOn,
-            CreatedBy = t.CreatedBy,
-            UpdatedOn = t.UpdatedOn,
-            UpdatedBy = t.UpdatedBy,
-            Version = t.Version
-        };
+        var query = this.Context.WorkOrders
+            .Include(m => m.Requestor)
+            .Include(m => m.Assigned)
+            .Include(m => m.Content)
+            .AsNoTracking();
 
         if (filter.WorkType.HasValue)
             query = query.Where(c => c.WorkType == filter.WorkType);
@@ -242,7 +157,7 @@ public class WorkOrderService : BaseService<WorkOrder, long>, IWorkOrderService
         if (filter.SeriesIds.Any())
             query = query.Where(c => filter.SeriesIds.Contains(c.Content!.SeriesId ?? 0));
         if (filter.MediaTypeIds.Any())
-            query = query.Where(c => filter.MediaTypeIds.Contains(c.Content!.MediaTypeId ?? 0));
+            query = query.Where(c => filter.MediaTypeIds.Contains(c.Content!.MediaTypeId));
 
         if (filter.CreatedOn.HasValue)
             query = query.Where(c => c.CreatedOn == filter.CreatedOn.Value.ToUniversalTime());
@@ -280,9 +195,10 @@ public class WorkOrderService : BaseService<WorkOrder, long>, IWorkOrderService
         var skip = (page - 1) * quantity;
         query = query.Skip(skip).Take(quantity);
 
-        var items = query?.ToArray() ?? Array.Empty<WorkOrderModel>();
+        var items = query?.ToArray() ?? Array.Empty<WorkOrder>();
+        var results = items.Select(wo => new WorkOrderModel(wo, _serializerOptions));
 
-        return new Paged<WorkOrderModel>(items, page, quantity, total);
+        return new Paged<WorkOrderModel>(results, page, quantity, total);
     }
 
     /// <summary>

--- a/libs/net/models/Areas/Services/Models/Ingest/IngestModel.cs
+++ b/libs/net/models/Areas/Services/Models/Ingest/IngestModel.cs
@@ -111,9 +111,10 @@ public class IngestModel : AuditColumnsModel
     public int RetryLimit { get; set; }
 
     /// <summary>
-    /// get/set -
+    /// get/set - Number of milliseconds to wait before retrying after a series of failures.
+    /// This should auto restart a failed ingestion service.
     /// </summary>
-    public int ResetRetryAfterDelayMs { get; set; }
+    public int ResetRetryAfterDelayMs { get; set; } = 300000;
 
     /// <summary>
     /// get/set -


### PR DESCRIPTION
Three changes made in this PR.

1. Default the retry timeout for all Ingest Services.  In theory they should pick backup where they left off after their timeout.
2. Apply proper dependency injection into the transcript workorder endpoint.
3. Rewrote LINQ statement to correct issues with generated SQL.