### PR TITLE
MMI-3276 Allow images in Notifications

### DIFF
--- a/api/net/Areas/Editor/Controllers/StorageController.cs
+++ b/api/net/Areas/Editor/Controllers/StorageController.cs
@@ -547,7 +547,7 @@ public class StorageController : ControllerBase
         var uploadedFiles = new List<string>();
         var failedUploads = new List<string>();
         // check if s3 credentials are set
-        if (!_s3Options.IsS3Enabled )
+        if (!_s3Options.IsS3Enabled)
         {
             return BadRequest("S3 is not enabled or credentials are not set");
         }

--- a/api/net/Areas/Subscriber/Controllers/ContentController.cs
+++ b/api/net/Areas/Subscriber/Controllers/ContentController.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Mime;
 using System.Text.Json;
 using System.Web;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Annotations;
@@ -184,6 +185,33 @@ public class ContentController : ControllerBase
         }
         var stream = _fileReferenceService.Download(fileReference, _storageOptions.GetUploadPath());
         return File(stream, fileReference.ContentType);
+    }
+
+    /// <summary>
+    /// Download the specified file.
+    /// Only allow configured file types to be freely downloaded.
+    /// This endpoint provides images for emails primarily.
+    /// </summary>
+    /// <param name="path"></param>
+    /// <returns></returns>
+    [AllowAnonymous]
+    [HttpGet("download")]
+    [Produces("application/octet-stream")]
+    [ProducesResponseType(typeof(FileStreamResult), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ErrorResponseModel), (int)HttpStatusCode.BadRequest)]
+    [SwaggerOperation(Tags = new[] { "Content" })]
+    public IActionResult AnonymousDownloadFile(string path)
+    {
+        var ext = Path.GetExtension(path).Substring(1);
+        if (!_storageOptions.AllowAnonymousDownloadFileTypes.Any(value => String.Equals(value, ext, StringComparison.OrdinalIgnoreCase))) throw new InvalidOperationException("Unable to download file.");
+
+        path = String.IsNullOrWhiteSpace(path) ? "" : HttpUtility.UrlDecode(path).MakeRelativePath();
+        var safePath = Path.Combine(_storageOptions.GetUploadPath(), path);
+        if (!safePath.FileExists() && !safePath.DirectoryExists()) throw new InvalidOperationException($"File/folder does not exist: '{path}'");
+
+        var info = new ItemModel(safePath, true);
+        var stream = System.IO.File.OpenRead(safePath);
+        return File(stream, contentType: info.MimeType!, fileDownloadName: info.Name, enableRangeProcessing: false);
     }
 
     /// <summary>

