### PR TITLE
MMI-3262 Fix user access

### DIFF
--- a/app/subscriber/src/features/search-page/components/advanced-search/components/sections/MediaTypeSection.tsx
+++ b/app/subscriber/src/features/search-page/components/advanced-search/components/sections/MediaTypeSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useContent, useLookupOptions } from 'store/hooks';
+import { useApp, useContent, useLookupOptions } from 'store/hooks';
 import { Button, ButtonVariant, Checkbox, FieldSize, Row, Select, Show } from 'tno-core';
 
 import { IFilterDisplayProps } from './IFilterDisplayProps';
@@ -12,6 +12,7 @@ export const MediaTypeSection: React.FC<IFilterDisplayProps> = ({ displayFilters
     },
     { storeSearchFilter: storeFilter },
   ] = useContent();
+  const [{ userInfo }] = useApp();
   const [{ mediaTypeOptions }] = useLookupOptions();
 
   return (
@@ -35,24 +36,26 @@ export const MediaTypeSection: React.FC<IFilterDisplayProps> = ({ displayFilters
               Deselect All
             </Button>
           </div>
-          {mediaTypeOptions.map((item, index) => (
-            <div key={`chk-media-type-${index}`} className="chk-box-container chk-media-type">
-              <Checkbox
-                id={`chk-media-type-${index}`}
-                label={item.label}
-                checked={filter.mediaTypeIds?.includes(+item.value!)}
-                value={item.value}
-                onChange={(e) => {
-                  storeFilter({
-                    ...filter,
-                    mediaTypeIds: e.target.checked
-                      ? [...(filter.mediaTypeIds ?? []), +e.target.value] // add it
-                      : filter.mediaTypeIds?.filter((i) => i !== +e.target.value), // remove it
-                  });
-                }}
-              />
-            </div>
-          ))}
+          {mediaTypeOptions
+            .filter((mt) => !userInfo?.mediaTypes.includes(+mt.value!))
+            .map((item, index) => (
+              <div key={`chk-media-type-${index}`} className="chk-box-container chk-media-type">
+                <Checkbox
+                  id={`chk-media-type-${index}`}
+                  label={item.label}
+                  checked={filter.mediaTypeIds?.includes(+item.value!)}
+                  value={item.value}
+                  onChange={(e) => {
+                    storeFilter({
+                      ...filter,
+                      mediaTypeIds: e.target.checked
+                        ? [...(filter.mediaTypeIds ?? []), +e.target.value] // add it
+                        : filter.mediaTypeIds?.filter((i) => i !== +e.target.value), // remove it
+                    });
+                  }}
+                />
+              </div>
+            ))}
         </div>
       </Show>
       <Show visible={displayFiltersAsDropdown}>

--- a/libs/net/dal/Services/UserService.cs
+++ b/libs/net/dal/Services/UserService.cs
@@ -128,7 +128,10 @@ public class UserService : BaseService<User, int>, IUserService
     public User? FindByUsername(string username)
     {
         return this.Context.Users
-            .Where(u => u.Username.ToLower() == username.ToLower()).FirstOrDefault();
+            .Include(u => u.MediaTypes)
+            .Include(u => u.Sources)
+            .Where(u => u.Username.ToLower() == username.ToLower())
+            .FirstOrDefault();
     }
 
     public IEnumerable<User> FindByEmail(string email)


### PR DESCRIPTION
When a user has been blocked for specific sources and media types, they should not be able to see them in the Subscriber app.  Additionally, all request to search should filter out blocked content.

## User Management

![image](https://github.com/user-attachments/assets/79af6b4b-ca4e-4adc-a564-95ebca7548dd)

## Advanced Search

![image](https://github.com/user-attachments/assets/bf693cec-49a2-4d2e-a533-85355f93b0fb)

## Filter by Media Type

![image](https://github.com/user-attachments/assets/3a3a72a2-b32f-4e3b-a672-8325234c3edf)
