### PR TITLE
MMI-3346 Fix Notification Service

### DIFF
--- a/db/postgres/README.md
+++ b/db/postgres/README.md
@@ -74,14 +74,20 @@ DB_VOLUME=/var/lib/pgsql/data
 ## Backup Commands
 
 ```bash
+# RSH into database backup pod
+oc -n 9b301c-test rsh db-backup-855b845cc7-zrk7t
+
+# Test connection
+psql -h postgres -U admin -d tno
+
 # Backup and zip
-pg_dump -h postgres -U admin -C -Fc -v -d tno | gzip > /mnt/data/dev.tar.gz
+pg_dump -h postgres -U admin -C -Fc -v -d tno | gzip > /backups/dev.tar.gz
+
+# Copy file to local
+oc -n 9b301c-dev rsync db-backup-855b845cc7-zrk7t:/backups/dev.tar.gz /D/db
 
 # Unzip
 gzip -dk dev.tar.gz
-
-# Copy file to local
-oc -n 9b301c-dev rsync psql-4-zdbv6:/mnt/data/dev.tar.gz /D/db
 
 # Copy file to database server
 scp -v /D/db/dev.tar.gz jerfos_a@142.34.249.231:/u02/data/postgres

--- a/libs/net/core/Http/HttpRequestClient.cs
+++ b/libs/net/core/Http/HttpRequestClient.cs
@@ -97,11 +97,8 @@ namespace TNO.Core.Http
                 throw;
             }
 
-            // Throw exception because the response failed and cannot be deserialized.
-            var errorEx = new HttpClientRequestException($"Response must contain JSON but was '{contentType?.MediaType}'.", response.StatusCode);
-            var responseBytes = responseStream.ReadAllBytes();
-            errorEx.Data["body"] = Encoding.Default.GetString(responseBytes);
-            throw errorEx;
+            // The request response was a failure, wrap exception.
+            throw new HttpClientRequestException(response);
         }
 
         #region HttpResponseMessage Methods

--- a/services/net/transcription/appsettings.json
+++ b/services/net/transcription/appsettings.json
@@ -53,9 +53,9 @@
       "GroupId": "Transcription",
       "BootstrapServers": "kafka-broker-0.kafka-headless:9092,kafka-broker-1.kafka-headless:9092,kafka-broker-2.kafka-headless:9092",
       "AutoOffsetReset": "Earliest",
-      "MaxInFlight": 5,
       "EnableAutoCommit": false,
-      "MaxThreads": 10
+      "MaxThreads": 10,
+      "MaxPollIntervalMs": 600000
     },
     "Producer": {
       "ClientId": "Transcription",


### PR DESCRIPTION
We are still receiving core dump crashes in the Notification Service.  This change is a best guess after reviewing the last log values.  This change does not attempt to read the body of the failed response from CHES.