### PR TITLE
MMI-3174 add Byline field in the paper content table

### DIFF
--- a/app/editor/src/features/content/papers/Papers.tsx
+++ b/app/editor/src/features/content/papers/Papers.tsx
@@ -396,8 +396,9 @@ const Papers: React.FC<IPapersProps> = (props) => {
                 ),
                 size: '40%',
               },
-              { name: 'otherSource', label: 'Source', sortable: true, size: '20%' },
-              { name: 'mediaTypeId', label: 'Media Type', sortable: true, size: '20%' },
+              { name: 'otherSource', label: 'Source', sortable: true, size: '15%' },
+              { name: 'byline', label: 'Byline', sortable: false, size: '15%' },
+              { name: 'mediaTypeId', label: 'Media Type', sortable: true, size: '15%' },
               {
                 name: 'page',
                 label: (
@@ -485,6 +486,15 @@ const Papers: React.FC<IPapersProps> = (props) => {
                       onClick={(e) => handleContentClick(row.id, e)}
                     >
                       <CellEllipsis>{row.otherSource}</CellEllipsis>
+                    </div>
+                  ),
+                  isSelected: isSelected,
+                  isFocused: isFocused,
+                },
+                {
+                  column: (
+                    <div key="">
+                      <CellEllipsis>{row.byline}</CellEllipsis>
                     </div>
                   ),
                   isSelected: isSelected,


### PR DESCRIPTION
Update Papers component to adjust column sizes and add Byline field

Because the byline field is not keywords type in Elasticsearch. I don't turn the sortable on. 