### PR TITLE
Fix syndication service

### DIFF
--- a/services/net/syndication/SyndicationAction.cs
+++ b/services/net/syndication/SyndicationAction.cs
@@ -99,7 +99,7 @@ public class SyndicationAction : IngestAction<SyndicationOptions>
                 var sourceContent = CreateSourceContent(manager.Ingest, item);
 
                 // Fetch content reference.
-                var reference = await this.FindContentReferenceAsync(manager.Ingest.Source?.Code, sourceContent.Uid);
+                var reference = await this.FindContentReferenceAsync(sourceContent.Source, sourceContent.Uid);
                 if (reference == null)
                 {
                     reference = await AddContentReferenceAsync(manager.Ingest, item, sourceContent);


### PR DESCRIPTION
I'm surprised we didn't run into this issue earlier.  The logic to determine the correct source for a content item wasn't being applied to the content reference search endpoint.