--- a/api/net/appsettings.json
+++ b/api/net/appsettings.json
@@ -56,7 +56,8 @@
   },
   "Storage": {
     "UploadPath": "/data",
-    "CapturePath": "/av"
+    "CapturePath": "/av",
+    "AllowAnonymousDownloadFileTypes": ["png", "jpg", "jpeg", "svg", "tiff", "gif", "webp"]
   },
   "Kafka": {
     "IndexingTopic": "index",

--- a/app/editor/src/features/admin/notifications/constants/defaultRazorTemplate.ts
+++ b/app/editor/src/features/admin/notifications/constants/defaultRazorTemplate.ts
@@ -3,9 +3,10 @@ export const defaultRazorTemplate = {
 @using System.Linq
 @{
   var isAV = @Content.ContentType == TNO.Entities.ContentType.AudioVideo;
+  var useSummary = @Content.ContentType == TNO.Entities.ContentType.Image || isAV;
   var isTranscriptAvailable = isAV && !string.IsNullOrWhiteSpace(@Content.Body) && @Content.IsApproved;
   var sourceCode = !string.IsNullOrEmpty(@Content.Source?.Code) ? @Content.Source.Code : @Content.OtherSource;
-  var body = isTranscriptAvailable ? @Content.Body : (isAV ? @Content.Summary : @Content.Body);
+  var body = isTranscriptAvailable ? @Content.Body : (useSummary ? @Content.Summary : @Content.Body);
   var transcriptIcon = isTranscriptAvailable ? "▶️📄" : (isAV ? "▶️" : "");
   var toneIcon = "";
   if (@EnableReportSentiment)
@@ -27,58 +28,73 @@ export const defaultRazorTemplate = {
         break;
     }
   }
-}DEV | @toneIcon@sourceCode: @Content.Headline @transcriptIcon`,
+}@toneIcon@sourceCode: @Content.Headline @transcriptIcon`,
   body: `@inherits RazorEngineCore.RazorEngineTemplateBase<TNO.TemplateEngine.Models.Notifications.NotificationEngineContentModel>
 @using System
+@using System.Web
+@using System.Linq
 @{
   var subscriberAppUrl = @SubscriberAppUrl?.ToString();
   var viewContentUrl = @ViewContentUrl?.ToString();
   var requestTranscriptUrl = @RequestTranscriptUrl?.ToString();
   var addToReportUrl = @AddToReportUrl?.ToString();
   var isAV = @Content.ContentType == TNO.Entities.ContentType.AudioVideo;
+  var useSummary = @Content.ContentType == TNO.Entities.ContentType.Image || isAV;
   var isTranscriptAvailable = isAV && !string.IsNullOrWhiteSpace(@Content.Body) && @Content.IsApproved;
   var sourceCode = !string.IsNullOrEmpty(@Content.Source?.Code) ? @Content.Source.Code : @Content.OtherSource;
-  var body = isTranscriptAvailable ? @Content.Body : (isAV ? @Content.Summary : @Content.Body);
-  //  body = System.Text.RegularExpressions.Regex.Replace(body, @"\\r\\n?|\\n", "<br/>");
+  var body = isTranscriptAvailable ? @Content.Body : (useSummary ? @Content.Summary : @Content.Body);
   var replaceWith = "<br/>";
-  body = body.Replace("\\r\\n", replaceWith).Replace("\\n", replaceWith).Replace("\\r", replaceWith);
+  body = body.Replace("\r\n", replaceWith).Replace("\n", replaceWith).Replace("\r", replaceWith);
+  var filePath = @Content.FileReferences.FirstOrDefault()?.Path;
 
   var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
   var utcOffset = tz.GetUtcOffset(System.DateTime.Now).Hours;
 }
-<div>@sourceCode (@Content.Source?.Name)</div>
+@if (!string.IsNullOrWhiteSpace(@Content.Source?.Name))
+{
+  <div>@Content.Source.Name</div>
+}
 @if (!string.IsNullOrEmpty(@Content.Series?.Name))
 {
   <div>@Content.Series.Name</div>
 }
-<div>@Content.PublishedOn?.AddHours(@utcOffset).ToString("dd-MMM-yyyy hh:mm")</div>
-@if (!string.IsNullOrEmpty(@Content.ImageContent))
+<div>@Content.PublishedOn?.AddHours(@utcOffset).ToString("dd-MMM-yyyy HH:mm")</div>
+@if (!string.IsNullOrEmpty(@Content.Byline))
 {
-  var src = $"data:{@Content.ContentType};base64," + Content.ImageContent;
-  <div><img src="@src" alt="@Content.FileReferences.FirstOrDefault()?.FileName" /></div>
+  <div>@Content.Byline</div>
 }
+@if (!string.IsNullOrEmpty(@Content.Page))
+{
+  <div>Page #@Content.Page</div>
+}
+@if (@Content.ContentType == TNO.Entities.ContentType.Image && !string.IsNullOrEmpty(filePath))
+{
+  var apiFileUrl = subscriberAppUrl + "api/subscriber/contents/download?path=" + filePath;
+  <div><img src="@apiFileUrl" alt="@Content.FileReferences.FirstOrDefault()?.FileName" /></div>
+}
+<br/>
+<p>
+<hr></hr>
 <div>@body</div>
 <br />
 @if (!string.IsNullOrEmpty(subscriberAppUrl))
 {
-  <div><a href="@subscriberAppUrl" target="">MMI</a> :: <a href="@viewContentUrl" target="_blank">View Article</a></div>
+  <div><a href="@subscriberAppUrl" target="">MMI</a> : <a href="@viewContentUrl@Content.Id" target="_blank">View article on MMI website</a></div>
   <br />
 }
 @if (isAV && !isTranscriptAvailable && !string.IsNullOrEmpty(requestTranscriptUrl) && Content.Source?.DisableTranscribe == false)
 {
-  <div><a href="@requestTranscriptUrl" target="_blank">Request Transcript...</a></div>
+  <div><a href="@($"{requestTranscriptUrl}{Content.Id}")?uid=@(Content.OwnerId)&headline=@(HttpUtility.UrlEncode(Content.Headline))&source=@(HttpUtility.UrlEncode(Content.OtherSource))" target="_blank"
+                 style="margin-left:auto; padding:0.5em; color:#123456; background-color:#fff7e1; border:2px solid #dcc797; height:2em; border-radius:0.85em; text-decoration:none; display:inline-flex; align-items:center; gap:0.5em;"
+                 onmouseover="this.style.backgroundColor='#ffebb3';"
+                 onmouseout="this.style.backgroundColor='#fff7e1';">
+                   <i class="fa fa-feather" style="color:#cccccc;"></i> Request Transcript</a>
+                   </div>
   <br />
 }
-@if (!string.IsNullOrEmpty(addToReportUrl))
-{
-  <div><a href="@addToReportUrl" target="_blank">Add to Report</a></div>
-  <br />
-}
-<br />
-<div style="font-size: 10px;">
-  This e-mail is a service provided by Government Communications and Public Engagement and is only intended
-  for the original addressee. All content is the copyrighted property of a third party creator of the material.
-  Copying, retransmitting, redistributing, selling, licensing, or emailing the material to any third party or
-  any employee of the Province who is not authorized to access the material is prohibited.
+<br /><hr></hr>
+<div style="font-size: 14px;">
+<b>This e-mail is a service provided by Government Communications and Public Engagement and is only intended
+  for the original addressee. All content is the copyrighted property of a third party creator of the material. Copying, re-transmitting, redistributing, selling, licensing, or e-mailing the material to any third party or any employee of the Province who is not authorized to access the material is prohibited. </b>
 </div>`,
 };

