### PR TITLE
MMI-3246 Fix report history

### DIFF
--- a/app/subscriber/src/features/my-reports/edit/view/ReportHistoryForm.tsx
+++ b/app/subscriber/src/features/my-reports/edit/view/ReportHistoryForm.tsx
@@ -26,10 +26,7 @@ export const ReportHistoryForm = () => {
       try {
         const instances = await findInstancesForReportId(reportId);
         setInstances(
-          instances.filter(
-            (i, index) =>
-              ![ReportStatusName.Reopen, ReportStatusName.Completed].includes(i.status) && i.body,
-          ),
+          instances.filter((i, index) => ![ReportStatusName.Reopen].includes(i.status) && i.body),
         );
       } catch {}
     },


### PR DESCRIPTION
Fixed the issue where report history was no longer displayed.  This was caused by an update to the CHES Retry Service.  Previously reports would get stuck in the Accepted status, but now they will get automatically updated to the Completed status.  The report history page needs to display completed reports.