### PR TITLE
Fix report concurrency error

### DIFF
--- a/api/net/Areas/Services/Controllers/EventScheduleController.cs
+++ b/api/net/Areas/Services/Controllers/EventScheduleController.cs
@@ -125,6 +125,7 @@ public class EventScheduleController : ControllerBase
                         Subject = instance?.Subject ?? report.Name,
                         OwnerId = user.Id,
                         Message = "event",
+                        Version = instance?.Version ?? report.Version,
                     } }))
                 );
             }

--- a/app/subscriber/src/features/my-reports/MyReports.tsx
+++ b/app/subscriber/src/features/my-reports/MyReports.tsx
@@ -59,6 +59,7 @@ export const MyReports: React.FC = () => {
             setReport({
               ...report,
               events: updateReport.events,
+              version: updateReport.version,
             });
           }
         } else {

--- a/app/subscriber/src/features/my-reports/edit/ReportEditPage.tsx
+++ b/app/subscriber/src/features/my-reports/edit/ReportEditPage.tsx
@@ -174,6 +174,7 @@ export const ReportEditPage = () => {
             setReport({
               ...report,
               events: updateReport.events,
+              version: updateReport.version,
             });
           }
         } else {

--- a/app/subscriber/src/store/hooks/subscriber/useReportSync.ts
+++ b/app/subscriber/src/store/hooks/subscriber/useReportSync.ts
@@ -49,6 +49,7 @@ export const useReportSync = () => {
                     ? {
                         ...report,
                         events: updateReport.events,
+                        version: updateReport.version,
                       }
                     : r,
                 );


### PR DESCRIPTION
The Scheduler Service will send a message to the Reporting Service to generate a report based on a schedule.  If the user has already loaded a version of the report when these events occur it will result in a concurrency error when the user saves their report.

This update should apply the latest version details to their report.  There is still a possible situation where the user will overwrite changes made by the automated process, but we prefer this possibility over the error message currently received.