### PR TITLE
MMI-3259 Add new helper script

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -79,4 +79,8 @@ up: ## Start up environment (e=environment).
 	$(info Start up environment (e=environment) [e=$(if $(e),$(e),dev)])
 	@cd ./scripts; ./up.sh $(if $(e),$(e),dev)
 
+annotate: ## Annotate an object.
+	$(info Annotate an object (n=name) [e=environment])
+	@cd ./scripts; ./annotate.sh $(if $(e),$(e),dev) $(n)
+
 .PHONY: local

--- a/openshift/scripts/annotate.sh
+++ b/openshift/scripts/annotate.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+env=${1-dev}
+name=${2}
+
+if [ ! $2 ]; then
+  die "Name argument require to specify the object type and name (i.e. dc/corenlp)."
+fi
+
+echo "oc annotate $name -n 9b301c-$env"
+
+oc annotate $name force-update=$(date +%s) --overwrite -n 9b301c-$env


### PR DESCRIPTION
New script to help annotate objects that need to be updated every year.  Essentially, this resolve the annual warning in DEV/TEST when we don't update specific objects.  It's very annoying that they enforce this, as we don't want to make changes to things that are working already.