### PR TITLE
Onboard Indexing service to GitHub Actions CI/CD using reusable workflow

### DIFF
--- a/.github/workflows/_reusable-dotnet-cicd.yml
+++ b/.github/workflows/_reusable-dotnet-cicd.yml
@@ -179,7 +179,7 @@ jobs:
         continue-on-error: true
         run: |
           TOKEN=$(curl -s -X POST \
-            "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token" \
+            "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token" \
             -H "Content-Type: application/x-www-form-urlencoded" \
             -d "grant_type=client_credentials" \
             -d "client_id=${{ secrets.CHES_CLIENT_ID }}" \
@@ -192,7 +192,7 @@ jobs:
             SUBJECT="Deployment FAILED - ${{ inputs.image_name }} to ${{ env.OPENSHIFT_NAMESPACE }}"
           fi
 
-          curl -s -X POST "https://ches.api.gov.bc.ca/api/v1/email" \
+          curl -s -X POST "https://ches-dev.api.gov.bc.ca/api/v1/email" \
             -H "Authorization: Bearer $TOKEN" \
             -H "Content-Type: application/json" \
             -d "{
@@ -299,7 +299,7 @@ jobs:
         continue-on-error: true
         run: |
           TOKEN=$(curl -s -X POST \
-            "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token" \
+            "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token" \
             -H "Content-Type: application/x-www-form-urlencoded" \
             -d "grant_type=client_credentials" \
             -d "client_id=${{ secrets.CHES_CLIENT_ID }}" \
@@ -312,7 +312,7 @@ jobs:
             SUBJECT="Deployment FAILED - ${{ inputs.image_name }} to ${{ env.OPENSHIFT_NAMESPACE }}"
           fi
 
-          curl -s -X POST "https://ches.api.gov.bc.ca/api/v1/email" \
+          curl -s -X POST "https://ches-dev.api.gov.bc.ca/api/v1/email" \
             -H "Authorization: Bearer $TOKEN" \
             -H "Content-Type: application/json" \
             -d "{

--- a/.github/workflows/_reusable-dotnet-cicd.yml
+++ b/.github/workflows/_reusable-dotnet-cicd.yml
@@ -43,6 +43,14 @@ on:
     secrets:
       OPENSHIFT_TOKEN:
         required: true
+      CHES_CLIENT_ID:
+        required: false
+      CHES_CLIENT_SECRET:
+        required: false
+      CHES_SENDER_EMAIL:
+        required: false
+      CHES_NOTIFY_EMAIL:
+        required: false
 
 permissions:
   contents: read
@@ -166,6 +174,35 @@ jobs:
           sleep 60
           oc logs $POD -n ${{ env.OPENSHIFT_NAMESPACE }} --tail=20
 
+      - name: Notify Deployment Result
+        if: always()
+        continue-on-error: true
+        run: |
+          TOKEN=$(curl -s -X POST \
+            "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token" \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "grant_type=client_credentials" \
+            -d "client_id=${{ secrets.CHES_CLIENT_ID }}" \
+            -d "client_secret=${{ secrets.CHES_CLIENT_SECRET }}" \
+            | jq -r '.access_token')
+
+          if [ "${{ job.status }}" = "success" ]; then
+            SUBJECT="Deployment Successful - ${{ inputs.image_name }} to ${{ env.OPENSHIFT_NAMESPACE }}"
+          else
+            SUBJECT="Deployment FAILED - ${{ inputs.image_name }} to ${{ env.OPENSHIFT_NAMESPACE }}"
+          fi
+
+          curl -s -X POST "https://ches.api.gov.bc.ca/api/v1/email" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"from\": \"${{ secrets.CHES_SENDER_EMAIL }}\",
+              \"to\": [\"${{ secrets.CHES_NOTIFY_EMAIL }}\"],
+              \"subject\": \"$SUBJECT\",
+              \"bodyType\": \"text\",
+              \"body\": \"SHA: ${{ github.sha }}\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"
+            }"
+
   cd-test:
     name: CD — Deploy to Test
     runs-on: ubuntu-latest
@@ -256,3 +293,32 @@ jobs:
           echo "--- recent logs ---"
           sleep 60
           oc logs $POD -n ${{ env.OPENSHIFT_NAMESPACE }} --tail=20
+
+      - name: Notify Deployment Result
+        if: always()
+        continue-on-error: true
+        run: |
+          TOKEN=$(curl -s -X POST \
+            "https://loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token" \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "grant_type=client_credentials" \
+            -d "client_id=${{ secrets.CHES_CLIENT_ID }}" \
+            -d "client_secret=${{ secrets.CHES_CLIENT_SECRET }}" \
+            | jq -r '.access_token')
+
+          if [ "${{ job.status }}" = "success" ]; then
+            SUBJECT="Deployment Successful - ${{ inputs.image_name }} to ${{ env.OPENSHIFT_NAMESPACE }}"
+          else
+            SUBJECT="Deployment FAILED - ${{ inputs.image_name }} to ${{ env.OPENSHIFT_NAMESPACE }}"
+          fi
+
+          curl -s -X POST "https://ches.api.gov.bc.ca/api/v1/email" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"from\": \"${{ secrets.CHES_SENDER_EMAIL }}\",
+              \"to\": [\"${{ secrets.CHES_NOTIFY_EMAIL }}\"],
+              \"subject\": \"$SUBJECT\",
+              \"bodyType\": \"text\",
+              \"body\": \"SHA: ${{ github.sha }}\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"
+            }"

