### PR TITLE
Automation Service + Scheduler Control

### DIFF
--- a/api/net/Areas/Admin/Controllers/AutomationController.cs
+++ b/api/net/Areas/Admin/Controllers/AutomationController.cs
@@ -747,6 +747,26 @@ public class AutomationController : ControllerBase
     }
 
     /// <summary>
+    /// Delete a single automation run from the run history. The run's responses are removed with it
+    /// (cascade). This only removes history - it does not affect scheduling, which is driven by the
+    /// schedule's own last-run date rather than by the run records.
+    /// </summary>
+    /// <param name="runId"></param>
+    /// <returns>The deleted run.</returns>
+    // The 'long' constraint keeps this from capturing the literal "runs/prune" route below.
+    [HttpDelete("runs/{runId:long}")]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(typeof(AutomationRunModel), (int)HttpStatusCode.OK)]
+    [SwaggerOperation(Tags = new[] { "Automation" })]
+    public IActionResult DeleteRun(long runId)
+    {
+        var run = _runService.FindById(runId) ?? throw new NoContentException();
+        var model = new AutomationRunModel(run);
+        _runService.DeleteAndSave(run);
+        return new JsonResult(model);
+    }
+
+    /// <summary>
     /// Prune automation runs older than the specified number of days. Used by the automation service for retention.
     /// </summary>
     /// <param name="days"></param>

