### PR TITLE
Fix docker build

### DIFF
--- a/.github/workflows/_reusable-db-migration-cd.yml
+++ b/.github/workflows/_reusable-db-migration-cd.yml
@@ -156,10 +156,20 @@ jobs:
             }'
 
           echo "Waiting for migration pod to complete (timeout 10m)..."
-          oc wait pod/${{ env.IMAGE_NAME }} \
-            -n ${{ inputs.openshift_namespace }} \
-            --for=jsonpath='{.status.phase}'=Succeeded \
-            --timeout=10m
+          for i in $(seq 1 120); do
+            PHASE=$(oc get pod ${{ env.IMAGE_NAME }} -n ${{ inputs.openshift_namespace }} -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
+            echo "  [$i] pod phase: $PHASE"
+            if [ "$PHASE" = "Succeeded" ]; then
+              echo "Migration completed successfully."
+              break
+            elif [ "$PHASE" = "Failed" ] || [ "$PHASE" = "Error" ]; then
+              echo "Migration pod failed with phase: $PHASE"
+              echo "--- migration logs ---"
+              oc logs ${{ env.IMAGE_NAME }} -n ${{ inputs.openshift_namespace }} || true
+              exit 1
+            fi
+            sleep 5
+          done
 
           echo "--- migration logs ---"
           oc logs ${{ env.IMAGE_NAME }} -n ${{ inputs.openshift_namespace }}

--- a/.github/workflows/_reusable-db-migration-cd.yml
+++ b/.github/workflows/_reusable-db-migration-cd.yml
@@ -98,11 +98,8 @@ jobs:
             -n ${{ inputs.openshift_namespace }} \
             --image=${{ env.ACR_URL }}/${{ env.IMAGE_NAME }}:${{ inputs.image_tag }} \
             --image-pull-policy=Always \
-            --attach \
-            --rm \
             --labels='role=migration,part-of=tno,component=database' \
             --restart=Never \
-            --timeout=10m \
             --override-type='merge' \
             --overrides='{
               "apiVersion":"v1",
@@ -157,6 +154,23 @@ jobs:
                 ]
               }
             }'
+
+          echo "Waiting for migration pod to complete (timeout 10m)..."
+          oc wait pod/${{ env.IMAGE_NAME }} \
+            -n ${{ inputs.openshift_namespace }} \
+            --for=jsonpath='{.status.phase}'=Succeeded \
+            --timeout=10m
+
+          echo "--- migration logs ---"
+          oc logs ${{ env.IMAGE_NAME }} -n ${{ inputs.openshift_namespace }}
+
+      - name: Cleanup Migration Pod
+        if: always()
+        continue-on-error: true
+        run: |
+          oc delete pod ${{ env.IMAGE_NAME }} \
+            -n ${{ inputs.openshift_namespace }} \
+            --ignore-not-found=true
 
       - name: Migration Report
         if: always()

--- a/.github/workflows/_reusable-db-migration-cd.yml
+++ b/.github/workflows/_reusable-db-migration-cd.yml
@@ -28,8 +28,6 @@ env:
   OPENSHIFT_TOOLS_NAMESPACE: 9b301c-tools
   ACR_URL: bcgov-c4awhwfpcremdbga.azurecr.io
   IMAGE_NAME: db-migration
-  DOCKER_CONTEXT: ./libs/net
-  DOCKERFILE: libs/net/Dockerfile
 
 jobs:
   migrate:
@@ -40,11 +38,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build Docker Image
+        working-directory: ./libs/net
         run: |
           docker build \
-            -f ${{ env.DOCKERFILE }} \
+            -f Dockerfile \
             -t ${{ env.IMAGE_NAME }}:${{ github.sha }} \
-            ${{ env.DOCKER_CONTEXT }}
+            .
 
       - name: Trivy Container Scan
         uses: ./.github/actions/trivy-scan

