### PR TITLE
Oc login retry

### DIFF
--- a/.github/CICD_GENERAL.md
+++ b/.github/CICD_GENERAL.md
@@ -36,3 +36,22 @@ Production is not wired into this flow yet.
   workflows.
 - Elasticsearch migration is not part of `deploy-all.yml` yet because dev uses
   OpenShift-hosted Elasticsearch while test and prod use cloud Elasticsearch.
+
+## Shared Actions
+
+These local actions hold the common deployment pieces used by the newer flows:
+
+- `actions/build-scan-push-image`: builds an image, runs Trivy, backs up the
+  existing ACR tag, and pushes the new image tag. ACR login, backup, and push
+  operations retry with increasing waits.
+- `actions/deploy-openshift-workload`: applies kustomize, restarts the target
+  workload, waits for rollout, and can update the API StatefulSet when needed.
+- `actions/install-oc`: installs a pinned `oc` client directly from the
+  OpenShift mirror. This avoids the Node 20 and cache warnings from
+  `redhat-actions/openshift-tools-installer@v1`.
+- `actions/openshift-login`: logs in to OpenShift with retry support and
+  increasing waits.
+
+DB migration also uses `actions/install-oc` and `actions/openshift-login`.
+Its image build and ACR push steps are still inside
+`_reusable-db-migration-cd.yml`.

--- a/.github/CICD_GENERAL.md
+++ b/.github/CICD_GENERAL.md
@@ -42,8 +42,7 @@ Production is not wired into this flow yet.
 These local actions hold the common deployment pieces used by the newer flows:
 
 - `actions/build-scan-push-image`: builds an image, runs Trivy, backs up the
-  existing ACR tag, and pushes the new image tag. ACR login, backup, and push
-  operations retry with increasing waits.
+  existing ACR tag, and pushes the new image tag.
 - `actions/deploy-openshift-workload`: applies kustomize, restarts the target
   workload, waits for rollout, and can update the API StatefulSet when needed.
 - `actions/install-oc`: installs a pinned `oc` client directly from the

--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -65,8 +65,7 @@ inside the same matrix can run in parallel, but each phase waits for the earlier
 phase through `needs`.
 
 The build phase uses the shared `actions/build-scan-push-image` action. Docker
-build failures retry, and ACR login, backup, and push operations retry with
-increasing waits.
+build failures retry.
 
 OpenShift deploy phases use the shared `actions/install-oc`,
 `actions/openshift-login`, and `actions/deploy-openshift-workload` actions.

--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -64,6 +64,15 @@ The build, service deploy, and frontend deploy phases use matrix jobs. Items
 inside the same matrix can run in parallel, but each phase waits for the earlier
 phase through `needs`.
 
+The build phase uses the shared `actions/build-scan-push-image` action. Docker
+build failures retry, and ACR login, backup, and push operations retry with
+increasing waits.
+
+OpenShift deploy phases use the shared `actions/install-oc`,
+`actions/openshift-login`, and `actions/deploy-openshift-workload` actions.
+`install-oc` is a local shell action that pins the OpenShift client version and
+avoids the warning noise from `redhat-actions/openshift-tools-installer@v1`.
+
 ## Change Detection
 
 Changed deploys are decided by:
@@ -149,6 +158,10 @@ In `all` mode, DB migration runs unless `skip_db_migration` is `true`.
 
 The migration job builds the EF migration bundle from `libs/net` and runs it as
 a temporary OpenShift pod.
+
+DB migration uses the same local `install-oc` and `openshift-login` actions as
+the orchestrated deploy jobs. Its Docker build, Trivy scan, ACR backup, and ACR
+push steps still live in `_reusable-db-migration-cd.yml`.
 
 ## API StatefulSet
 

--- a/.github/actions/build-scan-push-image/action.yml
+++ b/.github/actions/build-scan-push-image/action.yml
@@ -99,7 +99,7 @@ runs:
         done
 
     - name: Cache Trivy DB
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/trivy
         key: trivy-db-${{ github.run_id }}
@@ -117,7 +117,7 @@ runs:
         trivyignores: ${{ inputs.trivyignores }}
 
     - name: Upload Trivy Results to GitHub Security
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       if: ${{ hashFiles('trivy-results.sarif') != '' }}
       with:
         sarif_file: trivy-results.sarif

--- a/.github/actions/build-scan-push-image/action.yml
+++ b/.github/actions/build-scan-push-image/action.yml
@@ -42,14 +42,6 @@ inputs:
     description: Seconds to wait between Docker build attempts.
     required: false
     default: '15'
-  acr_attempts:
-    description: Number of attempts for ACR login, pull, and push operations.
-    required: false
-    default: '5'
-  acr_retry_seconds:
-    description: Base seconds to wait between ACR retry attempts.
-    required: false
-    default: '20'
   trivy_severity:
     description: Comma-separated list of severities to check.
     required: false
@@ -136,26 +128,10 @@ runs:
         ACR_URL: ${{ inputs.acr_url }}
         ACR_USERNAME: ${{ inputs.acr_username }}
         ACR_PASSWORD: ${{ inputs.acr_password }}
-        ACR_ATTEMPTS: ${{ inputs.acr_attempts }}
-        ACR_RETRY_SECONDS: ${{ inputs.acr_retry_seconds }}
       run: |
-        for attempt in $(seq 1 "${ACR_ATTEMPTS}"); do
-          if echo "${ACR_PASSWORD}" | docker login "${ACR_URL}" \
-            -u "${ACR_USERNAME}" \
-            --password-stdin; then
-            exit 0
-          else
-            status=$?
-          fi
-
-          if [ "$attempt" -eq "${ACR_ATTEMPTS}" ]; then
-            exit "$status"
-          fi
-
-          wait_seconds=$((ACR_RETRY_SECONDS * attempt))
-          echo "ACR login failed on attempt ${attempt}/${ACR_ATTEMPTS}; retrying in ${wait_seconds} seconds..."
-          sleep "${wait_seconds}"
-        done
+        echo "${ACR_PASSWORD}" | docker login "${ACR_URL}" \
+          -u "${ACR_USERNAME}" \
+          --password-stdin
 
     - name: Backup current image tag
       continue-on-error: true
@@ -164,30 +140,14 @@ runs:
         IMAGE_NAME: ${{ inputs.image_name }}
         IMAGE_TAG: ${{ inputs.image_tag }}
         ACR_URL: ${{ inputs.acr_url }}
-        ACR_ATTEMPTS: ${{ inputs.acr_attempts }}
-        ACR_RETRY_SECONDS: ${{ inputs.acr_retry_seconds }}
       run: |
-        for attempt in $(seq 1 "${ACR_ATTEMPTS}"); do
-          echo "Backing up ${IMAGE_NAME}:${IMAGE_TAG} to ${IMAGE_NAME}:${IMAGE_TAG}-backup"
-          if docker pull "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}" && \
-            docker tag \
-              "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}" \
-              "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}-backup" && \
-            docker push \
-              "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}-backup"; then
-            exit 0
-          else
-            status=$?
-          fi
-
-          if [ "$attempt" -eq "${ACR_ATTEMPTS}" ]; then
-            exit "$status"
-          fi
-
-          wait_seconds=$((ACR_RETRY_SECONDS * attempt))
-          echo "ACR backup failed on attempt ${attempt}/${ACR_ATTEMPTS}; retrying in ${wait_seconds} seconds..."
-          sleep "${wait_seconds}"
-        done
+        echo "Backing up ${IMAGE_NAME}:${IMAGE_TAG} to ${IMAGE_NAME}:${IMAGE_TAG}-backup"
+        docker pull "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}" && \
+          docker tag \
+            "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}" \
+            "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}-backup" && \
+          docker push \
+            "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}-backup"
 
     - name: Push Image to ACR
       shell: bash
@@ -196,25 +156,8 @@ runs:
         SOURCE_TAG: ${{ inputs.source_tag }}
         IMAGE_TAG: ${{ inputs.image_tag }}
         ACR_URL: ${{ inputs.acr_url }}
-        ACR_ATTEMPTS: ${{ inputs.acr_attempts }}
-        ACR_RETRY_SECONDS: ${{ inputs.acr_retry_seconds }}
       run: |
         docker tag \
           "${IMAGE_NAME}:${SOURCE_TAG}" \
           "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}"
-
-        for attempt in $(seq 1 "${ACR_ATTEMPTS}"); do
-          if docker push "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}"; then
-            exit 0
-          else
-            status=$?
-          fi
-
-          if [ "$attempt" -eq "${ACR_ATTEMPTS}" ]; then
-            exit "$status"
-          fi
-
-          wait_seconds=$((ACR_RETRY_SECONDS * attempt))
-          echo "ACR push failed on attempt ${attempt}/${ACR_ATTEMPTS}; retrying in ${wait_seconds} seconds..."
-          sleep "${wait_seconds}"
-        done
+        docker push "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}"

