### PR TITLE
Add ACR credentials to ches-retry and filemonitor CI/CD workflows

### DIFF
--- a/.github/workflows/ches-retry-service-cicd.yml
+++ b/.github/workflows/ches-retry-service-cicd.yml
@@ -42,6 +42,8 @@ jobs:
       health_check_method: exec_curl
     secrets:
       OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
+      ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
+      ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
       CHES_CLIENT_ID: ${{ secrets.CHES_CLIENT_ID }}
       CHES_CLIENT_SECRET: ${{ secrets.CHES_CLIENT_SECRET }}
       CHES_SENDER_EMAIL: ${{ secrets.CHES_SENDER_EMAIL }}

--- a/.github/workflows/filemonitor-service-cicd.yml
+++ b/.github/workflows/filemonitor-service-cicd.yml
@@ -42,6 +42,8 @@ jobs:
       health_check_method: exec_curl
     secrets:
       OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
+      ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
+      ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
       CHES_CLIENT_ID: ${{ secrets.CHES_CLIENT_ID }}
       CHES_CLIENT_SECRET: ${{ secrets.CHES_CLIENT_SECRET }}
       CHES_SENDER_EMAIL: ${{ secrets.CHES_SENDER_EMAIL }}


### PR DESCRIPTION
Add ACR credentials to ches-retry and filemonitor CI/CD workflows