### PR TITLE
MMI-3274 Enhance MarkKeywords 

### DIFF
--- a/libs/net/elastic/Extensions/StringExtensions.cs
+++ b/libs/net/elastic/Extensions/StringExtensions.cs
@@ -159,13 +159,17 @@ public static class StringExtensions
 
     /// <summary>
     /// Add html mark tags to each keyword.
+    /// If markRawTag is false, we will use span with style. this is useful for email clients like Outlook.
+    /// If markRawTag is true, we will use the raw tag name.
     /// </summary>
     /// <param name="text"></param>
     /// <param name="keywords"></param>
-    /// <param name="mark"></param>
+    /// <param name="tagName"></param>
+    /// <param name="markRawTag"></param>
     /// <returns></returns>
-    public static string MarkKeywords(this string text, IEnumerable<string> keywords, string tagName = "mark")
+    public static string MarkKeywords(this string text, IEnumerable<string> keywords, string tagName = "mark", bool markRawTag = false)
     {
+        const string highlightStyle = "background-color:#fff59e;color:inherit;";
         var values = String.Join("|", keywords.Where(v => !String.IsNullOrWhiteSpace(v)));
         return Regex.Replace(text, $@"\b({values})", match =>
         {
@@ -178,7 +182,11 @@ public static class StringExtensions
             values = values.Distinct().Where(v => !String.IsNullOrWhiteSpace(v)).ToList();
             var result = String.Join("", values);
             if (values.Count != 0)
+            {
+                if (!String.IsNullOrWhiteSpace(tagName) && !markRawTag && tagName.Equals("mark", StringComparison.OrdinalIgnoreCase))
+                    return $"<span style=\"{highlightStyle}\">{result}</span>";
                 return $"<{tagName}>{result}</{tagName}>";
+            }
             return result;
         }, RegexOptions.IgnoreCase);
     }


### PR DESCRIPTION
clients use outlook email doesn't support `<mark>` , this new way can highlight with style and `<span>` tag