--- a/.github/actions/build-scan-push-image/action.yml
+++ b/.github/actions/build-scan-push-image/action.yml
@@ -1,0 +1,141 @@
+name: Build, Scan, and Push Image
+description: Build a Docker image, scan it with Trivy, back up the current ACR tag, and push the new tag.
+
+inputs:
+  image_name:
+    description: Local image name and ACR repository name.
+    required: true
+  dockerfile:
+    description: Path to the Dockerfile.
+    required: true
+  context:
+    description: Docker build context.
+    required: true
+  source_tag:
+    description: Temporary local image tag, usually the commit SHA.
+    required: true
+  image_tag:
+    description: ACR deployment tag, such as dev or test.
+    required: true
+  acr_url:
+    description: ACR registry URL.
+    required: true
+  acr_username:
+    description: ACR username.
+    required: true
+  acr_password:
+    description: ACR password.
+    required: true
+  build_arg_name:
+    description: Optional Docker build argument name.
+    required: false
+    default: ''
+  build_arg_value:
+    description: Optional Docker build argument value.
+    required: false
+    default: ''
+  trivy_severity:
+    description: Comma-separated list of severities to check.
+    required: false
+    default: CRITICAL,HIGH
+  trivy_exit_code:
+    description: Exit code when vulnerabilities are found.
+    required: false
+    default: '0'
+  trivy_ignore_unfixed:
+    description: Whether to ignore unfixed vulnerabilities.
+    required: false
+    default: 'true'
+  trivyignores:
+    description: Path to .trivyignore file.
+    required: false
+    default: .trivyignore
+
+runs:
+  using: composite
+  steps:
+    - name: Build Docker Image
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image_name }}
+        DOCKERFILE: ${{ inputs.dockerfile }}
+        CONTEXT: ${{ inputs.context }}
+        SOURCE_TAG: ${{ inputs.source_tag }}
+        BUILD_ARG_NAME: ${{ inputs.build_arg_name }}
+        BUILD_ARG_VALUE: ${{ inputs.build_arg_value }}
+      run: |
+        BUILD_ARGS=()
+        if [ -n "${BUILD_ARG_NAME}" ]; then
+          BUILD_ARGS+=(--build-arg "${BUILD_ARG_NAME}=${BUILD_ARG_VALUE}")
+        fi
+
+        docker build \
+          -f "${DOCKERFILE}" \
+          -t "${IMAGE_NAME}:${SOURCE_TAG}" \
+          "${BUILD_ARGS[@]}" \
+          "${CONTEXT}"
+
+    - name: Cache Trivy DB
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/trivy
+        key: trivy-db-${{ github.run_id }}
+        restore-keys: trivy-db-
+
+    - name: Trivy Container Scan
+      uses: aquasecurity/trivy-action@master
+      with:
+        image-ref: ${{ inputs.image_name }}:${{ inputs.source_tag }}
+        format: sarif
+        output: trivy-results.sarif
+        severity: ${{ inputs.trivy_severity }}
+        ignore-unfixed: ${{ inputs.trivy_ignore_unfixed }}
+        exit-code: ${{ inputs.trivy_exit_code }}
+        trivyignores: ${{ inputs.trivyignores }}
+
+    - name: Upload Trivy Results to GitHub Security
+      uses: github/codeql-action/upload-sarif@v3
+      if: always()
+      with:
+        sarif_file: trivy-results.sarif
+
+    - name: Login to ACR
+      shell: bash
+      env:
+        ACR_URL: ${{ inputs.acr_url }}
+        ACR_USERNAME: ${{ inputs.acr_username }}
+        ACR_PASSWORD: ${{ inputs.acr_password }}
+      run: |
+        echo "${ACR_PASSWORD}" | docker login "${ACR_URL}" \
+          -u "${ACR_USERNAME}" \
+          --password-stdin
+
+    - name: Backup current image tag
+      continue-on-error: true
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image_name }}
+        IMAGE_TAG: ${{ inputs.image_tag }}
+        ACR_URL: ${{ inputs.acr_url }}
+      run: |
+        echo "Backing up ${IMAGE_NAME}:${IMAGE_TAG} to ${IMAGE_NAME}:${IMAGE_TAG}-backup"
+        docker pull "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}" && \
+        docker tag \
+          "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}" \
+          "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}-backup" && \
+        docker push \
+          "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}-backup"
+
+    - name: Push Image to ACR
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image_name }}
+        SOURCE_TAG: ${{ inputs.source_tag }}
+        IMAGE_TAG: ${{ inputs.image_tag }}
+        ACR_URL: ${{ inputs.acr_url }}
+      run: |
+        docker tag \
+          "${IMAGE_NAME}:${SOURCE_TAG}" \
+          "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}"
+        docker push \
+          "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}"

--- a/.github/actions/build-scan-push-image/action.yml
+++ b/.github/actions/build-scan-push-image/action.yml
@@ -42,6 +42,14 @@ inputs:
     description: Seconds to wait between Docker build attempts.
     required: false
     default: '15'
+  acr_attempts:
+    description: Number of attempts for ACR login, pull, and push operations.
+    required: false
+    default: '5'
+  acr_retry_seconds:
+    description: Base seconds to wait between ACR retry attempts.
+    required: false
+    default: '20'
   trivy_severity:
     description: Comma-separated list of severities to check.
     required: false
@@ -128,10 +136,26 @@ runs:
         ACR_URL: ${{ inputs.acr_url }}
         ACR_USERNAME: ${{ inputs.acr_username }}
         ACR_PASSWORD: ${{ inputs.acr_password }}
+        ACR_ATTEMPTS: ${{ inputs.acr_attempts }}
+        ACR_RETRY_SECONDS: ${{ inputs.acr_retry_seconds }}
       run: |
-        echo "${ACR_PASSWORD}" | docker login "${ACR_URL}" \
-          -u "${ACR_USERNAME}" \
-          --password-stdin
+        for attempt in $(seq 1 "${ACR_ATTEMPTS}"); do
+          if echo "${ACR_PASSWORD}" | docker login "${ACR_URL}" \
+            -u "${ACR_USERNAME}" \
+            --password-stdin; then
+            exit 0
+          else
+            status=$?
+          fi
+
+          if [ "$attempt" -eq "${ACR_ATTEMPTS}" ]; then
+            exit "$status"
+          fi
+
+          wait_seconds=$((ACR_RETRY_SECONDS * attempt))
+          echo "ACR login failed on attempt ${attempt}/${ACR_ATTEMPTS}; retrying in ${wait_seconds} seconds..."
+          sleep "${wait_seconds}"
+        done
 
     - name: Backup current image tag
       continue-on-error: true
@@ -140,14 +164,30 @@ runs:
         IMAGE_NAME: ${{ inputs.image_name }}
         IMAGE_TAG: ${{ inputs.image_tag }}
         ACR_URL: ${{ inputs.acr_url }}
+        ACR_ATTEMPTS: ${{ inputs.acr_attempts }}
+        ACR_RETRY_SECONDS: ${{ inputs.acr_retry_seconds }}
       run: |
-        echo "Backing up ${IMAGE_NAME}:${IMAGE_TAG} to ${IMAGE_NAME}:${IMAGE_TAG}-backup"
-        docker pull "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}" && \
-        docker tag \
-          "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}" \
-          "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}-backup" && \
-        docker push \
-          "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}-backup"
+        for attempt in $(seq 1 "${ACR_ATTEMPTS}"); do
+          echo "Backing up ${IMAGE_NAME}:${IMAGE_TAG} to ${IMAGE_NAME}:${IMAGE_TAG}-backup"
+          if docker pull "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}" && \
+            docker tag \
+              "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}" \
+              "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}-backup" && \
+            docker push \
+              "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}-backup"; then
+            exit 0
+          else
+            status=$?
+          fi
+
+          if [ "$attempt" -eq "${ACR_ATTEMPTS}" ]; then
+            exit "$status"
+          fi
+
+          wait_seconds=$((ACR_RETRY_SECONDS * attempt))
+          echo "ACR backup failed on attempt ${attempt}/${ACR_ATTEMPTS}; retrying in ${wait_seconds} seconds..."
+          sleep "${wait_seconds}"
+        done
 
     - name: Push Image to ACR
       shell: bash
@@ -156,9 +196,25 @@ runs:
         SOURCE_TAG: ${{ inputs.source_tag }}
         IMAGE_TAG: ${{ inputs.image_tag }}
         ACR_URL: ${{ inputs.acr_url }}
+        ACR_ATTEMPTS: ${{ inputs.acr_attempts }}
+        ACR_RETRY_SECONDS: ${{ inputs.acr_retry_seconds }}
       run: |
         docker tag \
           "${IMAGE_NAME}:${SOURCE_TAG}" \
           "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}"
-        docker push \
-          "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}"
+
+        for attempt in $(seq 1 "${ACR_ATTEMPTS}"); do
+          if docker push "${ACR_URL}/${IMAGE_NAME}:${IMAGE_TAG}"; then
+            exit 0
+          else
+            status=$?
+          fi
+
+          if [ "$attempt" -eq "${ACR_ATTEMPTS}" ]; then
+            exit "$status"
+          fi
+
+          wait_seconds=$((ACR_RETRY_SECONDS * attempt))
+          echo "ACR push failed on attempt ${attempt}/${ACR_ATTEMPTS}; retrying in ${wait_seconds} seconds..."
+          sleep "${wait_seconds}"
+        done

--- a/.github/actions/build-scan-push-image/action.yml
+++ b/.github/actions/build-scan-push-image/action.yml
@@ -34,6 +34,14 @@ inputs:
     description: Optional Docker build argument value.
     required: false
     default: ''
