### PR TITLE
MMI-3045 add fields to image form 

### DIFF
--- a/app/editor/package.json
+++ b/app/editor/package.json
@@ -117,6 +117,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
+    "test:coverage": "vitest --coverage",
     "eject": "react-scripts eject",
     "pretty-quick": "pretty-quick",
     "lint": "eslint src/ --ext .jsx,.js,.ts,.tsx --max-warnings 0",

--- a/app/editor/src/features/content/form/ContentForm.tsx
+++ b/app/editor/src/features/content/form/ContentForm.tsx
@@ -905,20 +905,18 @@ const ContentForm: React.FC<IContentFormProps> = ({
                   </Row>
                   <Row gap="0.5rem">
                     <Tags defaultTags={parsedTags} />
-                    <Show visible={props.values.contentType !== ContentTypeName.Image}>
-                      <FormikSentiment name="tonePools" options={tonePools} required />
-                      <Show
-                        visible={
-                          props.values.contentType === ContentTypeName.AudioVideo ||
-                          props.values.contentType === ContentTypeName.PrintContent
-                        }
-                      >
-                        <TimeLogSection
-                          prepTimeRequired={props.values.contentType === ContentTypeName.AudioVideo}
-                          prepTime={contentPrepTime}
-                          onPrepTimeChanged={onPrepTimeChanged}
-                        />
-                      </Show>
+                    <FormikSentiment name="tonePools" options={tonePools} required />
+                    <Show
+                      visible={
+                        props.values.contentType === ContentTypeName.AudioVideo ||
+                        props.values.contentType === ContentTypeName.PrintContent
+                      }
+                    >
+                      <TimeLogSection
+                        prepTimeRequired={props.values.contentType === ContentTypeName.AudioVideo}
+                        prepTime={contentPrepTime}
+                        onPrepTimeChanged={onPrepTimeChanged}
+                      />
                     </Show>
 
                     <Row className="submit-buttons" gap="0.5rem">

--- a/app/editor/src/features/content/form/ImageSection.tsx
+++ b/app/editor/src/features/content/form/ImageSection.tsx
@@ -7,6 +7,7 @@ import {
   filterEnabledOptions,
   FormikDatePicker,
   FormikSelect,
+  FormikText,
   getSourceOptions,
   IOptionItem,
   Row,
@@ -90,6 +91,7 @@ export const ImageSection: React.FunctionComponent<IImageSectionProps> = (props)
           }
         }}
       />
+      <FormikText name="page" label="Page" />
     </Row>
   );
 };

--- a/app/subscriber/package.json
+++ b/app/subscriber/package.json
@@ -104,7 +104,8 @@
     "check": "prettier --check \"./src/**/*.{js,jsx,ts,tsx,css,scss}\"",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest run --coverage"
   },
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f63443a5-5917-4df2-adae-ee7a3a4e57f0)


As the ticket required, I added two fields  `page number` and `sentiment `in the image page, and added coverage test command. 