### PR TITLE
MMI-3346 Notification Service

### DIFF
--- a/libs/net/ches/ChesService.cs
+++ b/libs/net/ches/ChesService.cs
@@ -1,6 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Web;
 using Microsoft.Extensions.Logging;
@@ -180,6 +181,11 @@ namespace TNO.Ches
                     throw new ChesException(ex, this.Client, response);
                 }
                 _logger.LogError(ex, "Failed to send/receive request: {code} {url}.  Error: {error}", ex.StatusCode, url, ex.GetAllMessages());
+                throw new ChesException("Failed to send message to CHES", ex);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to send/receive request: {url}.  Error: {error}", url, ex.GetAllMessages());
                 throw new ChesException("Failed to send message to CHES", ex);
             }
         }

--- a/libs/net/core/Exceptions/HttpClientRequestException.cs
+++ b/libs/net/core/Exceptions/HttpClientRequestException.cs
@@ -49,7 +49,6 @@ namespace TNO.Core.Exceptions
         public HttpClientRequestException(HttpResponseMessage response) : base($"HTTP Request failed [{response?.RequestMessage?.Method}]:[{response?.StatusCode}]:{response?.RequestMessage?.RequestUri}", null, response?.StatusCode)
         {
             this.Response = response ?? throw new ArgumentNullException(nameof(response));
-            this.Data["Body"] = response.Content.ReadAsStringAsync().Result;
         }
 
         /// <summary>
@@ -60,7 +59,6 @@ namespace TNO.Core.Exceptions
         public HttpClientRequestException(HttpResponseMessage response, string message) : base(message, null, response?.StatusCode)
         {
             this.Response = response ?? throw new ArgumentNullException(nameof(response));
-            this.Data["Body"] = response.Content.ReadAsStringAsync().Result;
         }
 
         /// <summary>
@@ -71,7 +69,6 @@ namespace TNO.Core.Exceptions
         public HttpClientRequestException(HttpResponseMessage response, Exception innerException) : base($"HTTP Request failed [{response?.RequestMessage?.Method}]:[{response?.StatusCode}]:{response?.RequestMessage?.RequestUri}", innerException, response?.StatusCode)
         {
             this.Response = response ?? throw new ArgumentNullException(nameof(response));
-            this.Data["Body"] = response.Content.ReadAsStringAsync().Result;
         }
         #endregion
     }


### PR DESCRIPTION
The Notification Service is crashing throughout the day.  It's very difficult to debug but there appears to be a relationship with CHES failures.  At certain points it becomes unavailable.  

I believe our code is attempting to read the response body twice.  Which for some reason in .NET is not allowed.  I've modified all the handling of HTTP request errors so that the HttpClientRequestException does not read the response body.