+  build_attempts:
+    description: Number of Docker build attempts.
+    required: false
+    default: '3'
+  retry_seconds:
+    description: Seconds to wait between Docker build attempts.
+    required: false
+    default: '15'
   trivy_severity:
     description: Comma-separated list of severities to check.
     required: false
@@ -63,17 +71,32 @@ runs:
         SOURCE_TAG: ${{ inputs.source_tag }}
         BUILD_ARG_NAME: ${{ inputs.build_arg_name }}
         BUILD_ARG_VALUE: ${{ inputs.build_arg_value }}
+        BUILD_ATTEMPTS: ${{ inputs.build_attempts }}
+        RETRY_SECONDS: ${{ inputs.retry_seconds }}
       run: |
         BUILD_ARGS=()
         if [ -n "${BUILD_ARG_NAME}" ]; then
           BUILD_ARGS+=(--build-arg "${BUILD_ARG_NAME}=${BUILD_ARG_VALUE}")
         fi
 
-        docker build \
-          -f "${DOCKERFILE}" \
-          -t "${IMAGE_NAME}:${SOURCE_TAG}" \
-          "${BUILD_ARGS[@]}" \
-          "${CONTEXT}"
+        for attempt in $(seq 1 "${BUILD_ATTEMPTS}"); do
+          if docker build \
+            -f "${DOCKERFILE}" \
+            -t "${IMAGE_NAME}:${SOURCE_TAG}" \
+            "${BUILD_ARGS[@]}" \
+            "${CONTEXT}"; then
+            exit 0
+          else
+            status=$?
+          fi
+
+          if [ "$attempt" -eq "${BUILD_ATTEMPTS}" ]; then
+            exit "$status"
+          fi
+
+          echo "Docker build failed on attempt ${attempt}/${BUILD_ATTEMPTS}; retrying in ${RETRY_SECONDS} seconds..."
+          sleep "${RETRY_SECONDS}"
+        done
 
     - name: Cache Trivy DB
       uses: actions/cache@v4
@@ -95,7 +118,7 @@ runs:
 
     - name: Upload Trivy Results to GitHub Security
       uses: github/codeql-action/upload-sarif@v3
-      if: always()
+      if: ${{ hashFiles('trivy-results.sarif') != '' }}
       with:
         sarif_file: trivy-results.sarif
 

--- a/.github/actions/deploy-openshift-workload/action.yml
+++ b/.github/actions/deploy-openshift-workload/action.yml
@@ -1,0 +1,122 @@
+name: Deploy OpenShift Workload
+description: Apply optional Kustomize manifests and restart/verify an OpenShift workload.
+
+inputs:
+  namespace:
+    description: OpenShift namespace.
+    required: true
+  resource_type:
+    description: Kubernetes resource kind, such as deployment or statefulset.
+    required: false
+    default: deployment
+  resource_name:
+    description: Workload resource name.
+    required: true
+  rollout_timeout:
+    description: Rollout status timeout.
+    required: false
+    default: 300s
+  continue_on_error_verify:
+    description: Continue when rollout verification fails.
+    required: false
+    default: 'false'
+  kustomize_path:
+    description: Optional kustomize path to apply before rollout.
+    required: false
+    default: ''
+  statefulset_name:
+    description: Optional StatefulSet to update and roll out.
+    required: false
+    default: ''
+  statefulset_container:
+    description: Optional StatefulSet container name. Defaults to statefulset_name.
+    required: false
+    default: ''
+  statefulset_image:
+    description: Image to set on the optional StatefulSet.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Apply Kustomize
+      if: ${{ inputs.kustomize_path != '' }}
+      shell: bash
+      env:
+        KUSTOMIZE_PATH: ${{ inputs.kustomize_path }}
+        OPENSHIFT_NAMESPACE: ${{ inputs.namespace }}
+      run: oc apply -k "${KUSTOMIZE_PATH}" -n "${OPENSHIFT_NAMESPACE}"
+
+    - name: Rollout Restart
+      shell: bash
+      env:
+        RESOURCE_TYPE: ${{ inputs.resource_type }}
+        RESOURCE_NAME: ${{ inputs.resource_name }}
+        OPENSHIFT_NAMESPACE: ${{ inputs.namespace }}
+      run: |
+        oc rollout restart "${RESOURCE_TYPE}/${RESOURCE_NAME}" \
+          -n "${OPENSHIFT_NAMESPACE}"
+
+    - name: Verify Rollout
+      shell: bash
+      env:
+        RESOURCE_TYPE: ${{ inputs.resource_type }}
+        RESOURCE_NAME: ${{ inputs.resource_name }}
+        OPENSHIFT_NAMESPACE: ${{ inputs.namespace }}
+        ROLLOUT_TIMEOUT: ${{ inputs.rollout_timeout }}
+        CONTINUE_ON_ERROR_VERIFY: ${{ inputs.continue_on_error_verify }}
+      run: |
+        set +e
+        oc rollout status "${RESOURCE_TYPE}/${RESOURCE_NAME}" \
+          -n "${OPENSHIFT_NAMESPACE}" \
+          --timeout="${ROLLOUT_TIMEOUT}"
+        STATUS=$?
+        set -e
+
+        if [ "$STATUS" -ne 0 ] && [ "$CONTINUE_ON_ERROR_VERIFY" != "true" ]; then
+          exit "$STATUS"
+        fi
+
+        if [ "$STATUS" -ne 0 ]; then
+          echo "Rollout verification failed, but continue_on_error_verify=true."
+        fi
+
+    - name: Update StatefulSet Image
+      if: ${{ inputs.statefulset_name != '' && inputs.statefulset_image != '' }}
+      continue-on-error: true
+      shell: bash
+      env:
+        STATEFULSET_NAME: ${{ inputs.statefulset_name }}
+        STATEFULSET_CONTAINER: ${{ inputs.statefulset_container }}
+        STATEFULSET_IMAGE: ${{ inputs.statefulset_image }}
+        OPENSHIFT_NAMESPACE: ${{ inputs.namespace }}
+      run: |
+        CONTAINER="${STATEFULSET_CONTAINER:-$STATEFULSET_NAME}"
+        oc set image "statefulset/${STATEFULSET_NAME}" \
+          "${CONTAINER}=${STATEFULSET_IMAGE}" \
+          -n "${OPENSHIFT_NAMESPACE}"
+
+    - name: Rollout StatefulSet
+      if: ${{ inputs.statefulset_name != '' }}
+      continue-on-error: true
+      shell: bash
+      env:
+        STATEFULSET_NAME: ${{ inputs.statefulset_name }}
+        OPENSHIFT_NAMESPACE: ${{ inputs.namespace }}
+      run: |
+        oc rollout restart "statefulset/${STATEFULSET_NAME}" \
+          -n "${OPENSHIFT_NAMESPACE}"
+
+    - name: Verify StatefulSet Rollout
+      if: ${{ inputs.statefulset_name != '' }}
+      continue-on-error: true
+      shell: bash
+      env:
+        STATEFULSET_NAME: ${{ inputs.statefulset_name }}
+        OPENSHIFT_NAMESPACE: ${{ inputs.namespace }}
+        ROLLOUT_TIMEOUT: ${{ inputs.rollout_timeout }}
+      run: |
+        oc rollout status "statefulset/${STATEFULSET_NAME}" \
+          -n "${OPENSHIFT_NAMESPACE}" \
+          --timeout="${ROLLOUT_TIMEOUT}"

--- a/.github/actions/install-oc/action.yml
+++ b/.github/actions/install-oc/action.yml
@@ -1,0 +1,34 @@
+name: Install OpenShift CLI
+description: Install a pinned OpenShift CLI without using the Node-based Red Hat installer.
+
+inputs:
+  version:
+    description: OpenShift client version to install.
+    required: false
+    default: '4.22.0'
+
+runs:
+  using: composite
+  steps:
+    - name: Install oc
+      shell: bash
+      env:
+        OC_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        INSTALL_DIR="${RUNNER_TEMP}/oc-${OC_VERSION}"
+        ARCHIVE="${RUNNER_TEMP}/openshift-client-linux-${OC_VERSION}.tar.gz"
+        URL="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux-${OC_VERSION}.tar.gz"
+
+        mkdir -p "${INSTALL_DIR}"
+        curl --fail --location --show-error --silent \
+          --retry 3 --retry-delay 5 --retry-all-errors \
+          "${URL}" \
+          --output "${ARCHIVE}"
+
+        tar -xzf "${ARCHIVE}" -C "${INSTALL_DIR}" oc
+        chmod +x "${INSTALL_DIR}/oc"
+        echo "${INSTALL_DIR}" >> "${GITHUB_PATH}"
+
+        "${INSTALL_DIR}/oc" version --client=true