--- a/.github/workflows/indexing-service-cicd.yml
+++ b/.github/workflows/indexing-service-cicd.yml
@@ -38,3 +38,7 @@ jobs:
       health_check_method: exec_curl
     secrets:
       OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
+      CHES_CLIENT_ID: ${{ secrets.CHES_CLIENT_ID }}
+      CHES_CLIENT_SECRET: ${{ secrets.CHES_CLIENT_SECRET }}
+      CHES_SENDER_EMAIL: ${{ secrets.CHES_SENDER_EMAIL }}
+      CHES_NOTIFY_EMAIL: ${{ secrets.CHES_NOTIFY_EMAIL }}

--- a/.github/workflows/indexing-service-cicd.yml
+++ b/.github/workflows/indexing-service-cicd.yml
@@ -30,8 +30,8 @@ jobs:
       dockerfile: services/net/indexing/Dockerfile
       component: indexing-service
       deployment_name: indexing-service
-      kustomize_dev_path: openshift/kustomize/services/indexing/dev
-      kustomize_test_path: openshift/kustomize/services/indexing/test
+      kustomize_dev_path: openshift/kustomize/services/indexing/overlays/dev
+      kustomize_test_path: openshift/kustomize/services/indexing/overlays/test
       dev_branch: indexing-service
       rollout_timeout: '180s'
       continue_on_error_verify: true

--- a/.github/workflows/indexing-service-cicd.yml
+++ b/.github/workflows/indexing-service-cicd.yml
@@ -33,7 +33,7 @@ jobs:
       kustomize_dev_path: openshift/kustomize/services/indexing/overlays/dev
       kustomize_test_path: openshift/kustomize/services/indexing/overlays/test
       dev_branch: indexing-service
-      rollout_timeout: '180s'
+      rollout_timeout: '220s'
       continue_on_error_verify: true
       health_check_method: exec_curl
     secrets:

