### PR TITLE
Onboard ffmpeg-service CI/CD using reusable workflow

### DIFF
--- a/.github/workflows/ffmpeg-service-cicd.yml
+++ b/.github/workflows/ffmpeg-service-cicd.yml
@@ -33,7 +33,7 @@ jobs:
       kustomize_dev_path: openshift/kustomize/services/ffmpeg/overlays/dev
       kustomize_test_path: openshift/kustomize/services/ffmpeg/overlays/test
       dev_branch: ffmpeg-service
-      rollout_timeout: '220s'
+      rollout_timeout: '180s'
       continue_on_error_verify: true
       health_check_method: exec_curl
     secrets:

--- a/.github/workflows/ffmpeg-service-cicd.yml
+++ b/.github/workflows/ffmpeg-service-cicd.yml
@@ -1,0 +1,44 @@
+name: FFmpeg Service CI/CD
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [dev, master]
+    paths:
+      - services/net/ffmpeg/**
+      - libs/net/**
+      - openshift/kustomize/services/ffmpeg/**
+      - .github/workflows/ffmpeg-service-cicd.yml
+  push:
+    branches: [dev, master, ffmpeg-service]
+    paths:
+      - services/net/ffmpeg/**
+      - libs/net/**
+      - openshift/kustomize/services/ffmpeg/**
+      - .github/workflows/ffmpeg-service-cicd.yml
+
+concurrency:
+  group: ffmpeg-service-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pipeline:
+    uses: ./.github/workflows/_reusable-dotnet-cicd.yml
+    with:
+      image_name: ffmpeg-service
+      csproj_path: services/net/ffmpeg/TNO.Services.FFmpeg.csproj
+      dockerfile: services/net/ffmpeg/Dockerfile
+      component: ffmpeg-service
+      deployment_name: ffmpeg-service
+      kustomize_dev_path: openshift/kustomize/services/ffmpeg/overlays/dev
+      kustomize_test_path: openshift/kustomize/services/ffmpeg/overlays/test
+      dev_branch: ffmpeg-service
+      rollout_timeout: '220s'
+      continue_on_error_verify: true
+      health_check_method: exec_curl
+    secrets:
+      OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
+      CHES_CLIENT_ID: ${{ secrets.CHES_CLIENT_ID }}
+      CHES_CLIENT_SECRET: ${{ secrets.CHES_CLIENT_SECRET }}
+      CHES_SENDER_EMAIL: ${{ secrets.CHES_SENDER_EMAIL }}
+      CHES_NOTIFY_EMAIL: ${{ secrets.CHES_NOTIFY_EMAIL }}

--- a/openshift/kustomize/tekton/base/tasks/build-all.yaml
+++ b/openshift/kustomize/tekton/base/tasks/build-all.yaml
@@ -178,12 +178,13 @@ spec:
         #   [dockerfile]="/services/net/folder-collection/Dockerfile"
         # )
 
-        declare -A COMPONENT12=(
-          [id]="ffmpeg"
-          [image]="ffmpeg-service"
-          [context]=""
-          [dockerfile]="/services/net/ffmpeg/Dockerfile"
-        )
+        # Moved to GitHub Actions CI/CD — ffmpeg-service-cicd.yml
+        # declare -A COMPONENT12=(
+        #   [id]="ffmpeg"
+        #   [image]="ffmpeg-service"
+        #   [context]=""
+        #   [dockerfile]="/services/net/ffmpeg/Dockerfile"
+        # )
 
         # Moved to GitHub Actions CI/CD — event-handler-cicd.yml
         # declare -A COMPONENT13=(

--- a/openshift/kustomize/tekton/base/tasks/deploy-all-deployment.yaml
+++ b/openshift/kustomize/tekton/base/tasks/deploy-all-deployment.yaml
@@ -211,15 +211,16 @@ spec:
         #   [env]="dev test prod"
         # )
 
-        declare -A COMPONENT14=(
-          [id]="ffmpeg"
-          [name]="ffmpeg-service"
-          [type]="deployment"
-          [replicas]="1"
-          [action]="stop"
-          [build]="yes"
-          [env]="dev test prod"
-        )
+        # Moved to GitHub Actions CI/CD — ffmpeg-service-cicd.yml
+        # declare -A COMPONENT14=(
+        #   [id]="ffmpeg"
+        #   [name]="ffmpeg-service"
+        #   [type]="deployment"
+        #   [replicas]="1"
+        #   [action]="stop"
+        #   [build]="yes"
+        #   [env]="dev test prod"
+        # )
 
         # Moved to GitHub Actions CI/CD — event-handler-cicd.yml
         # declare -A COMPONENT15=(

--- a/openshift/kustomize/tekton/base/tasks/deploy-all.yaml
+++ b/openshift/kustomize/tekton/base/tasks/deploy-all.yaml
@@ -210,15 +210,16 @@ spec:
         #   [env]="dev test prod"
         # )
 
-        declare -A COMPONENT14=(
-          [id]="ffmpeg"
-          [name]="ffmpeg-service"
-          [type]="dc"
-          [replicas]="1"
-          [action]="stop"
-          [build]="yes"
-          [env]="dev test prod"
-        )
+        # Moved to GitHub Actions CI/CD — ffmpeg-service-cicd.yml
+        # declare -A COMPONENT14=(
+        #   [id]="ffmpeg"
+        #   [name]="ffmpeg-service"
+        #   [type]="dc"
+        #   [replicas]="1"
+        #   [action]="stop"
+        #   [build]="yes"
+        #   [env]="dev test prod"
+        # )
 
         # Moved to GitHub Actions CI/CD — event-handler-cicd.yml
         # declare -A COMPONENT15=(


### PR DESCRIPTION
**Summary**

* Onboard ffmpeg-service to GitHub Actions CI/CD using the reusable .NET workflow template
* Disable Tekton build and deploy for ffmpeg-service to prevent duplicate builds running in parallel
* Explicitly pass CHES secrets - declared as required: false in reusable template for backward compatibility

**Test Plan**

 * CI triggers on push - restore, lint, and build steps pass
 * cd-dev deploys to 9b301c-dev - pod running and healthy
 * Tekton does not build or deploy ffmpeg-service - no duplicate builds
 * Pipeline stays green even if rollout verify times out