--- a/.github/actions/openshift-login/action.yml
+++ b/.github/actions/openshift-login/action.yml
@@ -1,0 +1,43 @@
+name: OpenShift Login
+description: Log in to OpenShift with retry support.
+
+inputs:
+  token:
+    description: OpenShift token.
+    required: true
+  server:
+    description: OpenShift API server URL.
+    required: true
+  attempts:
+    description: Number of login attempts.
+    required: false
+    default: '3'
+  retry_seconds:
+    description: Seconds to wait between attempts.
+    required: false
+    default: '10'
+
+runs:
+  using: composite
+  steps:
+    - name: Login to OpenShift
+      shell: bash
+      env:
+        OPENSHIFT_TOKEN: ${{ inputs.token }}
+        OPENSHIFT_SERVER: ${{ inputs.server }}
+        LOGIN_ATTEMPTS: ${{ inputs.attempts }}
+        RETRY_SECONDS: ${{ inputs.retry_seconds }}
+      run: |
+        for attempt in $(seq 1 "${LOGIN_ATTEMPTS}"); do
+          if oc login --token="${OPENSHIFT_TOKEN}" --server="${OPENSHIFT_SERVER}"; then
+            exit 0
+          fi
+
+          if [ "$attempt" -eq "${LOGIN_ATTEMPTS}" ]; then
+            echo "OpenShift login failed after ${attempt} attempts." >&2
+            exit 1
+          fi
+
+          echo "OpenShift login failed on attempt ${attempt}/${LOGIN_ATTEMPTS}; retrying in ${RETRY_SECONDS} seconds..."
+          sleep "${RETRY_SECONDS}"
+        done

--- a/.github/actions/openshift-login/action.yml
+++ b/.github/actions/openshift-login/action.yml
@@ -11,11 +11,11 @@ inputs:
   attempts:
     description: Number of login attempts.
     required: false
-    default: '3'
+    default: '5'
   retry_seconds:
-    description: Seconds to wait between attempts.
+    description: Base seconds to wait between attempts. The wait increases after each failed attempt.
     required: false
-    default: '10'
+    default: '20'
 
 runs:
   using: composite
@@ -38,6 +38,7 @@ runs:
             exit 1
           fi
 
-          echo "OpenShift login failed on attempt ${attempt}/${LOGIN_ATTEMPTS}; retrying in ${RETRY_SECONDS} seconds..."
-          sleep "${RETRY_SECONDS}"
+          WAIT_SECONDS=$((RETRY_SECONDS * attempt))
+          echo "OpenShift login failed on attempt ${attempt}/${LOGIN_ATTEMPTS}; retrying in ${WAIT_SECONDS} seconds..."
+          sleep "${WAIT_SECONDS}"
         done

--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -26,7 +26,7 @@ runs:
   using: 'composite'
   steps:
     - name: Cache Trivy DB
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/trivy
         key: trivy-db-${{ github.run_id }}
@@ -44,7 +44,7 @@ runs:
         trivyignores: ${{ inputs.trivyignores }}
 
     - name: Upload Trivy Results to GitHub Security
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       if: always()
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/actions/validate-deploy-request/action.yml
+++ b/.github/actions/validate-deploy-request/action.yml
@@ -1,0 +1,53 @@
+name: Validate Deploy Request
+description: Validate deploy-all environment, scope, and branch safety.
+
+inputs:
+  environment:
+    required: true
+  deploy_scope:
+    required: true
+  allow_dev_branch_override:
+    required: false
+    default: 'false'
+  event_name:
+    required: true
+  ref:
+    required: true
+  ref_name:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Validate inputs and branch
+      shell: bash
+      run: |
+        case "${{ inputs.environment }}" in
+          dev|test) ;;
+          *)
+            echo "::error::Unsupported environment: ${{ inputs.environment }}"
+            exit 1
+            ;;
+        esac
+
+        case "${{ inputs.deploy_scope }}" in
+          all|changed) ;;
+          *)
+            echo "::error::Unsupported deploy_scope: ${{ inputs.deploy_scope }}"
+            exit 1
+            ;;
+        esac
+
+        if [ "${{ inputs.environment }}" = "dev" ] && [ "${{ inputs.ref }}" != "refs/heads/dev" ]; then
+          if [ "${{ inputs.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.allow_dev_branch_override }}" = "true" ]; then
+            echo "Manual dev deploy branch override enabled for ${{ inputs.ref_name }}."
+          else
+            echo "::error::Dev deploy must run from refs/heads/dev unless allow_dev_branch_override is true on a manual run."
+            exit 1
+          fi
+        fi
+
+        if [ "${{ inputs.environment }}" = "test" ] && [ "${{ inputs.ref }}" != "refs/heads/master" ]; then
+          echo "::error::Test deploy must run from refs/heads/master."
+          exit 1
+        fi

--- a/.github/workflows/_reusable-db-migration-cd.yml
+++ b/.github/workflows/_reusable-db-migration-cd.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build Docker Image
         working-directory: ./libs/net
@@ -51,9 +51,9 @@ jobs:
           image-ref: '${{ env.IMAGE_NAME }}:${{ github.sha }}'
 
       - name: Install oc CLI
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          oc: latest
+        # Keep this local until redhat-actions/openshift-tools-installer has a
+        # Node 24 compatible release without cache/archive selection warnings.
+        uses: ./.github/actions/install-oc
 
       - name: Login to OpenShift
         uses: ./.github/actions/openshift-login

--- a/.github/workflows/_reusable-db-migration-cd.yml
+++ b/.github/workflows/_reusable-db-migration-cd.yml
@@ -56,10 +56,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Login to ACR
         run: |

--- a/.github/workflows/_reusable-dotnet-cicd.yml
+++ b/.github/workflows/_reusable-dotnet-cicd.yml
@@ -139,10 +139,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Login to ACR
         run: |
@@ -292,10 +292,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Login to ACR
         run: |

--- a/.github/workflows/_reusable-dotnet-cicd.yml
+++ b/.github/workflows/_reusable-dotnet-cicd.yml
@@ -121,17 +121,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build Docker Image
-        run: |
-          docker build \
-            -f ${{ inputs.dockerfile }} \
-            -t ${{ inputs.image_name }}:${{ github.sha }} \
-            .
-
-      - name: Trivy Container Scan
-        uses: ./.github/actions/trivy-scan
+      - name: Build, scan, and push image
+        uses: ./.github/actions/build-scan-push-image
         with:
-          image-ref: '${{ inputs.image_name }}:${{ github.sha }}'
+          image_name: ${{ inputs.image_name }}
+          dockerfile: ${{ inputs.dockerfile }}
+          context: .
+          source_tag: ${{ github.sha }}
+          image_tag: ${{ env.IMAGE_TAG }}
+          acr_url: ${{ env.ACR_URL }}
+          acr_username: ${{ secrets.ACR_USERNAME }}
+          acr_password: ${{ secrets.ACR_PASSWORD }}
 
       - name: Install oc CLI
         uses: redhat-actions/openshift-tools-installer@v1
@@ -144,68 +144,17 @@ jobs:
           token: ${{ secrets.OPENSHIFT_TOKEN }}
           server: ${{ env.OPENSHIFT_SERVER }}
 
-      - name: Login to ACR
-        run: |
-          echo "${{ secrets.ACR_PASSWORD }}" | docker login ${{ env.ACR_URL }} \
-            -u ${{ secrets.ACR_USERNAME }} \
-            --password-stdin
-
-      - name: Backup current image tag
-        continue-on-error: true
-        run: |
-          echo "Backing up ${{ inputs.image_name }}:${{ env.IMAGE_TAG }} → ${{ inputs.image_name }}:${{ env.IMAGE_TAG }}-backup"
-          docker pull ${{ env.ACR_URL }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }} && \
-          docker tag \
-            ${{ env.ACR_URL }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }} \
-            ${{ env.ACR_URL }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}-backup && \
-          docker push \
-            ${{ env.ACR_URL }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}-backup
-
-      - name: Push Image to ACR
-        run: |
-          docker tag \
-            ${{ inputs.image_name }}:${{ github.sha }} \
-            ${{ env.ACR_URL }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}
-          docker push \
-            ${{ env.ACR_URL }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}
-
-      - name: Deploy via Kustomize
-        run: oc apply -k ${{ inputs.kustomize_dev_path }} -n ${{ env.OPENSHIFT_NAMESPACE }}
-
-      - name: Rollout Restart
-        run: |
-          oc rollout restart ${{ inputs.resource_type }}/${{ inputs.deployment_name }} \
-            -n ${{ env.OPENSHIFT_NAMESPACE }}
-
-      - name: Verify Rollout
-        continue-on-error: ${{ inputs.continue_on_error_verify }}
-        run: |
-          oc rollout status ${{ inputs.resource_type }}/${{ inputs.deployment_name }} \
-            -n ${{ env.OPENSHIFT_NAMESPACE }} \
-            --timeout=${{ inputs.rollout_timeout }}
-
-      - name: Update StatefulSet Image
-        if: ${{ inputs.statefulset_name != '' }}
-        continue-on-error: true
-        run: |
-          oc set image statefulset/${{ inputs.statefulset_name }} \
-            ${{ inputs.statefulset_name }}=${{ env.ACR_URL }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }} \
-            -n ${{ env.OPENSHIFT_NAMESPACE }}
-
-      - name: Rollout StatefulSet
-        if: ${{ inputs.statefulset_name != '' }}
-        continue-on-error: true
-        run: |
-          oc rollout restart statefulset/${{ inputs.statefulset_name }} \
-            -n ${{ env.OPENSHIFT_NAMESPACE }}
-
-      - name: Verify StatefulSet Rollout
-        if: ${{ inputs.statefulset_name != '' }}
-        continue-on-error: true
-        run: |
-          oc rollout status statefulset/${{ inputs.statefulset_name }} \
-            -n ${{ env.OPENSHIFT_NAMESPACE }} \
-            --timeout=${{ inputs.rollout_timeout }}
+      - name: Deploy OpenShift workload
+        uses: ./.github/actions/deploy-openshift-workload
+        with:
+          namespace: ${{ env.OPENSHIFT_NAMESPACE }}
+          resource_type: ${{ inputs.resource_type }}
+          resource_name: ${{ inputs.deployment_name }}
+          rollout_timeout: ${{ inputs.rollout_timeout }}
+          continue_on_error_verify: ${{ inputs.continue_on_error_verify && 'true' || 'false' }}
+          kustomize_path: ${{ inputs.kustomize_dev_path }}
+          statefulset_name: ${{ inputs.statefulset_name }}
+          statefulset_image: ${{ env.ACR_URL }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}
 
       - name: Deployment Report
         if: always()
