### PR TITLE
Onboard scheduler-service CI/CD using reusable workflow and disable Tekton build

### DIFF
--- a/.github/workflows/scheduler-service-cicd.yml
+++ b/.github/workflows/scheduler-service-cicd.yml
@@ -1,0 +1,48 @@
+name: Scheduler Service CI/CD
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [dev, master]
+    paths:
+      - services/net/scheduler/**
+      - libs/net/**
+      - openshift/kustomize/services/scheduler/**
+      - .github/workflows/scheduler-service-cicd.yml
+  push:
+    branches: [dev, master, scheduler-service]
+    paths:
+      - services/net/scheduler/**
+      - libs/net/**
+      - openshift/kustomize/services/scheduler/**
+      - .github/workflows/scheduler-service-cicd.yml
+
+concurrency:
+  group: scheduler-service-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  pipeline:
+    uses: ./.github/workflows/_reusable-dotnet-cicd.yml
+    with:
+      image_name: scheduler-service
+      csproj_path: services/net/scheduler/TNO.Services.Scheduler.csproj
+      dockerfile: services/net/scheduler/Dockerfile
+      component: scheduler-service
+      deployment_name: scheduler-service
+      kustomize_dev_path: openshift/kustomize/services/scheduler/overlays/dev
+      kustomize_test_path: openshift/kustomize/services/scheduler/overlays/test
+      dev_branch: scheduler-service
+      rollout_timeout: '180s'
+      continue_on_error_verify: true
+      health_check_method: exec_curl
+    secrets:
+      OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
+      CHES_CLIENT_ID: ${{ secrets.CHES_CLIENT_ID }}
+      CHES_CLIENT_SECRET: ${{ secrets.CHES_CLIENT_SECRET }}
+      CHES_SENDER_EMAIL: ${{ secrets.CHES_SENDER_EMAIL }}
+      CHES_NOTIFY_EMAIL: ${{ secrets.CHES_NOTIFY_EMAIL }}

--- a/openshift/kustomize/tekton/base/tasks/build-all.yaml
+++ b/openshift/kustomize/tekton/base/tasks/build-all.yaml
@@ -169,12 +169,13 @@ spec:
         #   [dockerfile]="/services/net/notification/Dockerfile"
         # )
 
-        declare -A COMPONENT10=(
-          [id]="scheduler"
-          [image]="scheduler-service"
-          [context]=""
-          [dockerfile]="/services/net/scheduler/Dockerfile"
-        )
+        # Moved to GitHub Actions CI/CD — scheduler-service-cicd.yml
+        # declare -A COMPONENT10=(
+        #   [id]="scheduler"
+        #   [image]="scheduler-service"
+        #   [context]=""
+        #   [dockerfile]="/services/net/scheduler/Dockerfile"
+        # )
 
         # Moved to GitHub Actions CI/CD — folder-collection-cicd.yml
         # declare -A COMPONENT11=(

--- a/openshift/kustomize/tekton/base/tasks/deploy-all-deployment.yaml
+++ b/openshift/kustomize/tekton/base/tasks/deploy-all-deployment.yaml
@@ -195,15 +195,16 @@ spec:
         #   [env]="dev test prod"
         # )
 
-        declare -A COMPONENT12=(
-          [id]="scheduler"
-          [name]="scheduler-service"
-          [type]="deployment"
-          [replicas]="1"
-          [action]="stop"
-          [build]="yes"
-          [env]="dev test prod"
-        )
+        # Moved to GitHub Actions CI/CD — scheduler-service-cicd.yml
+        # declare -A COMPONENT12=(
+        #   [id]="scheduler"
+        #   [name]="scheduler-service"
+        #   [type]="deployment"
+        #   [replicas]="1"
+        #   [action]="stop"
+        #   [build]="yes"
+        #   [env]="dev test prod"
+        # )
 
         # Moved to GitHub Actions CI/CD — folder-collection-cicd.yml
         # declare -A COMPONENT13=(

--- a/openshift/kustomize/tekton/base/tasks/deploy-all.yaml
+++ b/openshift/kustomize/tekton/base/tasks/deploy-all.yaml
@@ -194,15 +194,16 @@ spec:
         #   [env]="dev test prod"
         # )
 
-        declare -A COMPONENT12=(
-          [id]="scheduler"
-          [name]="scheduler-service"
-          [type]="dc"
-          [replicas]="1"
-          [action]="stop"
-          [build]="yes"
-          [env]="dev test prod"
-        )
+        # Moved to GitHub Actions CI/CD — scheduler-service-cicd.yml
+        # declare -A COMPONENT12=(
+        #   [id]="scheduler"
+        #   [name]="scheduler-service"
+        #   [type]="dc"
+        #   [replicas]="1"
+        #   [action]="stop"
+        #   [build]="yes"
+        #   [env]="dev test prod"
+        # )
 
         # Moved to GitHub Actions CI/CD — folder-collection-cicd.yml
         # declare -A COMPONENT13=(


### PR DESCRIPTION
**Summary:**

* Added scheduler-service-cicd.yml using the shared _reusable-dotnet-cicd.yml reusable workflow
* Commented out scheduler-service entries in Tekton build-all.yaml, deploy-all.yaml and deploy-all-deployment.yaml

**Test Plan:**

* CI stage passes — lint, build and unit tests
* Image builds and pushes successfully
* Tekton no longer builds scheduler-service
* Dev is currently not active — deployment will be validated on merge to master via cd-test targeting 9b301c-test