### PR TITLE
MMI-3342 Fix highlight search terms

### DIFF
--- a/libs/net/elastic/Extensions/RegexSettings.cs
+++ b/libs/net/elastic/Extensions/RegexSettings.cs
@@ -29,5 +29,8 @@ public static partial class RegexSettings
 
     [GeneratedRegex(@"(\sAND\s|\sOR\s|\sNOT\s|\s?\&\&\s?|\s?\|\|\s?|\s?[\+\-\!]\s?)", RegexOptions.IgnoreCase)]
     public static partial Regex RemoveAdvancedKeywordsRegex();
+
+    [GeneratedRegex(@"\b\w+:/(\\/|[^/])*/")]
+    public static partial Regex RemoveFieldedSearchRegex();
     #endregion
 }

--- a/libs/net/elastic/Extensions/StringExtensions.cs
+++ b/libs/net/elastic/Extensions/StringExtensions.cs
@@ -16,7 +16,7 @@ public static class StringExtensions
     static readonly Regex EndOfQuote = RegexSettings.EndOfQuoteRegex();
     static readonly Regex RemoveSimpleKeywords = RegexSettings.RemoveSimpleKeywordsRegex();
     static readonly Regex RemoveAdvancedKeywords = RegexSettings.RemoveAdvancedKeywordsRegex();
-
+    static readonly Regex RemoveFieldedSearch = RegexSettings.RemoveFieldedSearchRegex();
     #endregion
 
     #region Methods
@@ -32,12 +32,13 @@ public static class StringExtensions
         var isAdvanced = queryType == "query-string";
         var keywords = new List<string>();
         var startOfPhrase = -1;
-        var endOfPhrase = -1;
+        int endOfPhrase;
         var phrase = new StringBuilder();
 
         if (isAdvanced)
         {
-            var cleanSearch = RemoveAdvancedKeywords.Replace(search, " ");
+            var cleanSearch = RemoveFieldedSearch.Replace(search, " ");
+            cleanSearch = RemoveAdvancedKeywords.Replace(cleanSearch, " ");
             var tokens = cleanSearch.Split(" ", StringSplitOptions.RemoveEmptyEntries);
 
             // Iterate through each token to determine whether it is a keyword that should be marked.


### PR DESCRIPTION
Reports that use advanced searches for content, that also use field name searches cause the highlight search terms to malfunction.

The following advanced search would result in part of the regular expression being used to highlight words.

```txt
page:/[aA](1|01)( \/ [a-zA-Z]*)?/ 
|| "federal government"
```

We now have a process to remove all field name searches from the highlight functionality.  This could result in some specific use-cases that will not show the highlights, but they are not used very often.