--- a/libs/net/core/Extensions/StringExtensions.cs
+++ b/libs/net/core/Extensions/StringExtensions.cs
@@ -258,7 +258,10 @@ public static partial class StringExtensions
     public static bool FileExists(this string path, bool ignoreCase = false)
     {
         var directory = Path.GetDirectoryName(path) ?? "";
-        return directory.DirectoryExists() && File.Exists(path) && Directory.GetFiles(directory).Any(f => String.Compare(f, path, ignoreCase) == 0);
+
+        var actualDir = Path.GetFullPath(directory);
+        var actualPath = Path.GetFullPath(path);
+        return directory.DirectoryExists() && File.Exists(path) && Directory.GetFiles(actualDir).Any(f => String.Compare(f, actualPath, ignoreCase) == 0);
     }
 
     /// <summary>
@@ -274,7 +277,8 @@ public static partial class StringExtensions
 
         var parent = directory.Parent?.FullName ?? "";
 
-        return Directory.GetFileSystemEntries(parent).Any(f => String.Compare(f, path, ignoreCase) == 0);
+        var actualPath = Path.GetFullPath(path);
+        return Directory.GetFileSystemEntries(parent).Any(f => String.Compare(f, actualPath, ignoreCase) == 0);
     }
 
     /// <summary>

--- a/libs/net/dal/Config/StorageOptions.cs
+++ b/libs/net/dal/Config/StorageOptions.cs
@@ -22,6 +22,11 @@ public class StorageOptions
     public string CapturePath { get; set; } = "/usr/app/av";
 
     /// <summary>
+    /// get/set - An array of allowed file types that can be downloaded anonymously.
+    /// </summary>
+    public string[] AllowAnonymousDownloadFileTypes { get; set; } = [];
+
+    /// <summary>
     /// get/set - The current environment.
     /// </summary>
     public IWebHostEnvironment? Environment { get; set; }