@@ -274,17 +223,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build Docker Image
-        run: |
-          docker build \
-            -f ${{ inputs.dockerfile }} \
-            -t ${{ inputs.image_name }}:${{ github.sha }} \
-            .
-
-      - name: Trivy Container Scan
-        uses: ./.github/actions/trivy-scan
+      - name: Build, scan, and push image
+        uses: ./.github/actions/build-scan-push-image
         with:
-          image-ref: '${{ inputs.image_name }}:${{ github.sha }}'
+          image_name: ${{ inputs.image_name }}
+          dockerfile: ${{ inputs.dockerfile }}
+          context: .
+          source_tag: ${{ github.sha }}
+          image_tag: ${{ env.IMAGE_TAG }}
+          acr_url: ${{ env.ACR_URL }}
+          acr_username: ${{ secrets.ACR_USERNAME }}
+          acr_password: ${{ secrets.ACR_PASSWORD }}
 
       - name: Install oc CLI
         uses: redhat-actions/openshift-tools-installer@v1
@@ -297,68 +246,17 @@ jobs:
           token: ${{ secrets.OPENSHIFT_TOKEN }}
           server: ${{ env.OPENSHIFT_SERVER }}
 
-      - name: Login to ACR
-        run: |
-          echo "${{ secrets.ACR_PASSWORD }}" | docker login ${{ env.ACR_URL }} \
-            -u ${{ secrets.ACR_USERNAME }} \
-            --password-stdin
-
-      - name: Backup current image tag
-        continue-on-error: true
-        run: |
-          echo "Backing up ${{ inputs.image_name }}:${{ env.IMAGE_TAG }} → ${{ inputs.image_name }}:${{ env.IMAGE_TAG }}-backup"
-          docker pull ${{ env.ACR_URL }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }} && \
-          docker tag \
-            ${{ env.ACR_URL }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }} \
-            ${{ env.ACR_URL }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}-backup && \
-          docker push \
-            ${{ env.ACR_URL }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}-backup
-
-      - name: Push Image to ACR
-        run: |
-          docker tag \
-            ${{ inputs.image_name }}:${{ github.sha }} \
-            ${{ env.ACR_URL }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}
-          docker push \
-            ${{ env.ACR_URL }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}
-
-      - name: Deploy via Kustomize
-        run: oc apply -k ${{ inputs.kustomize_test_path }} -n ${{ env.OPENSHIFT_NAMESPACE }}
-
-      - name: Rollout Restart
-        run: |
-          oc rollout restart ${{ inputs.resource_type }}/${{ inputs.deployment_name }} \
-            -n ${{ env.OPENSHIFT_NAMESPACE }}
-
-      - name: Verify Rollout
-        continue-on-error: ${{ inputs.continue_on_error_verify }}
-        run: |
-          oc rollout status ${{ inputs.resource_type }}/${{ inputs.deployment_name }} \
-            -n ${{ env.OPENSHIFT_NAMESPACE }} \
-            --timeout=${{ inputs.rollout_timeout }}
-
-      - name: Update StatefulSet Image
-        if: ${{ inputs.statefulset_name != '' }}
-        continue-on-error: true
-        run: |
-          oc set image statefulset/${{ inputs.statefulset_name }} \
-            ${{ inputs.statefulset_name }}=${{ env.ACR_URL }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }} \
-            -n ${{ env.OPENSHIFT_NAMESPACE }}
-
-      - name: Rollout StatefulSet
-        if: ${{ inputs.statefulset_name != '' }}
-        continue-on-error: true
-        run: |
-          oc rollout restart statefulset/${{ inputs.statefulset_name }} \
-            -n ${{ env.OPENSHIFT_NAMESPACE }}
-
-      - name: Verify StatefulSet Rollout
-        if: ${{ inputs.statefulset_name != '' }}
-        continue-on-error: true
-        run: |
-          oc rollout status statefulset/${{ inputs.statefulset_name }} \
-            -n ${{ env.OPENSHIFT_NAMESPACE }} \
-            --timeout=${{ inputs.rollout_timeout }}
+      - name: Deploy OpenShift workload
+        uses: ./.github/actions/deploy-openshift-workload
+        with:
+          namespace: ${{ env.OPENSHIFT_NAMESPACE }}
+          resource_type: ${{ inputs.resource_type }}
+          resource_name: ${{ inputs.deployment_name }}
+          rollout_timeout: ${{ inputs.rollout_timeout }}
+          continue_on_error_verify: ${{ inputs.continue_on_error_verify && 'true' || 'false' }}
+          kustomize_path: ${{ inputs.kustomize_test_path }}
+          statefulset_name: ${{ inputs.statefulset_name }}
+          statefulset_image: ${{ env.ACR_URL }}/${{ inputs.image_name }}:${{ env.IMAGE_TAG }}
 
       - name: Deployment Report
         if: always()

--- a/.github/workflows/_reusable-dotnet-cicd.yml
+++ b/.github/workflows/_reusable-dotnet-cicd.yml
@@ -67,14 +67,6 @@ on:
         required: true
       ACR_PASSWORD:
         required: true
-      CHES_CLIENT_ID:
-        required: false
-      CHES_CLIENT_SECRET:
-        required: false
-      CHES_SENDER_EMAIL:
-        required: false
-      CHES_NOTIFY_EMAIL:
-        required: false
 
 permissions:
   contents: read
@@ -181,36 +173,6 @@ jobs:
           echo "--- recent logs ---"
           sleep 60
           oc logs $POD -n ${{ env.OPENSHIFT_NAMESPACE }} --tail=20
-
-      - name: Notify Deployment Result
-        if: always()
-        continue-on-error: true
-        run: |
-          TOKEN=$(curl -s -X POST \
-            "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token" \
-            -H "Content-Type: application/x-www-form-urlencoded" \
-            -d "grant_type=client_credentials" \
-            -d "client_id=${{ secrets.CHES_CLIENT_ID }}" \
-            -d "client_secret=${{ secrets.CHES_CLIENT_SECRET }}" \
-            | jq -r '.access_token')
-
-          if [ "${{ job.status }}" = "success" ]; then
-            SUBJECT="Deployment Successful - ${{ inputs.image_name }} to ${{ env.OPENSHIFT_NAMESPACE }}"
-          else
-            SUBJECT="Deployment FAILED - ${{ inputs.image_name }} to ${{ env.OPENSHIFT_NAMESPACE }}"
-          fi
-
-          curl -s -X POST "https://ches-dev.api.gov.bc.ca/api/v1/email" \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"from\": \"${{ secrets.CHES_SENDER_EMAIL }}\",
-              \"to\": [\"${{ secrets.CHES_NOTIFY_EMAIL }}\"],
-              \"subject\": \"$SUBJECT\",
-              \"bodyType\": \"text\",
-              \"body\": \"SHA: ${{ github.sha }}\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"
-            }"
-
   cd-test:
     name: CD — Deploy to Test
     runs-on: ubuntu-latest
@@ -283,32 +245,3 @@ jobs:
           echo "--- recent logs ---"
           sleep 60
           oc logs $POD -n ${{ env.OPENSHIFT_NAMESPACE }} --tail=20
-
-      - name: Notify Deployment Result
-        if: always()
-        continue-on-error: true
-        run: |
-          TOKEN=$(curl -s -X POST \
-            "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token" \
-            -H "Content-Type: application/x-www-form-urlencoded" \
-            -d "grant_type=client_credentials" \
-            -d "client_id=${{ secrets.CHES_CLIENT_ID }}" \
-            -d "client_secret=${{ secrets.CHES_CLIENT_SECRET }}" \
-            | jq -r '.access_token')
-
-          if [ "${{ job.status }}" = "success" ]; then
-            SUBJECT="Deployment Successful - ${{ inputs.image_name }} to ${{ env.OPENSHIFT_NAMESPACE }}"
-          else
-            SUBJECT="Deployment FAILED - ${{ inputs.image_name }} to ${{ env.OPENSHIFT_NAMESPACE }}"
-          fi
-
-          curl -s -X POST "https://ches-dev.api.gov.bc.ca/api/v1/email" \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"from\": \"${{ secrets.CHES_SENDER_EMAIL }}\",
-              \"to\": [\"${{ secrets.CHES_NOTIFY_EMAIL }}\"],
-              \"subject\": \"$SUBJECT\",
-              \"bodyType\": \"text\",
-              \"body\": \"SHA: ${{ github.sha }}\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"
-            }"

--- a/.github/workflows/_reusable-elastic-migration-cd.yml
+++ b/.github/workflows/_reusable-elastic-migration-cd.yml
@@ -65,10 +65,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Login to ACR
         run: |

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -1,4 +1,5 @@
 name: Auto Deploy