--- a/.github/workflows/indexing-service-cicd.yml
+++ b/.github/workflows/indexing-service-cicd.yml
@@ -1,0 +1,40 @@
+name: Indexing Service CI/CD
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [dev, master]
+    paths:
+      - services/net/indexing/**
+      - libs/net/**
+      - openshift/kustomize/services/indexing/**
+      - .github/workflows/indexing-service-cicd.yml
+  push:
+    branches: [dev, master, indexing-service]
+    paths:
+      - services/net/indexing/**
+      - libs/net/**
+      - openshift/kustomize/services/indexing/**
+      - .github/workflows/indexing-service-cicd.yml
+
+concurrency:
+  group: indexing-service-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pipeline:
+    uses: ./.github/workflows/_reusable-dotnet-cicd.yml
+    with:
+      image_name: indexing-service
+      csproj_path: services/net/indexing/TNO.Services.Indexing.csproj
+      dockerfile: services/net/indexing/Dockerfile
+      component: indexing-service
+      deployment_name: indexing-service
+      kustomize_dev_path: openshift/kustomize/services/indexing/dev
+      kustomize_test_path: openshift/kustomize/services/indexing/test
+      dev_branch: indexing-service
+      rollout_timeout: '180s'
+      continue_on_error_verify: true
+      health_check_method: exec_curl
+    secrets:
+      OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}

--- a/openshift/kustomize/tekton/base/tasks/build-all.yaml
+++ b/openshift/kustomize/tekton/base/tasks/build-all.yaml
@@ -121,12 +121,13 @@ spec:
           [dockerfile]="/services/net/content/Dockerfile"
         )
 
-        declare -A COMPONENT4=(
-          [id]="indexing"
-          [image]="indexing-service"
-          [context]=""
-          [dockerfile]="/services/net/indexing/Dockerfile"
-        )
+        # Moved to GitHub Actions CI/CD — indexing-service-cicd.yml
+        # declare -A COMPONENT4=(
+        #   [id]="indexing"
+        #   [image]="indexing-service"
+        #   [context]=""
+        #   [dockerfile]="/services/net/indexing/Dockerfile"
+        # )
 
         declare -A COMPONENT5=(
           [id]="transcription"

--- a/openshift/kustomize/tekton/base/tasks/deploy-all-deployment.yaml
+++ b/openshift/kustomize/tekton/base/tasks/deploy-all-deployment.yaml
@@ -120,15 +120,16 @@ spec:
           [env]="dev test prod"
         )
 
-        declare -A COMPONENT5=(
-          [id]="indexing"
-          [name]="indexing-service"
-          [type]="deployment"
-          [replicas]="1"
-          [action]="stop"
-          [build]="yes"
-          [env]="dev test prod"
-        )
+        # Moved to GitHub Actions CI/CD — indexing-service-cicd.yml
+        # declare -A COMPONENT5=(
+        #   [id]="indexing"
+        #   [name]="indexing-service"
+        #   [type]="deployment"
+        #   [replicas]="1"
+        #   [action]="stop"
+        #   [build]="yes"
+        #   [env]="dev test prod"
+        # )
 
         declare -A COMPONENT6=(
           [id]="indexing-cloud"

--- a/openshift/kustomize/tekton/base/tasks/deploy-all.yaml
+++ b/openshift/kustomize/tekton/base/tasks/deploy-all.yaml
@@ -119,15 +119,16 @@ spec:
           [env]="dev test prod"
         )
 
-        declare -A COMPONENT5=(
-          [id]="indexing"
-          [name]="indexing-service"
-          [type]="dc"
-          [replicas]="1"
-          [action]="stop"
-          [build]="yes"
-          [env]="dev test prod"
-        )
+        # Moved to GitHub Actions CI/CD — indexing-service-cicd.yml
+        # declare -A COMPONENT5=(
+        #   [id]="indexing"
+        #   [name]="indexing-service"
+        #   [type]="dc"
+        #   [replicas]="1"
+        #   [action]="stop"
+        #   [build]="yes"
+        #   [env]="dev test prod"
+        # )
 
         declare -A COMPONENT6=(
           [id]="indexing-cloud"


### PR DESCRIPTION
**Summary:**

* Onboard indexing-service to GitHub Actions CI/CD using the reusable .NET workflow template
* Disabled Tekton build and deploy for indexing-service to prevent duplicate builds running in parallel
* Fix kustomize overlay path — corrected to openshift/kustomize/services/indexing/overlays/dev and overlays/test
* Add CHES email notification to reusable workflow — notifies on deployment success/failure with corrected dev environment URLs
* Explicitly pass CHES secrets in indexing-service-cicd.yml — declared as required: false in reusable template for backward compatibility
* Increase rollout timeout to 220s to prevent false-negative pipeline failures


**Test Plan:**

* CI triggers on push — restore, lint, and build steps pass
* cd-dev deploys to 9b301c-dev — pod running and healthy
* Kustomize overlay path resolves without errors
* CHES notification step runs — token acquired, email request accepted
* Tekton does not build or deploy indexing-service — no duplicate builds
* Pipeline stays green even if rollout verify times out