--- a/libs/net/template/Models/BaseTemplateModel.cs
+++ b/libs/net/template/Models/BaseTemplateModel.cs
@@ -72,10 +72,10 @@ public abstract class BaseTemplateModel<T> : RazorEngineTemplateBase
     public static string? GetImageContent(string uploadPath, string? path)
     {
         path = string.IsNullOrWhiteSpace(path) ? "" : HttpUtility.UrlDecode(path).MakeRelativePath();
-        var safePath = Path.Combine(uploadPath, path);
-        if (!safePath.FileExists()) return null;
+        var fullPath = Path.Combine(uploadPath, path).Replace('\\', '/');
+        if (!fullPath.FileExists()) return null;
 
-        using FileStream fileStream = new(safePath, FileMode.Open, FileAccess.Read);
+        using FileStream fileStream = new(fullPath, FileMode.Open, FileAccess.Read);
         var imageBytes = new byte[fileStream.Length];
         fileStream.ReadExactly(imageBytes, 0, (int)fileStream.Length);
         return Convert.ToBase64String(imageBytes);

--- a/openshift/kustomize/services/notification/base/deploy.yaml
+++ b/openshift/kustomize/services/notification/base/deploy.yaml
@@ -36,6 +36,10 @@ spec:
         part-of: tno
         component: notification-service
     spec:
+      volumes:
+        - name: api-storage
+          persistentVolumeClaim:
+            claimName: api-storage
       containers:
         - name: notification-service
           image: ""
@@ -43,6 +47,9 @@ spec:
           ports:
             - containerPort: 8080
               protocol: TCP
+          volumeMounts:
+            - name: api-storage
+              mountPath: /mnt/data
           resources:
             requests:
               cpu: 20m
@@ -130,6 +137,8 @@ spec:
                 configMapKeyRef:
                   name: notification-service
                   key: TOPICS
+            - name: Service__UploadPath
+              value: "/mnt/data"
             - name: Service__IgnoreContentPublishedBeforeOffset
               valueFrom:
                 configMapKeyRef:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
-      
+
   fileupload:
     image: tno:fileupload
     profiles:
@@ -345,6 +345,8 @@ services:
       - broker
     networks:
       - tno
+    volumes:
+      - tno-api-data:/data
     healthcheck:
       test: curl -s -f http://localhost:8081/health || exit 1
       interval: 1m

--- a/services/net/notification/Config/NotificationOptions.cs
+++ b/services/net/notification/Config/NotificationOptions.cs
@@ -23,5 +23,10 @@ public class NotificationOptions : ServiceOptions
     /// get/set - Ignore any content that was indexed before this day offset.
     /// </summary>
     public int? IgnoreContentPublishedBeforeOffset { get; set; }
+
+    /// <summary>
+    /// get/set - The path files are uploaded to in the API.
+    /// </summary>
+    public string? UploadPath { get; set; }
     #endregion
 }

--- a/services/net/notification/NotificationManager.cs
+++ b/services/net/notification/NotificationManager.cs
@@ -433,7 +433,7 @@ public class NotificationManager : ServiceManager<NotificationOptions>
 
         var subscribers = await GetNotificationSubscribersAsync(notification, content);
 
-        var body = await GenerateNotificationBodyAsync(notification, content, null, request.IsPreview);
+        var body = await GenerateNotificationBodyAsync(notification, content, this.Options.UploadPath, request.IsPreview);
         var subject = string.Empty;
         if (!String.IsNullOrWhiteSpace(request.To))
         {

--- a/services/net/notification/appsettings.json
+++ b/services/net/notification/appsettings.json
@@ -21,7 +21,8 @@
     "RequestTranscriptUrl": "https://mmi.gov.bc.ca/api/subscriber/work/orders/transcribe/",
     "AddToReportUrl": "https://mmi.gov.bc.ca",
     "AlertId": 1,
-    "SendEmailOnFailure": true
+    "SendEmailOnFailure": true,
+    "UploadPath": "/data"
   },
   "Elastic": {
     "Url": "http://elastic:9200",

--- a/tools/scripts/gen-env-files.sh
+++ b/tools/scripts/gen-env-files.sh
@@ -610,6 +610,7 @@ Auth__Keycloak__Secret={YOU WILL NEED TO GET THIS FROM KEYCLOAK}
 Auth__OIDC__Token=/realms/mmi/protocol/openid-connect/token
 
 Service__ApiUrl=http://host.docker.internal:$portApi/api
+# Service__UploadPath=../data
 
 Kafka__BootstrapServers=host.docker.internal:$portKafkaBrokerAdvertisedExternal
 


### PR DESCRIPTION
This update provides a way to display uploaded image files in notifications.

## Summary

- Updated notification template (separate PR for the DB migration)
- Updated API, added new endpoint for downloading files

<img width="1662" height="1236" alt="image" src="https://github.com/user-attachments/assets/e040563b-b2b8-43e1-a1f8-cb98a8876e11" />
