### PR TITLE
Onboard Transcription Service CI/CD and disable Tekton build

### DIFF
--- a/.github/workflows/transcription-service-cicd.yml
+++ b/.github/workflows/transcription-service-cicd.yml
@@ -21,7 +21,9 @@ concurrency:
   group: transcription-service-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: {}
+permissions:
+  contents: read
+  security-events: write
 
 jobs:
   pipeline:

--- a/.github/workflows/transcription-service-cicd.yml
+++ b/.github/workflows/transcription-service-cicd.yml
@@ -1,0 +1,46 @@
+name: Transcription Service CI/CD
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [dev, master]
+    paths:
+      - services/net/transcription/**
+      - libs/net/**
+      - openshift/kustomize/services/transcription/**
+      - .github/workflows/transcription-service-cicd.yml
+  push:
+    branches: [dev, master, transcription-service]
+    paths:
+      - services/net/transcription/**
+      - libs/net/**
+      - openshift/kustomize/services/transcription/**
+      - .github/workflows/transcription-service-cicd.yml
+
+concurrency:
+  group: transcription-service-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  pipeline:
+    uses: ./.github/workflows/_reusable-dotnet-cicd.yml
+    with:
+      image_name: transcription-service
+      csproj_path: services/net/transcription/TNO.Services.Transcription.csproj
+      dockerfile: services/net/transcription/Dockerfile
+      component: transcription-service
+      deployment_name: transcription-service
+      kustomize_dev_path: openshift/kustomize/services/transcription/overlays/dev
+      kustomize_test_path: openshift/kustomize/services/transcription/overlays/test
+      dev_branch: transcription-service
+      rollout_timeout: '180s'
+      continue_on_error_verify: true
+      health_check_method: exec_curl
+    secrets:
+      OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
+      CHES_CLIENT_ID: ${{ secrets.CHES_CLIENT_ID }}
+      CHES_CLIENT_SECRET: ${{ secrets.CHES_CLIENT_SECRET }}
+      CHES_SENDER_EMAIL: ${{ secrets.CHES_SENDER_EMAIL }}
+      CHES_NOTIFY_EMAIL: ${{ secrets.CHES_NOTIFY_EMAIL }}

--- a/openshift/kustomize/tekton/base/tasks/build-all.yaml
+++ b/openshift/kustomize/tekton/base/tasks/build-all.yaml
@@ -130,12 +130,13 @@ spec:
         #   [dockerfile]="/services/net/indexing/Dockerfile"
         # )
 
-        declare -A COMPONENT5=(
-          [id]="transcription"
-          [image]="transcription-service"
-          [context]=""
-          [dockerfile]="/services/net/transcription/Dockerfile"
-        )
+        # Moved to GitHub Actions CI/CD — transcription-service-cicd.yml
+        # declare -A COMPONENT5=(
+        #   [id]="transcription"
+        #   [image]="transcription-service"
+        #   [context]=""
+        #   [dockerfile]="/services/net/transcription/Dockerfile"
+        # )
 
         declare -A COMPONENT6=(
           [id]="nlp"

--- a/openshift/kustomize/tekton/base/tasks/deploy-all-deployment.yaml
+++ b/openshift/kustomize/tekton/base/tasks/deploy-all-deployment.yaml
@@ -141,15 +141,16 @@ spec:
           [env]="test prod"
         )
 
-        declare -A COMPONENT7=(
-          [id]="transcription"
-          [name]="transcription-service"
-          [type]="deployment"
-          [replicas]="1"
-          [action]="stop"
-          [build]="yes"
-          [env]="dev test prod"
-        )
+        # Moved to GitHub Actions CI/CD — transcription-service-cicd.yml
+        # declare -A COMPONENT7=(
+        #   [id]="transcription"
+        #   [name]="transcription-service"
+        #   [type]="deployment"
+        #   [replicas]="1"
+        #   [action]="stop"
+        #   [build]="yes"
+        #   [env]="dev test prod"
+        # )
 
         declare -A COMPONENT8=(
           [id]="nlp"

--- a/openshift/kustomize/tekton/base/tasks/deploy-all.yaml
+++ b/openshift/kustomize/tekton/base/tasks/deploy-all.yaml
@@ -140,15 +140,16 @@ spec:
           [env]="test prod"
         )
 
-        declare -A COMPONENT7=(
-          [id]="transcription"
-          [name]="transcription-service"
-          [type]="dc"
-          [replicas]="1"
-          [action]="stop"
-          [build]="yes"
-          [env]="dev test prod"
-        )
+        # Moved to GitHub Actions CI/CD — transcription-service-cicd.yml
+        # declare -A COMPONENT7=(
+        #   [id]="transcription"
+        #   [name]="transcription-service"
+        #   [type]="dc"
+        #   [replicas]="1"
+        #   [action]="stop"
+        #   [build]="yes"
+        #   [env]="dev test prod"
+        # )
 
         declare -A COMPONENT8=(
           [id]="nlp"


### PR DESCRIPTION
**Summary**

* Created transcription-service-cicd.yml using the shared reusable workflow template
* CD to dev triggers on push to transcription-service branch
* Explicit permissions block added (contents: read, security-events: write) for CodeQL compliance
* Tekton build disabled in build-all.yaml, deploy-all.yaml and deploy-all-deployment.yaml to prevent duplicate deployments

**Test Plan**

 * CI passes — restore, lint, build green
 * CD dev triggers on push to transcription-service branch
 * Pod reaches Running state in 9b301c-dev
 * No duplicate Tekton build triggered after merge