--- a/app/editor/src/features/admin/automation/AutomationProfileForm.tsx
+++ b/app/editor/src/features/admin/automation/AutomationProfileForm.tsx
@@ -2691,9 +2691,12 @@ const AutomationProfileForm: React.FC = () => {
                         portalId={DATE_PICKER_PORTAL_ID}
                         selectedDate={scheduleModalState?.schedule.runOn ?? undefined}
                         onChange={(date) => {
-                          // Stored as a local date/time string, matching how report schedules
-                          // record 'runOn'; the scheduler converts it to its configured time zone.
-                          const runOn = date ? moment(date as Date).toString() : null;
+                          // Sent as a UTC ISO string: the API binds it to a DateTime with
+                          // Kind=Utc, which is what both the 'timestamp with time zone' column
+                          // and the Scheduler's ToTimeZone conversion require. A non-ISO string
+                          // (moment's toString) fails JSON binding, and an offset-less one binds
+                          // as Kind=Unspecified, which Npgsql refuses to write.
+                          const runOn = date ? moment(date as Date).toISOString() : null;
                           setScheduleModalState((state) =>
                             state ? { ...state, schedule: { ...state.schedule, runOn } } : state,
                           );

--- a/app/editor/src/features/admin/automation/AutomationProfileForm.tsx
+++ b/app/editor/src/features/admin/automation/AutomationProfileForm.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable simple-import-sort/imports */
 import { FormikForm } from 'components/formik';
+import moment from 'moment';
 import React from 'react';
 import { DragDropContext, Draggable, type DropResult } from 'react-beautiful-dnd';
 import {
@@ -42,6 +43,7 @@ import {
   Modal,
   Row,
   Select,
+  SelectDate,
   Show,
   Tab,
   Tabs,
@@ -63,10 +65,10 @@ import {
   createDefaultStep,
   DEDUPLICATION_ACTION,
   defaultAutomationProfile,
+  getRunColumns,
   noneTargetOptions,
   RUN_NOTIFICATION_ACTION,
   RUN_REPORT_ACTION,
-  runColumns,
   SCORE_CONTENT_ACTION,
   sectionDocs,
   SELECT_TOP_ACTION,
@@ -173,6 +175,8 @@ const AutomationProfileForm: React.FC = () => {
   const [runDetail, setRunDetail] = React.useState<IAutomationRunModel | null>(null);
   const [runDiff, setRunDiff] = React.useState<IAutomationRunDiffModel | null>(null);
   const { toggle: toggleRunDetailModal, isShowing: isRunDetailModalShowing } = useModal();
+  // The run pending deletion; also drives the confirmation modal's visibility.
+  const [runDeleteState, setRunDeleteState] = React.useState<IAutomationRunModel | null>(null);
 
   const profileId = Number(id);
   const hub = useApiHub();
@@ -439,6 +443,16 @@ const AutomationProfileForm: React.FC = () => {
     setRunDiff(null);
     if (isRunDetailModalShowing) toggleRunDetailModal();
   };
+
+  const openRunDelete = React.useCallback((run: IAutomationRunModel) => {
+    setRunDeleteState(run);
+  }, []);
+
+  const closeRunDelete = () => setRunDeleteState(null);
+
+  // FlexboxTable rebuilds its internal table whenever the columns array identity changes, so this
+  // must stay referentially stable - hence the stable (state setter only) delete handler above.
+  const runColumns = React.useMemo(() => getRunColumns(openRunDelete), [openRunDelete]);
 
   React.useEffect(() => {
     if (!!profileId && profile.id !== profileId) {
@@ -988,6 +1002,7 @@ const AutomationProfileForm: React.FC = () => {
                           <Col className="name-col">Name</Col>
                           <Col className="state-col">Run At</Col>
                           <Col className="condition-col">Run On</Col>
+                          <Col className="date-col">Start After</Col>
                           <Col className="state-col">Enabled</Col>
                           <Col className="actions-col">
                             <button
@@ -1020,6 +1035,9 @@ const AutomationProfileForm: React.FC = () => {
                             </Col>
                             <Col className="condition-col">
                               {formatScheduleWeekDays(schedule.runOnWeekDays)}
+                            </Col>
+                            <Col className="date-col">
+                              {schedule.runOn ? formatRunTime(schedule.runOn) : 'Any time'}
                             </Col>
                             <Col className="state-col">{schedule.isEnabled ? 'Yes' : 'No'}</Col>
                             <Col className="actions-col">
@@ -2620,7 +2638,9 @@ const AutomationProfileForm: React.FC = () => {
                   <div className="rule-modal-content">
                     <p className="modal-intro-text">
                       The Scheduler service queues a run once per day at (or after) the Run At time
-                      on the selected week days.
+                      on the selected week days. The schedule is not eligible to run before Start
+                      After - set it to a future date/time so a schedule created after its Run At
+                      time has already passed does not run on the day it is created.
                     </p>
                     <Row className="field-grid" gap="1rem">
                       <Text
@@ -2653,6 +2673,25 @@ const AutomationProfileForm: React.FC = () => {
                                   },
                                 }
                               : state,
+                          );
+                        }}
+                      />
+                      <SelectDate
+                        width={FieldSize.Medium}
+                        name="schedule-run-on"
+                        label="Start After"
+                        placeholderText="Any time"
+                        dateFormat="yyyy-MM-dd HH:mm:ss"
+                        showTimeInput
+                        showTimeSelect
+                        isClearable
+                        selectedDate={scheduleModalState?.schedule.runOn ?? undefined}
+                        onChange={(date) => {
+                          // Stored as a local date/time string, matching how report schedules
+                          // record 'runOn'; the scheduler converts it to its configured time zone.
+                          const runOn = date ? moment(date as Date).toString() : null;
+                          setScheduleModalState((state) =>
+                            state ? { ...state, schedule: { ...state.schedule, runOn } } : state,
                           );
                         }}
                       />
@@ -2823,6 +2862,30 @@ const AutomationProfileForm: React.FC = () => {
                     </Button>
                   </Row>
                 }
+              />
+              <Modal
+                headerText="Confirm Run Removal"
+                body={`Are you sure you wish to delete run #${
+                  runDeleteState?.id ?? ''
+                } from the run history? This cannot be undone.`}
+                isShowing={!!runDeleteState}
+                hide={closeRunDelete}
+                type="delete"
+                confirmText="Yes, Delete Run"
+                onConfirm={async () => {
+                  const run = runDeleteState;
+                  if (!run) return closeRunDelete();
+                  try {
+                    await api.deleteRun(run.id);
+                    setRuns((runs) => runs.filter((r) => r.id !== run.id));
+                    // The in-progress poll keys off the latest run; drop it so it does not keep
+                    // polling for a run that no longer exists.
+                    setLastRun((last) => (last?.id === run.id ? null : last));
+                    toast.success(`Run #${run.id} has been deleted.`);
+                  } finally {
+                    closeRunDelete();
+                  }
+                }}
               />
             </div>
           );

--- a/app/editor/src/features/admin/automation/AutomationProfileForm.tsx
+++ b/app/editor/src/features/admin/automation/AutomationProfileForm.tsx
@@ -63,6 +63,7 @@ import {
   contentFieldOptionItems,
   createDefaultAction,
   createDefaultStep,
+  DATE_PICKER_PORTAL_ID,
   DEDUPLICATION_ACTION,
   defaultAutomationProfile,
   getRunColumns,
@@ -2685,6 +2686,9 @@ const AutomationProfileForm: React.FC = () => {
                         showTimeInput
                         showTimeSelect
                         isClearable
+                        // The modal clips its popup and scrolls its body, so the calendar renders
+                        // into a body-level portal instead of being cut off inside the dialog.
+                        portalId={DATE_PICKER_PORTAL_ID}
                         selectedDate={scheduleModalState?.schedule.runOn ?? undefined}
                         onChange={(date) => {
                           // Stored as a local date/time string, matching how report schedules

--- a/app/editor/src/features/admin/automation/constants/columns.tsx
+++ b/app/editor/src/features/admin/automation/constants/columns.tsx
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import { FaTrash } from 'react-icons/fa';
 import { CellCheckbox, CellEllipsis, type ITableHookColumn } from 'tno-core';
 
 import { type IAutomationProfileModel, type IAutomationRunModel } from '../interfaces';
@@ -57,7 +58,13 @@ export const columns: Array<ITableHookColumn<IAutomationProfileModel>> = [
   },
 ];
 
-export const runColumns: Array<ITableHookColumn<IAutomationRunModel>> = [
+/**
+ * Run history columns. The delete column is only included when 'onDelete' is supplied; its click is
+ * stopped from bubbling so removing a run does not also open the run detail modal (row click).
+ */
+export const getRunColumns = (
+  onDelete?: (run: IAutomationRunModel) => void,
+): Array<ITableHookColumn<IAutomationRunModel>> => [
   {
     label: 'Started',
     accessor: 'startedOn',
@@ -88,4 +95,29 @@ export const runColumns: Array<ITableHookColumn<IAutomationRunModel>> = [
     width: 2,
     cell: (cell) => <CellEllipsis>{cell.original.note ?? ''}</CellEllipsis>,
   },
+  ...(onDelete
+    ? [
+        {
+          label: '',
+          accessor: 'id',
+          width: 0.4,
+          hAlign: 'center',
+          showSort: false,
+          cell: (cell) => (
+            <button
+              type="button"
+              className="rule-icon-button delete"
+              aria-label={`Delete run ${cell.original.id}`}
+              title={`Delete run ${cell.original.id}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onDelete(cell.original);
+              }}
+            >
+              <FaTrash />
+            </button>
+          ),
+        } as ITableHookColumn<IAutomationRunModel>,
+      ]
+    : []),
 ];

--- a/app/editor/src/features/admin/automation/constants/datePickerPortalId.ts
+++ b/app/editor/src/features/admin/automation/constants/datePickerPortalId.ts
@@ -1,0 +1,6 @@
+/**
+ * The id of the body-level element the schedule modal's date picker renders its calendar into.
+ * The modal clips its popup and scrolls its body, so an inline calendar would be cut off; the
+ * portal escapes that overflow while the popper stays anchored to the input.
+ */
+export const DATE_PICKER_PORTAL_ID = 'automation-date-picker-portal';

--- a/app/editor/src/features/admin/automation/constants/index.ts
+++ b/app/editor/src/features/admin/automation/constants/index.ts
@@ -1,4 +1,5 @@
 export * from './columns';
+export * from './datePickerPortalId';
 export * from './defaultAutomationProfile';
 export * from './options';
 export * from './sectionDocs';

--- a/app/editor/src/features/admin/automation/constants/sectionDocs.tsx
+++ b/app/editor/src/features/admin/automation/constants/sectionDocs.tsx
@@ -51,6 +51,12 @@ export const sectionDocs = {
         <ul>
           <li>Times are interpreted in the Scheduler service's configured time zone.</li>
           <li>Select no week days to run every day.</li>
+          <li>
+            <strong>Start After</strong> is the date/time the schedule becomes valid; nothing runs
+            before it. Leave it empty and a schedule saved after its Run At time has already passed
+            becomes eligible the same day - set it to a future date/time to hold the first run until
+            then.
+          </li>
           <li>Disable the schedule to run this profile manually only.</li>
         </ul>
       </>

--- a/app/editor/src/features/admin/automation/interfaces.ts
+++ b/app/editor/src/features/admin/automation/interfaces.ts
@@ -67,6 +67,10 @@ export interface IAutomationScheduleModel {
   isEnabled: boolean;
   /** Time of day to run at (or after), 'HH:mm:ss'. */
   startAt?: string | null;
+  /** The date/time the schedule becomes valid; the scheduler will not fire before it. Set it in
+   * the future so a schedule created after its 'startAt' time has passed does not run prematurely
+   * on the day it is created. */
+  runOn?: string | null;
   /** ScheduleWeekDay flag values; empty runs every day. */
   runOnWeekDays: number[];
 }

--- a/app/editor/src/features/admin/automation/styled/AutomationProfileForm.tsx
+++ b/app/editor/src/features/admin/automation/styled/AutomationProfileForm.tsx
@@ -438,7 +438,7 @@ export const AutomationProfileForm = styled(FormPage)`
   .schedules-grid-header,
   .schedules-grid-row {
     display: grid;
-    grid-template-columns: minmax(150px, 1fr) 110px minmax(180px, 1fr) 90px 120px;
+    grid-template-columns: minmax(150px, 1fr) 110px minmax(180px, 1fr) 150px 90px 120px;
     gap: 0.5rem;
     align-items: center;
     padding: 0.6rem 0.75rem;

--- a/app/editor/src/features/admin/automation/styled/AutomationProfileForm.tsx
+++ b/app/editor/src/features/admin/automation/styled/AutomationProfileForm.tsx
@@ -1,6 +1,10 @@
 import { FormPage } from 'components/formpage';
 import styled, { createGlobalStyle } from 'styled-components';
 
+// Imported from the module rather than the 'constants' barrel to keep the component index out of
+// this stylesheet's import graph.
+import { DATE_PICKER_PORTAL_ID } from '../constants/datePickerPortalId';
+
 export const AutomationProfileForm = styled(FormPage)`
   display: flex;
   flex-direction: column;
@@ -798,6 +802,14 @@ export const AutomationModalStyles = createGlobalStyle`
 
   .modal-popup:has(.rule-modal-content) .button-row {
     flex-shrink: 0;
+  }
+
+  /* The schedule modal clips its popup ('overflow: hidden' above) and scrolls its body, so the
+     Start After calendar is rendered into a body-level portal ('portalId') instead of inline.
+     Both the modal and the portal are children of document.body, so the popper has to out-rank
+     the modal wrapper's z-index (1050) to paint over the dialog. */
+  #${DATE_PICKER_PORTAL_ID} .react-datepicker-popper {
+    z-index: 1060;
   }
 
   /* Full-width select rows (Prior Action, Report): the whole label is always visible.

--- a/app/editor/src/features/admin/automation/utils/buildProfileForExport.ts
+++ b/app/editor/src/features/admin/automation/utils/buildProfileForExport.ts
@@ -18,6 +18,7 @@ export const buildProfileForExport = (values: IAutomationProfileModel) => {
       name: schedule.name,
       isEnabled: schedule.isEnabled,
       startAt: schedule.startAt,
+      runOn: schedule.runOn,
       runOnWeekDays: schedule.runOnWeekDays,
     })),
     steps: (saved.steps ?? []).map((step) => ({

--- a/app/editor/src/features/admin/automation/utils/buildProfileForSave.ts
+++ b/app/editor/src/features/admin/automation/utils/buildProfileForSave.ts
@@ -14,6 +14,7 @@ export const buildProfileForSave = (values: IAutomationProfileModel): IAutomatio
     name: schedule.name,
     isEnabled: schedule.isEnabled,
     startAt: schedule.startAt,
+    runOn: schedule.runOn ?? null,
     runOnWeekDays: schedule.runOnWeekDays ?? [],
   })),
   steps: normalizeSteps(values.steps).map((step) => ({

--- a/app/editor/src/features/admin/automation/utils/createDefaultSchedule.ts
+++ b/app/editor/src/features/admin/automation/utils/createDefaultSchedule.ts
@@ -5,5 +5,6 @@ export const createDefaultSchedule = (): IAutomationScheduleModel => ({
   name: '',
   isEnabled: true,
   startAt: null,
+  runOn: null,
   runOnWeekDays: [],
 });

--- a/app/editor/src/features/admin/folders/FolderFormCollect.tsx
+++ b/app/editor/src/features/admin/folders/FolderFormCollect.tsx
@@ -153,7 +153,10 @@ export const FolderFormCollect: React.FC = () => {
                     : undefined
                 }
                 onChange={(value) => {
-                  setFieldValue('events.0.runOn', value ? moment(value).toString() : undefined);
+                  // Must be a UTC ISO string: moment's toString emits a non-ISO format the API
+                  // cannot bind to DateTime, and an offset-less one binds as Kind=Unspecified,
+                  // which Npgsql refuses to write to schedule.run_on (timestamp with time zone).
+                  setFieldValue('events.0.runOn', value ? moment(value).toISOString() : undefined);
                 }}
                 isClearable
               />

--- a/app/editor/src/features/admin/reports/ReportSchedule.tsx
+++ b/app/editor/src/features/admin/reports/ReportSchedule.tsx
@@ -62,7 +62,13 @@ export const ReportSchedule: React.FC<IReportScheduleProps> = ({ label, index })
                 : undefined
             }
             onChange={(value) => {
-              setFieldValue(`events.${index}.runOn`, value ? moment(value).toString() : undefined);
+              // Must be a UTC ISO string: moment's toString emits a non-ISO format the API cannot
+              // bind to DateTime, and an offset-less one binds as Kind=Unspecified, which Npgsql
+              // refuses to write to schedule.run_on (timestamp with time zone).
+              setFieldValue(
+                `events.${index}.runOn`,
+                value ? moment(value).toISOString() : undefined,
+              );
             }}
             isClearable
           />

--- a/app/editor/src/store/hooks/admin/useApiAdminAutomation.ts
+++ b/app/editor/src/store/hooks/admin/useApiAdminAutomation.ts
@@ -58,6 +58,11 @@ export const useApiAdminAutomation = () => {
         `/admin/automation/runs/${runId}/diff`,
       );
     },
+    deleteRun: (runId: number) => {
+      return api.delete<never, AxiosResponse<IAutomationRunModel>, any>(
+        `/admin/automation/runs/${runId}`,
+      );
+    },
     debugContent: (id: number, request: IAutomationDebugRequestModel) => {
       return api.post<
         IAutomationDebugRequestModel,

--- a/app/editor/src/store/hooks/admin/useAutomationProfiles.ts
+++ b/app/editor/src/store/hooks/admin/useAutomationProfiles.ts
@@ -21,6 +21,7 @@ interface IAutomationProfileController {
   runProfile: (id: number, request: IAutomationRunRequestModel) => Promise<IAutomationRunModel>;
   findRuns: (profileId?: number) => Promise<IAutomationRunModel[]>;
   getRunDiff: (runId: number) => Promise<IAutomationRunDiffModel>;
+  deleteRun: (runId: number) => Promise<IAutomationRunModel>;
   debugContent: (
     id: number,
     request: IAutomationDebugRequestModel,
@@ -94,6 +95,13 @@ export const useAutomationProfiles = (): [IAdminState, IAutomationProfileControl
           async () => await api.getRunDiff(runId),
           undefined,
           true,
+        );
+        return response.data;
+      },
+      deleteRun: async (runId: number) => {
+        const response = await dispatch<IAutomationRunModel>(
+          'delete-automation-run',
+          async () => await api.deleteRun(runId),
         );
         return response.data;
       },

--- a/libs/net/dal/Services/AutomationProfileService.cs
+++ b/libs/net/dal/Services/AutomationProfileService.cs
@@ -141,6 +141,7 @@ public class AutomationProfileService : BaseService<AutomationProfile, int>, IAu
                 originalEvent.Schedule.Name = incomingEvent.Name;
                 originalEvent.Schedule.IsEnabled = incomingEvent.Schedule.IsEnabled;
                 originalEvent.Schedule.StartAt = incomingEvent.Schedule.StartAt;
+                originalEvent.Schedule.RunOn = incomingEvent.Schedule.RunOn;
                 originalEvent.Schedule.RunOnWeekDays = incomingEvent.Schedule.RunOnWeekDays;
             }
         }

--- a/libs/net/models/Areas/Admin/Automation/AutomationProfileModel.cs
+++ b/libs/net/models/Areas/Admin/Automation/AutomationProfileModel.cs
@@ -140,7 +140,11 @@ public class AutomationProfileModel
             })
             {
                 Id = schedule.Id,
-                IsEnabled = schedule.IsEnabled,
+                // The scheduler skips event schedules that are not enabled, so gate the event on the
+                // profile as well; a disabled profile would otherwise still queue a run every day
+                // that the automation service can only fail. The schedule keeps its own IsEnabled
+                // (above), so re-enabling the profile restores each schedule's setting.
+                IsEnabled = this.IsEnabled && schedule.IsEnabled,
                 AutomationProfileId = this.Id,
             });
         }

--- a/libs/net/models/Areas/Admin/Automation/AutomationProfileModel.cs
+++ b/libs/net/models/Areas/Admin/Automation/AutomationProfileModel.cs
@@ -135,6 +135,7 @@ public class AutomationProfileModel
             {
                 IsEnabled = schedule.IsEnabled,
                 StartAt = schedule.StartAt,
+                RunOn = schedule.RunOn,
                 RunOnWeekDays = schedule.GetRunOnWeekDays(),
             })
             {

--- a/libs/net/models/Areas/Admin/Automation/AutomationScheduleModel.cs
+++ b/libs/net/models/Areas/Admin/Automation/AutomationScheduleModel.cs
@@ -29,6 +29,13 @@ public class AutomationScheduleModel
     public TimeSpan? StartAt { get; set; }
 
     /// <summary>
+    /// get/set - The date and time the schedule becomes valid; the scheduler will not fire before
+    /// it. Set it in the future so a schedule created after its 'StartAt' time has passed does not
+    /// run prematurely on the day it is created.
+    /// </summary>
+    public DateTime? RunOn { get; set; }
+
+    /// <summary>
     /// get/set - The week days to run on (ScheduleWeekDay flag values).
     /// </summary>
     public int[] RunOnWeekDays { get; set; } = Array.Empty<int>();
@@ -50,6 +57,7 @@ public class AutomationScheduleModel
         this.Name = entity.Name;
         this.IsEnabled = entity.IsEnabled && (entity.Schedule?.IsEnabled ?? false);
         this.StartAt = entity.Schedule?.StartAt;
+        this.RunOn = entity.Schedule?.RunOn;
         this.RunOnWeekDays = entity.Schedule == null
             ? Array.Empty<int>()
             : Enum.GetValues<Entities.ScheduleWeekDay>()

--- a/libs/net/models/Areas/Admin/Automation/AutomationScheduleModel.cs
+++ b/libs/net/models/Areas/Admin/Automation/AutomationScheduleModel.cs
@@ -55,7 +55,10 @@ public class AutomationScheduleModel
     {
         this.Id = entity.Id;
         this.Name = entity.Name;
-        this.IsEnabled = entity.IsEnabled && (entity.Schedule?.IsEnabled ?? false);
+        // The schedule's own setting, not the event's: the event is additionally gated on the
+        // profile being enabled, and reporting that here would silently clear the schedule's
+        // setting the next time a disabled profile was saved.
+        this.IsEnabled = entity.Schedule?.IsEnabled ?? false;
         this.StartAt = entity.Schedule?.StartAt;
         this.RunOn = entity.Schedule?.RunOn;
         this.RunOnWeekDays = entity.Schedule == null


### PR DESCRIPTION
Currently when a schedule is configured it will run the automation profile immediately.  This update provides a way to configure when the schedule begins to take effect.

An automation run has a way to be deleted.  This his helpful to debug issues, and clear invalid runs.