### PR TITLE
MMI-3265 Fix Syndication service

### DIFF
--- a/services/net/syndication/SyndicationAction.cs
+++ b/services/net/syndication/SyndicationAction.cs
@@ -523,7 +523,13 @@ public class SyndicationAction : IngestAction<SyndicationOptions>
         {
             try
             {
-                using var xmlr = XmlReader.Create(new StringReader(data));
+                var settings = new XmlReaderSettings()
+                {
+                    IgnoreComments = false,
+                    IgnoreWhitespace = true,
+                    DtdProcessing = DtdProcessing.Parse,
+                };
+                using var xmlr = XmlReader.Create(new StringReader(data), settings);
                 var feed = SyndicationFeed.Load(xmlr);
                 return feed;
             }


### PR DESCRIPTION
Adding an additional XmlReaderSetting so that it parses Dtd attributes.  It won't solve the face we're be IP blocked however.