+run-name: Auto Deploy to ${{ fromJSON('{"refs/heads/dev":"dev","refs/heads/master":"test"}')[github.ref] }} from ${{ github.ref_name }}
 
 on:
   push:
@@ -19,9 +20,10 @@ permissions:
 
 jobs:
   deploy:
+    if: ${{ contains(fromJSON('["refs/heads/dev", "refs/heads/master"]'), github.ref) }}
     uses: ./.github/workflows/deploy-all.yml
     with:
-      environment: ${{ github.ref == 'refs/heads/dev' && 'dev' || 'test' }}
+      environment: ${{ fromJSON('{"refs/heads/dev":"dev","refs/heads/master":"test"}')[github.ref] }}
       skip_db_migration: false
       deploy_scope: changed
     secrets:

--- a/.github/workflows/backup-cronjob-cicd.yml
+++ b/.github/workflows/backup-cronjob-cicd.yml
@@ -56,10 +56,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Deploy CronJob via Kustomize
         run: oc apply -k openshift/kustomize/cron/backup/overlays/dev -n 9b301c-dev
@@ -82,10 +82,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Deploy CronJob via Kustomize
         run: oc apply -k openshift/kustomize/cron/backup/overlays/test -n 9b301c-test

--- a/.github/workflows/charts-api-cicd.yml
+++ b/.github/workflows/charts-api-cicd.yml
@@ -79,10 +79,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Login to ACR
         run: |
@@ -151,10 +151,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Login to ACR
         run: |

--- a/.github/workflows/ches-retry-service-cicd.yml
+++ b/.github/workflows/ches-retry-service-cicd.yml
@@ -44,7 +44,3 @@ jobs:
       OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
       ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
       ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
-      CHES_CLIENT_ID: ${{ secrets.CHES_CLIENT_ID }}
-      CHES_CLIENT_SECRET: ${{ secrets.CHES_CLIENT_SECRET }}
-      CHES_SENDER_EMAIL: ${{ secrets.CHES_SENDER_EMAIL }}
-      CHES_NOTIFY_EMAIL: ${{ secrets.CHES_NOTIFY_EMAIL }}

--- a/.github/workflows/corenlp-service-cicd.yml
+++ b/.github/workflows/corenlp-service-cicd.yml
@@ -72,10 +72,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Login to ACR
         run: |
@@ -144,10 +144,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Login to ACR
         run: |

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -233,7 +233,7 @@ jobs:
           namespace: ${{ env.OPENSHIFT_NAMESPACE }}
           resource_type: deployment
           resource_name: api-services
-          rollout_timeout: 600s
+          rollout_timeout: 1200s
           statefulset_name: api
           statefulset_container: api
           statefulset_image: ${{ env.ACR_URL }}/api:${{ env.IMAGE_TAG }}

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -172,9 +172,13 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install oc CLI
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          oc: latest
+        # Previously used redhat-actions/openshift-tools-installer@v1:
+        #   uses: redhat-actions/openshift-tools-installer@v1
+        #   with:
+        #     oc: latest
+        # Keep the local installer while v1 emits Node.js 20 and cache race warnings.
+        # If a Node 24-compatible v2 becomes available, this can be switched back.
+        uses: ./.github/actions/install-oc
 
       - name: Login to OpenShift
         uses: ./.github/actions/openshift-login
@@ -224,9 +228,13 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install oc CLI
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          oc: latest
+        # Previously used redhat-actions/openshift-tools-installer@v1:
+        #   uses: redhat-actions/openshift-tools-installer@v1
+        #   with:
+        #     oc: latest
+        # Keep the local installer while v1 emits Node.js 20 and cache race warnings.
+        # If a Node 24-compatible v2 becomes available, this can be switched back.
+        uses: ./.github/actions/install-oc
 
       - name: Login to OpenShift
         uses: ./.github/actions/openshift-login
@@ -261,9 +269,13 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install oc CLI
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          oc: latest
+        # Previously used redhat-actions/openshift-tools-installer@v1:
+        #   uses: redhat-actions/openshift-tools-installer@v1
+        #   with:
+        #     oc: latest
+        # Keep the local installer while v1 emits Node.js 20 and cache race warnings.
+        # If a Node 24-compatible v2 becomes available, this can be switched back.
+        uses: ./.github/actions/install-oc
 
       - name: Login to OpenShift
         uses: ./.github/actions/openshift-login

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -123,46 +123,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build Docker Image
-        run: |
-          BUILD_ARGS=""
-          if [ -n "${{ matrix.build_arg_name }}" ]; then
-            BUILD_ARGS="--build-arg ${{ matrix.build_arg_name }}=${{ github.sha }}"
-          fi
-          docker build \
-            -f ${{ matrix.dockerfile }} \
-            -t ${{ matrix.image }}:${{ github.sha }} \
-            $BUILD_ARGS \
-            ${{ matrix.context }}
-
-      - name: Trivy Container Scan
-        uses: ./.github/actions/trivy-scan
+      - name: Build, scan, and push image
+        uses: ./.github/actions/build-scan-push-image
         with:
-          image-ref: '${{ matrix.image }}:${{ github.sha }}'
-
-      - name: Login to ACR
-        run: |
-          echo "${{ secrets.ACR_PASSWORD }}" | docker login ${{ env.ACR_URL }} \
-            -u ${{ secrets.ACR_USERNAME }} \
-            --password-stdin
-
-      - name: Backup current image tag
-        continue-on-error: true
-        run: |
-          docker pull ${{ env.ACR_URL }}/${{ matrix.image }}:${{ env.IMAGE_TAG }} && \
-          docker tag \
-            ${{ env.ACR_URL }}/${{ matrix.image }}:${{ env.IMAGE_TAG }} \
-            ${{ env.ACR_URL }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}-backup && \
-          docker push \
-            ${{ env.ACR_URL }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}-backup
-
-      - name: Push Image to ACR
-        run: |
-          docker tag \
-            ${{ matrix.image }}:${{ github.sha }} \
-            ${{ env.ACR_URL }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}
-          docker push \
-            ${{ env.ACR_URL }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}
+          image_name: ${{ matrix.image }}
+          dockerfile: ${{ matrix.dockerfile }}
+          context: ${{ matrix.context }}
+          source_tag: ${{ github.sha }}
+          image_tag: ${{ env.IMAGE_TAG }}
+          acr_url: ${{ env.ACR_URL }}
+          acr_username: ${{ secrets.ACR_USERNAME }}
+          acr_password: ${{ secrets.ACR_PASSWORD }}
+          build_arg_name: ${{ matrix.build_arg_name }}
+          build_arg_value: ${{ github.sha }}
 
   # ---------------------------------------------------------------------------
   # Phase 2 — DB Migration
@@ -208,23 +181,16 @@ jobs:
           token: ${{ secrets.OPENSHIFT_TOKEN }}
           server: ${{ env.OPENSHIFT_SERVER }}
 
-      - name: Rollout API Deployment
-        run: |
-          oc rollout restart deployment/api-services -n ${{ env.OPENSHIFT_NAMESPACE }}
-          oc rollout status deployment/api-services -n ${{ env.OPENSHIFT_NAMESPACE }} --timeout=600s
-
-      - name: Update API StatefulSet Image
-        continue-on-error: true
-        run: |
-          oc set image statefulset/api \
-            api=${{ env.ACR_URL }}/api:${{ env.IMAGE_TAG }} \
-            -n ${{ env.OPENSHIFT_NAMESPACE }}
-
-      - name: Rollout API StatefulSet
-        continue-on-error: true
-        run: |
-          oc rollout restart statefulset/api -n ${{ env.OPENSHIFT_NAMESPACE }}
-          oc rollout status statefulset/api -n ${{ env.OPENSHIFT_NAMESPACE }} --timeout=600s
+      - name: Deploy API workloads
+        uses: ./.github/actions/deploy-openshift-workload
+        with:
+          namespace: ${{ env.OPENSHIFT_NAMESPACE }}
+          resource_type: deployment
+          resource_name: api-services
+          rollout_timeout: 600s
+          statefulset_name: api
+          statefulset_container: api
+          statefulset_image: ${{ env.ACR_URL }}/api:${{ env.IMAGE_TAG }}
 
       - name: Verify API Health
         continue-on-error: true
@@ -266,16 +232,14 @@ jobs:
           token: ${{ secrets.OPENSHIFT_TOKEN }}
           server: ${{ env.OPENSHIFT_SERVER }}
 
-      - name: Rollout ${{ matrix.name }}
-        run: |
-          oc rollout restart deployment/${{ matrix.deployment }} -n ${{ env.OPENSHIFT_NAMESPACE }}
-
-      - name: Verify ${{ matrix.name }}
-        continue-on-error: true
-        run: |
-          oc rollout status deployment/${{ matrix.deployment }} \
-            -n ${{ env.OPENSHIFT_NAMESPACE }} \
-            --timeout=300s
+      - name: Deploy ${{ matrix.name }}
+        uses: ./.github/actions/deploy-openshift-workload
+        with:
+          namespace: ${{ env.OPENSHIFT_NAMESPACE }}
+          resource_type: deployment
+          resource_name: ${{ matrix.deployment }}
+          rollout_timeout: 300s
+          continue_on_error_verify: 'true'
 
   # ---------------------------------------------------------------------------
   # Phase 5 — Deploy frontend (editor + subscriber)