--- a/.github/workflows/_reusable-db-migration-cd.yml
+++ b/.github/workflows/_reusable-db-migration-cd.yml
@@ -142,11 +142,11 @@ jobs:
                     ],
                     "resources":{
                       "requests":{
-                        "memory":"1Gi",
+                        "memory":"2Gi",
                         "cpu":"500m"
                       },
                       "limits":{
-                        "memory":"2Gi",
+                        "memory":"4Gi",
                         "cpu":"1000m"
                       }
                     }

--- a/.github/workflows/_reusable-db-migration-cd.yml
+++ b/.github/workflows/_reusable-db-migration-cd.yml
@@ -111,6 +111,7 @@ jobs:
                   {
                     "name":"${{ env.IMAGE_NAME }}",
                     "image":"${{ env.ACR_URL }}/${{ env.IMAGE_NAME }}:${{ inputs.image_tag }}",
+                    "imagePullPolicy":"Always",
                     "env":[
                       {
                         "name":"ConnectionStrings__TNO",

--- a/libs/net/Dockerfile
+++ b/libs/net/Dockerfile
@@ -14,6 +14,15 @@ RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u 
     fix_permissions "/src" "/tmp"
 RUN dotnet restore
 RUN dotnet build /src/dal/TNO.DAL.csproj --no-restore -c Release
+
+RUN dotnet ef migrations bundle \
+    --project /src/dal/TNO.DAL.csproj \
+    --configuration Release \
+    --no-build \
+    --verbose \
+    -o /app/efbundle
+
+RUN chmod +x /app/efbundle
 RUN chmod -R 0777 /src
 RUN mkdir /.local
 RUN chmod -R 0777 /.local
@@ -21,4 +30,4 @@ RUN chmod -R 0777 /.local
 # Run container by default as user with id 1001 (default)
 USER 1001
 
-ENTRYPOINT cd /src/dal && dotnet ef database update -v --no-build --configuration Release
+ENTRYPOINT ["/app/efbundle", "--verbose"]

--- a/libs/net/Dockerfile
+++ b/libs/net/Dockerfile
@@ -13,6 +13,7 @@ COPY . .
 RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \
     fix_permissions "/src" "/tmp"
 RUN dotnet restore
+RUN dotnet build /src/dal/TNO.DAL.csproj --no-restore -c Release
 RUN chmod -R 0777 /src
 RUN mkdir /.local
 RUN chmod -R 0777 /.local
@@ -20,4 +21,4 @@ RUN chmod -R 0777 /.local
 # Run container by default as user with id 1001 (default)
 USER 1001
 
-ENTRYPOINT cd /src/dal && dotnet ef database update -v
+ENTRYPOINT cd /src/dal && dotnet ef database update -v --no-build --configuration Release

--- a/libs/net/Dockerfile
+++ b/libs/net/Dockerfile
@@ -15,7 +15,10 @@ RUN fix_permissions() { while [ $# -gt 0 ] ; do chgrp -R 0 "$1" && chmod -R g=u 
 RUN dotnet restore
 RUN dotnet build /src/dal/TNO.DAL.csproj --no-restore -c Release
 
-RUN dotnet ef migrations bundle \
+RUN ConnectionStrings__TNO="Host=placeholder;Database=placeholder" \
+    DB_POSTGRES_USERNAME=placeholder \
+    DB_POSTGRES_PASSWORD=placeholder \
+    dotnet ef migrations bundle \
     --project /src/dal/TNO.DAL.csproj \
     --configuration Release \
     --no-build \


### PR DESCRIPTION
Refactored the DB migration Docker image to use a pre-compiled EF Core bundle instead of running dotnet ef database update at runtime. 
This makes the migration container start faster and eliminates the need for the full .NET project context at runtime. 
Also increased memory limits (2Gi/4Gi) and added imagePullPolicy:
Always to ensure the latest image is always pulled during migration jobs.