### PR TITLE
Automation Update

### DIFF
--- a/app/editor/src/features/admin/automation/designer/AnalysisEditor.tsx
+++ b/app/editor/src/features/admin/automation/designer/AnalysisEditor.tsx
@@ -22,6 +22,8 @@ export interface IAnalysisEditorProps {
   analysis: IAutomationAnalysis;
   /** Names of analyses declared earlier in the step (valid chain targets). */
   earlierNames: string[];
+  /** Drafts the step's content.create actions declare (valid '{target}' sources). */
+  draftNames: string[];
   promptNames: string[];
   llmOptions: IOptionItem[];
   onChange: (analysis: IAutomationAnalysis) => void;
@@ -39,6 +41,7 @@ const RETURN_TYPES = ['string', 'string?', 'string[]', 'bool', 'int', 'int(-5..5
 export const AnalysisEditor: React.FC<IAnalysisEditorProps> = ({
   analysis,
   earlierNames,
+  draftNames,
   promptNames,
   llmOptions,
   onChange,
@@ -51,6 +54,12 @@ export const AnalysisEditor: React.FC<IAnalysisEditorProps> = ({
   const chainOptions = [
     createOption('(none)', ''),
     ...earlierNames.map((name) => createOption(name, name)),
+  ];
+  // The draft an analysis reads through '{target...}'. Every draft the step creates is offered:
+  // an analysis runs where the action consuming it runs, not at a position of its own.
+  const targetOptions = [
+    createOption('(none)', ''),
+    ...draftNames.map((name) => createOption(name.replace(/^\$item\./, ''), name)),
   ];
   const llmSelectOptions = [createOption('step default', ''), ...llmOptions];
   const returnEntries = Object.entries(analysis.returns ?? {});
@@ -95,6 +104,21 @@ export const AnalysisEditor: React.FC<IAnalysisEditorProps> = ({
         />
       </Row>
       <Row gap="1rem" alignItems="flex-end" nowrap>
+        <Show visible={draftNames.length > 0}>
+          <Select
+            name="analysis-target"
+            label="Target"
+            tooltip="The draft this analysis's '{target...}' tokens read, so the prompt can see what earlier actions put on the copy. '{content...}' always reads the item the iteration started from."
+            width={fitSelectWidth(['(none)', ...draftNames])}
+            isClearable={false}
+            options={targetOptions}
+            value={findOptionByValue(targetOptions, analysis.target ?? '')}
+            onChange={(newValue) => {
+              const option = newValue as IOptionItem;
+              set({ target: option?.value ? `${option.value}` : null });
+            }}
+          />
+        </Show>
         <Select
           name="analysis-llm"
           label="LLM Override"
@@ -114,6 +138,14 @@ export const AnalysisEditor: React.FC<IAnalysisEditorProps> = ({
           />
         </div>
       </Row>
+      <Show visible={!!analysis.target}>
+        <p className="automation-field-help">
+          <code>{'{target}'}</code> and <code>{'{target.field}'}</code> read{' '}
+          <code>{analysis.target}</code> — the copy this step&apos;s actions are building, including
+          the changes they have already made to it. <code>{'{content}'}</code> and{' '}
+          <code>{'{content.field}'}</code> keep reading the item the iteration started from.
+        </p>
+      </Show>
       <Show visible={!analysis.prompt?.ref}>
         <TextArea
           name="analysis-prompt-text"
@@ -136,6 +168,7 @@ export const AnalysisEditor: React.FC<IAnalysisEditorProps> = ({
         </div>
         <PromptTokens
           editorRef={overrideRef}
+          showTarget={draftNames.length > 0}
           onAppend={(token) =>
             set({
               prompt: {

--- a/app/editor/src/features/admin/automation/designer/AutomationDesigner.tsx
+++ b/app/editor/src/features/admin/automation/designer/AutomationDesigner.tsx
@@ -211,7 +211,8 @@ export const AutomationDesigner: React.FC<IAutomationDesignerProps> = ({
     update({ ...definition, steps });
   };
 
-  /** Drafts declared by content.create actions before the given index (modal draft pickers). */
+  /** Drafts declared by content.create actions before the given index, or every draft the step
+   * declares when the index is null (the analysis target picker, which has no action position). */
   const draftNamesBefore = (step: IAutomationStep, index: number | null): string[] =>
     step.actions
       .slice(0, index ?? step.actions.length)
@@ -291,6 +292,15 @@ export const AutomationDesigner: React.FC<IAutomationDesignerProps> = ({
                   Select Top Scored never calls the LLM: it ranks the recorded scores highest first
                   and breaks ties on the lowest content id. The run&apos;s Outcome tab lists every
                   scored story and how many carried each score.
+                </p>
+                <p>
+                  <strong>Analysing a draft.</strong> When a step creates a copy with{' '}
+                  <strong>New Content</strong> and its actions target that draft, an analysis still
+                  reads the item the iteration started from — <code>{'{content.tags}'}</code> is the
+                  original&apos;s tags, not the ones an earlier action just put on the copy. Set the
+                  analysis&apos;s <strong>Target</strong> to that draft and read it with{' '}
+                  <code>{'{target.tags}'}</code>; <code>{'{content...}'}</code> keeps meaning the
+                  original.
                 </p>
               </>
             }
@@ -478,6 +488,7 @@ export const AutomationDesigner: React.FC<IAutomationDesignerProps> = ({
                                       <span className="automation-gc-name">Analysis</span>
                                       <span className="automation-gc-source">Prompt</span>
                                       <span className="automation-gc-sm">Chain</span>
+                                      <span className="automation-gc-sm">Target</span>
                                       <span className="automation-gc-sm">LLM Override</span>
                                       <span className="automation-gc-sm">Returns</span>
                                       <span className="automation-gc-actions">
@@ -541,6 +552,18 @@ export const AutomationDesigner: React.FC<IAutomationDesignerProps> = ({
                                         </span>
                                         <span className="automation-gc-sm">
                                           {analysis.chain ?? (
+                                            <span className="automation-muted">—</span>
+                                          )}
+                                        </span>
+                                        <span
+                                          className="automation-gc-sm"
+                                          title={
+                                            analysis.target
+                                              ? `'{target...}' tokens read ${analysis.target}`
+                                              : undefined
+                                          }
+                                        >
+                                          {analysis.target?.replace(/^\$item\./, '') ?? (
                                             <span className="automation-muted">—</span>
                                           )}
                                         </span>
@@ -926,6 +949,11 @@ export const AutomationDesigner: React.FC<IAutomationDesignerProps> = ({
                     ? definition.steps[analysisModal.stepIndex].analyses
                         .slice(0, analysisModal.index ?? undefined)
                         .map((analysis) => analysis.name)
+                    : []
+                }
+                draftNames={
+                  analysisModal
+                    ? draftNamesBefore(definition.steps[analysisModal.stepIndex], null)
                     : []
                 }
                 promptNames={promptNames}

--- a/app/editor/src/features/admin/automation/designer/PromptLibrary.tsx
+++ b/app/editor/src/features/admin/automation/designer/PromptLibrary.tsx
@@ -303,6 +303,7 @@ export const PromptLibrary: React.FC<IPromptLibraryProps> = ({ definition, onCha
                 )
               }
               showCandidates
+              showTarget
             />
           </div>
         }

--- a/app/editor/src/features/admin/automation/designer/PromptTokens.tsx
+++ b/app/editor/src/features/admin/automation/designer/PromptTokens.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { CANDIDATE_TOKENS, CONTENT_TOKENS, LOOKUP_TOKENS } from './constants';
+import { CANDIDATE_TOKENS, CONTENT_TOKENS, LOOKUP_TOKENS, TARGET_TOKENS } from './constants';
 
 export interface IPromptTokensProps {
   /** Container holding the target Wysiwyg; tokens insert at the caret when it has focus. */
@@ -9,6 +9,8 @@ export interface IPromptTokensProps {
   onAppend: (token: string) => void;
   /** Show the Candidate group (only meaningful for Detect Duplicate prompts). */
   showCandidates?: boolean;
+  /** Show the Target group (only meaningful once the analysis names a target draft). */
+  showTarget?: boolean;
 }
 
 /**
@@ -20,6 +22,7 @@ export const PromptTokens: React.FC<IPromptTokensProps> = ({
   editorRef,
   onAppend,
   showCandidates = false,
+  showTarget = false,
 }) => {
   /**
    * Insert a token at the cursor when the prompt editor has focus (mousedown keeps the focus and
@@ -65,10 +68,13 @@ export const PromptTokens: React.FC<IPromptTokensProps> = ({
         itself — see default-dedupe for the layout. <code>{'{lookup:*}'}</code> inserts reference
         lists (identical for every item). Analyses only: a prompt with no content tokens at all gets
         the story appended as a final '## News Story' section; any <code>{'{content...}'}</code>{' '}
-        token disables that.
+        token disables that. When an analysis names a Target draft, <code>{'{target.*}'}</code>{' '}
+        reads that draft instead — including what earlier actions in the step have already put on it
+        — while <code>{'{content.*}'}</code> keeps meaning the item the iteration started from.
       </p>
       {group('Lookups', LOOKUP_TOKENS)}
       {group('Content (the item being processed)', CONTENT_TOKENS)}
+      {showTarget && group('Target (the draft the analysis names)', TARGET_TOKENS)}
       {showCandidates && group('Candidate (Detect Duplicate prompts)', CANDIDATE_TOKENS)}
     </>
   );

--- a/app/editor/src/features/admin/automation/designer/constants.ts
+++ b/app/editor/src/features/admin/automation/designer/constants.ts
@@ -316,6 +316,16 @@ export const CONTENT_TOKENS: { token: string; hint: string }[] = [
   { token: '{content.topics}', hint: 'JSON array of {"name","score"} topic objects' },
 ];
 
+/** Insertable target tokens: the same fields as the content tokens, but read from the draft an
+ * analysis names as its target rather than from the item the iteration started from. Derived from
+ * CONTENT_TOKENS so the two lists cannot drift apart. */
+export const TARGET_TOKENS: { token: string; hint: string }[] = CONTENT_TOKENS.map(
+  ({ token, hint }) => ({
+    token: token.replace('{content', '{target'),
+    hint: `${hint} — read from the targeted draft`,
+  }),
+);
+
 /** The working-copy property fields conditions can test, derived from the content token list so
  * the dropdown and the prompt tokens stay one surface. */
 export const contentTokenFieldOptions: IOptionItem[] = CONTENT_TOKENS.filter(({ token }) =>

--- a/app/editor/src/features/admin/automation/designer/interfaces.ts
+++ b/app/editor/src/features/admin/automation/designer/interfaces.ts
@@ -49,6 +49,9 @@ export interface IAutomationAnalysis {
   prompt: IAutomationPrompt;
   /** Continue an earlier analysis as a conversation (the model sees the earlier exchange). */
   chain?: string | null;
+  /** The draft ('$item.<name>', created by a content.create action in this step) the prompt's
+   * '{target}' tokens read; '{content}' always reads the item the iteration started from. */
+  target?: string | null;
   /** Result shape: key -> type spec ('string', 'string?', 'string[]', 'bool', 'int', 'int(a..b)'). */
   returns: Record<string, string>;
   /** Raw mode: keep the response as text; actions gate on it with confirmation statements. */

--- a/libs/net/models/Areas/Admin/Automation/AnalysisDefinition.cs
+++ b/libs/net/models/Areas/Admin/Automation/AnalysisDefinition.cs
@@ -27,6 +27,15 @@ public class AnalysisDefinition
     public string? Chain { get; set; }
 
     /// <summary>
+    /// get/set - The draft ('$item.&lt;name&gt;', created by a content.create action in this step)
+    /// the prompt's '{target}' / '{target.field}' tokens read, so an analysis can describe the copy
+    /// the step's actions are building rather than only the item the iteration started from.
+    /// '{content}' / '{content.field}' always read that original item, target or not; with no
+    /// target set the '{target...}' tokens resolve to nothing.
+    /// </summary>
+    public string? Target { get; set; }
+
+    /// <summary>
     /// get/set - The declared result shape: key -> type spec. Supported specs: 'string',
     /// 'string?', 'string[]', 'bool', 'int', 'int(min..max)'. The engine requests structured
     /// JSON and validates the response against these keys.

--- a/libs/net/models/Areas/Admin/Automation/AutomationDefinitionValidator.cs
+++ b/libs/net/models/Areas/Admin/Automation/AutomationDefinitionValidator.cs
@@ -106,6 +106,13 @@ public static class AutomationDefinitionValidator
                 errors.Add(new($"{stepPath}.source", "An init step runs once and cannot declare a source."));
 
             // Analyses.
+            // Every draft the step creates, wherever it is created: an analysis runs at the
+            // position of the action that consumes it, not at a position of its own, so a target
+            // is judged against the step as a whole rather than against what precedes it.
+            var stepDrafts = step.Actions
+                .Where(a => a.Type == "content.create" && !string.IsNullOrWhiteSpace(a.As))
+                .Select(a => a.As!)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
             var analyses = new Dictionary<string, AnalysisDefinition>(StringComparer.OrdinalIgnoreCase);
             for (var a = 0; a < step.Analyses.Count; a++)
             {
@@ -120,6 +127,13 @@ public static class AutomationDefinitionValidator
                 var analysisPromptText = $"{analysis.Prompt.Text} {analysis.Prompt.Override} " +
                     (analysis.Prompt.Ref != null && definition.Prompts.TryGetValue(analysis.Prompt.Ref, out var libraryEntry) ? libraryEntry.Text : "");
                 ValidatePromptTokens(analysisPromptText, $"{path}.prompt", allowCandidates: false, errors);
+
+                if (!string.IsNullOrWhiteSpace(analysis.Target) && !stepDrafts.Contains(analysis.Target!))
+                    errors.Add(new($"{path}.target", $"Draft '{analysis.Target}' is not created by a content.create action in this step."));
+                // A '{target...}' token with nothing to read renders as nothing, which looks like
+                // the model ignored the instruction rather than like a missing setting.
+                else if (string.IsNullOrWhiteSpace(analysis.Target) && _targetToken.IsMatch(analysisPromptText))
+                    errors.Add(new($"{path}.target", "The prompt uses a '{target}' token but the analysis has no target, so the token renders as nothing. Set the target to the draft it should read.", "warning"));
 
                 if (!analysis.Raw && analysis.Returns.Count == 0)
                     errors.Add(new($"{path}.returns", "A structured analysis must declare at least one return key (or set raw)."));
@@ -292,6 +306,9 @@ public static class AutomationDefinitionValidator
         }
     }
 
+    private static readonly System.Text.RegularExpressions.Regex _targetToken =
+        new(@"\{target(\.[^}]*)?\}", System.Text.RegularExpressions.RegexOptions.Compiled);
+
     private static readonly System.Text.RegularExpressions.Regex _promptToken =
         new(@"\{(?<name>[a-zA-Z][a-zA-Z0-9_-]*)(?<rest>[.:][^}]*)?\}", System.Text.RegularExpressions.RegexOptions.Compiled);
 
@@ -302,7 +319,7 @@ public static class AutomationDefinitionValidator
     private static void ValidatePromptTokens(string? text, string path, bool allowCandidates, List<ValidationError> errors)
     {
         if (string.IsNullOrWhiteSpace(text)) return;
-        var known = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "content", "lookup", "collection", "value" };
+        var known = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "content", "target", "lookup", "collection", "value" };
         if (allowCandidates) { known.Add("candidate"); known.Add("candidates"); }
         var unknown = _promptToken.Matches(text!)
             .Select(m => m.Groups["name"].Value)

--- a/libs/net/tests/dal/Automation/AutomationDefinitionValidatorTest.cs
+++ b/libs/net/tests/dal/Automation/AutomationDefinitionValidatorTest.cs
@@ -67,6 +67,51 @@ public class AutomationDefinitionValidatorTest
         Assert.Empty(errors.Where(e => e.Severity == "error"));
     }
 
+    /// <summary>An analysis target must name a draft the step actually creates.</summary>
+    [Fact]
+    public void AnalysisTargetWithoutMatchingDraft_IsAnError()
+    {
+        var definition = ValidDefinition();
+        definition.Steps[1].Analyses[0].Target = "$item.copy";
+        var errors = AutomationDefinitionValidator.Validate(definition);
+        Assert.Contains(errors, e => e.Path == "steps[1].analyses[0].target" && e.Severity == "error");
+    }
+
+    /// <summary>A draft created anywhere in the step is a valid target: the analysis runs where the
+    /// action consuming it runs, not at a position of its own.</summary>
+    [Fact]
+    public void AnalysisTargetNamingAStepDraft_IsValid()
+    {
+        var definition = ValidDefinition();
+        definition.Steps[1].Actions.Insert(0, new ActionDefinition { Type = "content.create", As = "$item.copy", CopyFrom = "$item" });
+        definition.Steps[1].Analyses[0].Target = "$item.copy";
+        var errors = AutomationDefinitionValidator.Validate(definition);
+        Assert.Empty(errors.Where(e => e.Severity == "error"));
+    }
+
+    /// <summary>A '{target}' token with no target renders as nothing, which reads like the model
+    /// ignored the instruction rather than like a missing setting.</summary>
+    [Fact]
+    public void TargetTokenWithoutATarget_IsAWarning()
+    {
+        var definition = ValidDefinition();
+        definition.Prompts["rules"] = new PromptEntry { Text = "Review the story. {target.tags}" };
+        var errors = AutomationDefinitionValidator.Validate(definition);
+        Assert.Contains(errors, e => e.Path == "steps[1].analyses[0].target" && e.Severity == "warning");
+    }
+
+    /// <summary>'{target...}' is a recognized token, so it must not be reported as a typo.</summary>
+    [Fact]
+    public void TargetTokenWithATarget_IsNotReported()
+    {
+        var definition = ValidDefinition();
+        definition.Prompts["rules"] = new PromptEntry { Text = "Review the story. {target.tags}" };
+        definition.Steps[1].Actions.Insert(0, new ActionDefinition { Type = "content.create", As = "$item.copy", CopyFrom = "$item" });
+        definition.Steps[1].Analyses[0].Target = "$item.copy";
+        var errors = AutomationDefinitionValidator.Validate(definition);
+        Assert.DoesNotContain(errors, e => e.Message.Contains("target"));
+    }
+
     [Fact]
     public void UnknownActionType_IsAnError()
     {

--- a/services/net/automation/Engine/AutomationEngine.cs
+++ b/services/net/automation/Engine/AutomationEngine.cs
@@ -651,9 +651,21 @@ public class AutomationEngine
         }
 
         var subject = scope.Subject;
+        // '{target...}' reads the draft the analysis names, so a prompt can describe the copy the
+        // step's actions are building instead of only the item the iteration started from. An
+        // unresolved draft is logged, never silent: the tokens then render as nothing.
+        ContentEntry? target = null;
+        if (!string.IsNullOrWhiteSpace(analysis.Target))
+        {
+            target = scope.ResolveTarget(analysis.Target);
+            if (target == null)
+                env.Log.LogDecision(step.Name, name, "analysis", subject is { Kind: "existing" } ? subject.Id : (long?)null, Outcomes.Info,
+                    $"Draft '{analysis.Target}' does not exist yet, so the analysis's {{target...}} tokens are empty. It is created by a content.create action - make sure that action runs before whatever consumes this analysis.");
+        }
         var text = env.Prompts.Resolve(analysis.Prompt);
-        // The first message of an exchange carries the working copy; later chained turns already have it.
-        text = messages.Count == 0 ? env.Prompts.Substitute(text, subject) : env.Prompts.Substitute(text, null);
+        // The first message of an exchange carries the working copy; later chained turns already
+        // have it, so they substitute the tokens without re-appending the story.
+        text = env.Prompts.Substitute(text, subject, target, appendSubject: messages.Count == 0);
         if (!analysis.Raw && analysis.Returns.Count > 0)
         {
             var spec = string.Join("\n", analysis.Returns.Select(kv => $"- \"{kv.Key}\": {kv.Value}"));

--- a/services/net/automation/Engine/PromptBuilder.cs
+++ b/services/net/automation/Engine/PromptBuilder.cs
@@ -10,6 +10,9 @@ namespace TNO.Services.Automation.Engine;
 /// PromptBuilder class, resolves prompt text (library reference + override or inline text) and
 /// substitutes runtime tokens:
 /// - {content} and {content.field} - the subject's working copy (deltas folded in);
+/// - {target} and {target.field} - the working copy of the draft an analysis names as its
+///   target, so a prompt can read what earlier actions built on the copy rather than on the
+///   item the iteration started from (nothing when the analysis declares no target);
 /// - {lookup:name} / {lookup:name[col,col]} - reference data from the run's lookup bundle,
 ///   enabled records only, stable order, size-guarded (so prompts stop pasting tag lists);
 /// - {collection:$run.name} / {collection:$run.name[field,field]} - a collection's digests.
@@ -27,6 +30,7 @@ public class PromptBuilder
     private static readonly Regex _lookupToken = new(@"\{lookup:(?<name>[a-zA-Z]+)(\[(?<cols>[^\]]+)\])?\}", RegexOptions.Compiled);
     private static readonly Regex _collectionToken = new(@"\{collection:(?<name>\$run\.[a-zA-Z0-9_-]+)(\[(?<cols>[^\]]+)\])?\}", RegexOptions.Compiled);
     private static readonly Regex _contentFieldToken = new(@"\{content\.(?<field>[a-zA-Z.]+)\}", RegexOptions.Compiled);
+    private static readonly Regex _targetFieldToken = new(@"\{target\.(?<field>[a-zA-Z.]+)\}", RegexOptions.Compiled);
 
     private readonly AutomationDefinition _definition;
     private readonly LookupModel? _lookups;
@@ -69,12 +73,21 @@ public class PromptBuilder
     /// <summary>
     /// Substitute runtime tokens into resolved prompt text for the specified subject.
     /// When the text carries no {content} token and a subject exists, the working copy is
-    /// appended as a '## News Story' section so the model always sees the item.
+    /// appended as a '## News Story' section so the model always sees the item. The optional
+    /// target is a second working copy (a draft the analysis names) read by the {target} tokens;
+    /// it never triggers the appended section - the target is only ever placed explicitly.
     /// </summary>
-    public string Substitute(string text, ContentEntry? subject, bool appendSubject = true)
+    public string Substitute(string text, ContentEntry? subject, ContentEntry? target = null, bool appendSubject = true)
     {
         var result = _lookupToken.Replace(text, match => RenderLookup(match.Groups["name"].Value, SplitColumns(match)));
         result = _collectionToken.Replace(result, match => RenderCollection(match.Groups["name"].Value, SplitColumns(match)));
+
+        // The field tokens go first so '{target}' cannot swallow the '{target.field}' ones. With
+        // no target (none declared, or the draft does not exist yet) they resolve to nothing
+        // rather than reaching the model as literal text.
+        result = _targetFieldToken.Replace(result, match => target?.GetField(match.Groups["field"].Value) ?? "");
+        if (result.Contains("{target}"))
+            result = result.Replace("{target}", target?.ToWorkingJson(_jsonOptions) ?? "");
 
         if (subject != null)
         {

--- a/services/net/automation/Engine/ValueResolver.cs
+++ b/services/net/automation/Engine/ValueResolver.cs
@@ -27,7 +27,9 @@ public static class ValueResolver
         if (source.Literal.HasValue)
             return ElementToString(source.Literal.Value);
         if (!string.IsNullOrWhiteSpace(source.Template))
-            return prompts.Substitute(source.Template!, null) is var text && target != null
+            // The target goes in so '{target.field}' resolves in an action template exactly as
+            // '{content.field}' does here - both read the entry the action acts on.
+            return prompts.Substitute(source.Template!, null, target) is var text && target != null
                 ? SubstituteFields(text, target)
                 : text;
         return null;


### PR DESCRIPTION
An analysis always substituted {content.*} against the step's subject, so a prompt feeding an action that targets a draft described the item the iteration started from rather than the copy the step was building. In BC Calendar the format prompt's {content.tags} rendered the original's empty tag list instead of the codes the preceding tags action had just stamped on the draft.

An analysis can now name a target draft. {target} / {target.field} read that draft's working copy (deltas folded in); {content} / {content.field} keep meaning the step's subject in every case, so no existing prompt changes meaning. With no target - or a draft that does not exist yet - the target tokens render as nothing rather than reaching the model as literal text, and an unresolved draft is recorded in the decision log.

- AnalysisDefinition.Target, validated against the content.create actions the step declares. Position is not checked: an analysis runs where the action consuming it runs, not at a position of its own.
- Warn when a prompt uses a {target} token but the analysis has no target, since the token would silently render as nothing.
- Editor: Target picker beside LLM Override (shown only for steps that create drafts), a {target.*} insert group in both token modals, and a Target column in the analyses grid.
- Substitute the subject on chained turns too. Turn 2+ passed a null subject, which left {content.*} in the prompt as literal text; appendSubject already keeps the story from being appended twice.
- Pass the action's target through value templates so {target.field} resolves there exactly as {content.field} does.