@@ -305,16 +269,14 @@ jobs:
           token: ${{ secrets.OPENSHIFT_TOKEN }}
           server: ${{ env.OPENSHIFT_SERVER }}
 
-      - name: Rollout ${{ matrix.name }}
-        run: |
-          oc rollout restart deployment/${{ matrix.deployment }} -n ${{ env.OPENSHIFT_NAMESPACE }}
-
-      - name: Verify ${{ matrix.name }}
-        continue-on-error: true
-        run: |
-          oc rollout status deployment/${{ matrix.deployment }} \
-            -n ${{ env.OPENSHIFT_NAMESPACE }} \
-            --timeout=300s
+      - name: Deploy ${{ matrix.name }}
+        uses: ./.github/actions/deploy-openshift-workload
+        with:
+          namespace: ${{ env.OPENSHIFT_NAMESPACE }}
+          resource_type: deployment
+          resource_name: ${{ matrix.deployment }}
+          rollout_timeout: 300s
+          continue_on_error_verify: 'true'
 
   # ---------------------------------------------------------------------------
   # Summary

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 12
       matrix: ${{ fromJSON(needs.detect-changes.outputs.build_matrix) }}
     env:
       IMAGE_TAG: ${{ inputs.environment }}

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -195,16 +195,18 @@ jobs:
       IMAGE_TAG: ${{ inputs.environment }}
       OPENSHIFT_NAMESPACE: 9b301c-${{ inputs.environment }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Install oc CLI
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Rollout API Deployment
         run: |
@@ -251,16 +253,18 @@ jobs:
     env:
       OPENSHIFT_NAMESPACE: 9b301c-${{ inputs.environment }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Install oc CLI
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Rollout ${{ matrix.name }}
         run: |
@@ -288,16 +292,18 @@ jobs:
     env:
       OPENSHIFT_NAMESPACE: 9b301c-${{ inputs.environment }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Install oc CLI
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Rollout ${{ matrix.name }}
         run: |

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -175,7 +175,7 @@ jobs:
       environment: ${{ inputs.environment }}
       image_tag: ${{ inputs.environment }}
       openshift_namespace: 9b301c-${{ inputs.environment }}
-      db_secret_name: ${{ inputs.environment == 'dev' && 'montford' || 'mooncrest' }}
+      db_secret_name: ${{ fromJSON('{"dev":"montford","test":"mooncrest"}')[inputs.environment] }}
     secrets:
       OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
       ACR_USERNAME: ${{ secrets.ACR_USERNAME }}

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -23,6 +23,11 @@ on:
           - all
           - changed
         default: all
+      allow_dev_branch_override:
+        description: 'Allow manual dev deploy from a non-dev branch for testing'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       environment:
@@ -36,6 +41,10 @@ on:
         required: false
         type: string
         default: all
+      allow_dev_branch_override:
+        required: false
+        type: boolean
+        default: false
     secrets:
       OPENSHIFT_TOKEN:
         required: true
@@ -57,8 +66,22 @@ env:
   ACR_URL: bcgov-c4awhwfpcremdbga.azurecr.io
 
 jobs:
+  validate-request:
+    name: Validate Deployment Request
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/validate-deploy-request
+        with:
+          environment: ${{ inputs.environment }}
+          deploy_scope: ${{ inputs.deploy_scope }}
+          allow_dev_branch_override: ${{ inputs.allow_dev_branch_override }}
+          event_name: ${{ github.event_name }}
+          ref: ${{ github.ref }}
+          ref_name: ${{ github.ref_name }}
+
   detect-changes:
     name: Detect Deploy Targets
+    needs: validate-request
     runs-on: ubuntu-latest
     outputs:
       build_matrix: ${{ steps.detect.outputs.build_matrix }}
@@ -297,7 +320,7 @@ jobs:
   # ---------------------------------------------------------------------------
   summary:
     name: Deployment Summary
-    needs: [detect-changes, build, db-migration, deploy-api, deploy-services, deploy-frontend]
+    needs: [validate-request, detect-changes, build, db-migration, deploy-api, deploy-services, deploy-frontend]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -307,6 +330,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Phase | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Validate Request | ${{ needs.validate-request.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Detect Deploy Targets | ${{ needs.detect-changes.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Build Images | ${{ needs.build.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| DB Migration | ${{ needs.db-migration.result }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -169,7 +169,15 @@ jobs:
   db-migration:
     name: DB Migration
     needs: [detect-changes, build]
-    if: ${{ always() && inputs.skip_db_migration == false && needs.detect-changes.outputs.run_db_migration == 'true' && (needs.build.result == 'success' || needs.build.result == 'skipped') }}
+    # Run migration only when detection requested it, the user did not skip it,
+    # and the image build phase did not fail.
+    if: >-
+      ${{
+        always() &&
+        inputs.skip_db_migration == false &&
+        needs.detect-changes.outputs.run_db_migration == 'true' &&
+        (needs.build.result == 'success' || needs.build.result == 'skipped')
+      }}
     uses: ./.github/workflows/_reusable-db-migration-cd.yml
     with:
       environment: ${{ inputs.environment }}
@@ -187,7 +195,15 @@ jobs:
   deploy-api:
     name: Deploy API
     needs: [detect-changes, build, db-migration]
-    if: ${{ always() && needs.detect-changes.outputs.deploy_api == 'true' && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.db-migration.result == 'success' || needs.db-migration.result == 'skipped') }}
+    # Deploy API only when selected, after build and optional DB migration have
+    # either completed successfully or were skipped.
+    if: >-
+      ${{
+        always() &&
+        needs.detect-changes.outputs.deploy_api == 'true' &&
+        (needs.build.result == 'success' || needs.build.result == 'skipped') &&
+        (needs.db-migration.result == 'success' || needs.db-migration.result == 'skipped')
+      }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:
@@ -240,12 +256,21 @@ jobs:
   deploy-services:
     name: Deploy ${{ matrix.name }}
     needs: [detect-changes, build, db-migration, deploy-api]
-    if: ${{ always() && needs.detect-changes.outputs.deploy_services == 'true' && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.db-migration.result == 'success' || needs.db-migration.result == 'skipped') && (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped') }}
+    # Deploy backend services only when selected, after build, DB migration, and
+    # any selected API deployment have cleared.
+    if: >-
+      ${{
+        always() &&
+        needs.detect-changes.outputs.deploy_services == 'true' &&
+        (needs.build.result == 'success' || needs.build.result == 'skipped') &&
+        (needs.db-migration.result == 'success' || needs.db-migration.result == 'skipped') &&
+        (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped')
+      }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 4
       matrix: ${{ fromJSON(needs.detect-changes.outputs.service_matrix) }}
     env:
       OPENSHIFT_NAMESPACE: 9b301c-${{ inputs.environment }}
@@ -282,7 +307,17 @@ jobs:
   deploy-frontend:
     name: Deploy ${{ matrix.name }}
     needs: [detect-changes, build, db-migration, deploy-api, deploy-services]
-    if: ${{ always() && needs.detect-changes.outputs.deploy_frontend == 'true' && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.db-migration.result == 'success' || needs.db-migration.result == 'skipped') && (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped') && (needs.deploy-services.result == 'success' || needs.deploy-services.result == 'skipped') }}
+    # Deploy frontend apps only when selected, after all earlier rollout phases
+    # have either completed successfully or were skipped.
+    if: >-
+      ${{
+        always() &&
+        needs.detect-changes.outputs.deploy_frontend == 'true' &&
+        (needs.build.result == 'success' || needs.build.result == 'skipped') &&
+        (needs.db-migration.result == 'success' || needs.db-migration.result == 'skipped') &&
+        (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped') &&
+        (needs.deploy-services.result == 'success' || needs.deploy-services.result == 'skipped')
+      }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     strategy:

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -70,7 +70,7 @@ jobs:
       deploy_frontend: ${{ steps.detect.outputs.deploy_frontend }}
       run_db_migration: ${{ steps.detect.outputs.run_db_migration }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -122,7 +122,7 @@ jobs:
       IMAGE_TAG: ${{ inputs.environment }}
       OPENSHIFT_NAMESPACE: 9b301c-${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build, scan, and push image
         uses: ./.github/actions/build-scan-push-image
@@ -169,7 +169,7 @@ jobs:
       IMAGE_TAG: ${{ inputs.environment }}
       OPENSHIFT_NAMESPACE: 9b301c-${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install oc CLI
         uses: redhat-actions/openshift-tools-installer@v1
@@ -221,7 +221,7 @@ jobs:
     env:
       OPENSHIFT_NAMESPACE: 9b301c-${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install oc CLI
         uses: redhat-actions/openshift-tools-installer@v1
@@ -258,7 +258,7 @@ jobs:
     env:
       OPENSHIFT_NAMESPACE: 9b301c-${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install oc CLI
         uses: redhat-actions/openshift-tools-installer@v1

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -116,6 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 6
       matrix: ${{ fromJSON(needs.detect-changes.outputs.build_matrix) }}
     env:
       IMAGE_TAG: ${{ inputs.environment }}
@@ -215,6 +216,7 @@ jobs:
     environment: ${{ inputs.environment }}
     strategy:
       fail-fast: false
+      max-parallel: 6
       matrix: ${{ fromJSON(needs.detect-changes.outputs.service_matrix) }}
     env:
       OPENSHIFT_NAMESPACE: 9b301c-${{ inputs.environment }}

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 12
+      max-parallel: 6
       matrix: ${{ fromJSON(needs.detect-changes.outputs.build_matrix) }}
     env:
       IMAGE_TAG: ${{ inputs.environment }}

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -70,6 +70,8 @@ jobs:
     name: Validate Deployment Request
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+
       - uses: ./.github/actions/validate-deploy-request
         with:
           environment: ${{ inputs.environment }}

--- a/.github/workflows/ffmpeg-service-cicd.yml
+++ b/.github/workflows/ffmpeg-service-cicd.yml
@@ -40,7 +40,3 @@ jobs:
       OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
       ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
       ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
-      CHES_CLIENT_ID: ${{ secrets.CHES_CLIENT_ID }}
-      CHES_CLIENT_SECRET: ${{ secrets.CHES_CLIENT_SECRET }}
-      CHES_SENDER_EMAIL: ${{ secrets.CHES_SENDER_EMAIL }}
-      CHES_NOTIFY_EMAIL: ${{ secrets.CHES_NOTIFY_EMAIL }}

--- a/.github/workflows/filemonitor-service-cicd.yml
+++ b/.github/workflows/filemonitor-service-cicd.yml
@@ -44,7 +44,3 @@ jobs:
       OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
       ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
       ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
-      CHES_CLIENT_ID: ${{ secrets.CHES_CLIENT_ID }}
-      CHES_CLIENT_SECRET: ${{ secrets.CHES_CLIENT_SECRET }}
-      CHES_SENDER_EMAIL: ${{ secrets.CHES_SENDER_EMAIL }}
-      CHES_NOTIFY_EMAIL: ${{ secrets.CHES_NOTIFY_EMAIL }}

--- a/.github/workflows/fileupload-cronjob-cicd.yml
+++ b/.github/workflows/fileupload-cronjob-cicd.yml
@@ -86,10 +86,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Login to ACR
         run: |
@@ -152,10 +152,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Login to ACR
         run: |

--- a/.github/workflows/indexing-service-cicd.yml
+++ b/.github/workflows/indexing-service-cicd.yml
@@ -40,7 +40,3 @@ jobs:
       OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
       ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
       ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
-      CHES_CLIENT_ID: ${{ secrets.CHES_CLIENT_ID }}
-      CHES_CLIENT_SECRET: ${{ secrets.CHES_CLIENT_SECRET }}
-      CHES_SENDER_EMAIL: ${{ secrets.CHES_SENDER_EMAIL }}
-      CHES_NOTIFY_EMAIL: ${{ secrets.CHES_NOTIFY_EMAIL }}

--- a/.github/workflows/manual-rollback.yml
+++ b/.github/workflows/manual-rollback.yml
@@ -54,6 +54,8 @@ jobs:
       IMAGE_TAG: ${{ inputs.environment }}
       OPENSHIFT_NAMESPACE: 9b301c-${{ inputs.environment }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Set service names
         id: svc
         run: |
@@ -120,10 +122,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Rollout Restart
         run: |

--- a/.github/workflows/net-libs.yml
+++ b/.github/workflows/net-libs.yml
@@ -22,7 +22,7 @@ jobs:
       codeCov-token: ${{ secrets.CodeCov }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Extract Branch Name
         shell: bash

--- a/.github/workflows/notification-service-cicd.yml
+++ b/.github/workflows/notification-service-cicd.yml
@@ -44,7 +44,3 @@ jobs:
       OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
       ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
       ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
-      CHES_CLIENT_ID: ${{ secrets.CHES_CLIENT_ID }}
-      CHES_CLIENT_SECRET: ${{ secrets.CHES_CLIENT_SECRET }}
-      CHES_SENDER_EMAIL: ${{ secrets.CHES_SENDER_EMAIL }}
-      CHES_NOTIFY_EMAIL: ${{ secrets.CHES_NOTIFY_EMAIL }}

--- a/.github/workflows/purge-cronjob-cicd.yml
+++ b/.github/workflows/purge-cronjob-cicd.yml
@@ -56,10 +56,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Deploy CronJob via Kustomize
         run: oc apply -k openshift/kustomize/cron/purge/overlays/dev -n 9b301c-dev
@@ -82,10 +82,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Deploy CronJob via Kustomize
         run: oc apply -k openshift/kustomize/cron/purge/overlays/test -n 9b301c-test

--- a/.github/workflows/react-editor.yml
+++ b/.github/workflows/react-editor.yml
@@ -96,10 +96,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Login to ACR
         run: |
@@ -191,10 +191,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Login to ACR
         run: |

--- a/.github/workflows/react-subscriber.yml
+++ b/.github/workflows/react-subscriber.yml
@@ -96,10 +96,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Login to ACR
         run: |
@@ -191,10 +191,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Login to ACR
         run: |

--- a/.github/workflows/reporting-service-cicd.yml
+++ b/.github/workflows/reporting-service-cicd.yml
@@ -44,7 +44,3 @@ jobs:
       OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
       ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
       ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
-      CHES_CLIENT_ID: ${{ secrets.CHES_CLIENT_ID }}
-      CHES_CLIENT_SECRET: ${{ secrets.CHES_CLIENT_SECRET }}
-      CHES_SENDER_EMAIL: ${{ secrets.CHES_SENDER_EMAIL }}
-      CHES_NOTIFY_EMAIL: ${{ secrets.CHES_NOTIFY_EMAIL }}

--- a/.github/workflows/restart-cronjob-cicd.yml
+++ b/.github/workflows/restart-cronjob-cicd.yml
@@ -56,10 +56,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Deploy CronJob via Kustomize
         run: oc apply -k openshift/kustomize/cron/restart/overlays/dev -n 9b301c-dev
@@ -82,10 +82,10 @@ jobs:
           oc: latest
 
       - name: Login to OpenShift
-        run: |
-          oc login \
-            --token=${{ secrets.OPENSHIFT_TOKEN }} \
-            --server=${{ env.OPENSHIFT_SERVER }}
+        uses: ./.github/actions/openshift-login
+        with:
+          token: ${{ secrets.OPENSHIFT_TOKEN }}
+          server: ${{ env.OPENSHIFT_SERVER }}
 
       - name: Deploy CronJob via Kustomize
         run: oc apply -k openshift/kustomize/cron/restart/overlays/test -n 9b301c-test

--- a/.github/workflows/scheduler-service-cicd.yml
+++ b/.github/workflows/scheduler-service-cicd.yml
@@ -44,7 +44,3 @@ jobs:
       OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
       ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
       ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
-      CHES_CLIENT_ID: ${{ secrets.CHES_CLIENT_ID }}
-      CHES_CLIENT_SECRET: ${{ secrets.CHES_CLIENT_SECRET }}
-      CHES_SENDER_EMAIL: ${{ secrets.CHES_SENDER_EMAIL }}
-      CHES_NOTIFY_EMAIL: ${{ secrets.CHES_NOTIFY_EMAIL }}

--- a/.github/workflows/syndication-service-cicd.yml
+++ b/.github/workflows/syndication-service-cicd.yml
@@ -44,7 +44,3 @@ jobs:
       OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
       ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
       ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
-      CHES_CLIENT_ID: ${{ secrets.CHES_CLIENT_ID }}
-      CHES_CLIENT_SECRET: ${{ secrets.CHES_CLIENT_SECRET }}
-      CHES_SENDER_EMAIL: ${{ secrets.CHES_SENDER_EMAIL }}
-      CHES_NOTIFY_EMAIL: ${{ secrets.CHES_NOTIFY_EMAIL }}

--- a/.github/workflows/transcription-service-cicd.yml
+++ b/.github/workflows/transcription-service-cicd.yml
@@ -44,7 +44,3 @@ jobs:
       OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
       ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
       ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
-      CHES_CLIENT_ID: ${{ secrets.CHES_CLIENT_ID }}
-      CHES_CLIENT_SECRET: ${{ secrets.CHES_CLIENT_SECRET }}
-      CHES_SENDER_EMAIL: ${{ secrets.CHES_SENDER_EMAIL }}
-      CHES_NOTIFY_EMAIL: ${{ secrets.CHES_NOTIFY_EMAIL }}


### PR DESCRIPTION
## Summary

- Added shared GitHub composite actions for OpenShift login, OpenShift CLI installation, image build/scan/push, deployment rollout, and deploy request validation.
- Refactored deploy workflows to reuse the shared actions and reduce duplicated deployment logic.
- Improved Deploy All orchestration with request validation, safer phase conditions, max-parallel limits, and environment-specific DB secret mapping.
- Standardized OpenShift login retry behavior across deploy workflows.
- Kept Docker build retry support, but removed ACR login/backup/push retry logic after deciding it was unnecessary.
- Replaced the Red Hat OpenShift tools installer with a local pinned `oc` installer in newer deploy flows.
- Updated GitHub Actions versions such as checkout/cache/SARIF upload where applicable.
- Removed unused CHES secrets from service workflow calls.
- Increased API deploy rollout timeout from 600s to 1200s to handle slower OpenShift rollouts caused by PVC attachment delays.
- Updated CI/CD documentation for the new deploy flow behavior.
