### PR TITLE
Stamp content actions with a value

### DIFF
--- a/api/net/Areas/Admin/Controllers/AutomationController.cs
+++ b/api/net/Areas/Admin/Controllers/AutomationController.cs
@@ -37,6 +37,7 @@ public class AutomationController : ControllerBase
     private readonly IAutomationRunLogService _runLogService;
     private readonly ILLMService _llmService;
     private readonly IContentService _contentService;
+    private readonly IActionService _actionService;
     private readonly IEventScheduleService _eventScheduleService;
     private readonly System.Net.Http.IHttpClientFactory _httpClientFactory;
     private readonly System.Text.Json.JsonSerializerOptions _serializerOptions;
@@ -54,6 +55,7 @@ public class AutomationController : ControllerBase
     /// <param name="runLogService"></param>
     /// <param name="llmService"></param>
     /// <param name="contentService"></param>
+    /// <param name="actionService"></param>
     /// <param name="eventScheduleService"></param>
     /// <param name="httpClientFactory"></param>
     /// <param name="serializerOptions"></param>
@@ -66,6 +68,7 @@ public class AutomationController : ControllerBase
         IAutomationRunLogService runLogService,
         ILLMService llmService,
         IContentService contentService,
+        IActionService actionService,
         IEventScheduleService eventScheduleService,
         System.Net.Http.IHttpClientFactory httpClientFactory,
         IOptions<System.Text.Json.JsonSerializerOptions> serializerOptions,
@@ -78,6 +81,7 @@ public class AutomationController : ControllerBase
         _runLogService = runLogService;
         _llmService = llmService;
         _contentService = contentService;
+        _actionService = actionService;
         _eventScheduleService = eventScheduleService;
         _httpClientFactory = httpClientFactory;
         _serializerOptions = serializerOptions.Value;
@@ -1122,7 +1126,7 @@ public class AutomationController : ControllerBase
             try
             {
                 var candidate = AutomationDefinition.Parse(request!.CompareDefinition!);
-                var candidateErrors = AutomationDefinitionValidator.Validate(candidate).Where(e => e.Severity == "error").ToArray();
+                var candidateErrors = AutomationDefinitionValidator.Validate(candidate, GetContentActionSpecs()).Where(e => e.Severity == "error").ToArray();
                 if (candidateErrors.Length > 0) return BadRequest(new { errors = candidateErrors });
                 compareDefinition = System.Text.Json.JsonDocument.Parse(request.CompareDefinition!);
             }
@@ -1397,7 +1401,7 @@ public class AutomationController : ControllerBase
         try
         {
             var definition = AutomationDefinition.Parse(model.Definition!);
-            return new JsonResult(AutomationDefinitionValidator.Validate(definition));
+            return new JsonResult(AutomationDefinitionValidator.Validate(definition, GetContentActionSpecs()));
         }
         catch (System.Text.Json.JsonException ex)
         {
@@ -1675,6 +1679,13 @@ public class AutomationController : ControllerBase
         }
         sb.AppendLine();
     }
+
+    /// <summary>
+    /// The content actions a definition may reference, with what each one stores. The catalog
+    /// only knows a field holds an action id; the value type lives in the database.
+    /// </summary>
+    private IEnumerable<ContentActionSpec> GetContentActionSpecs()
+        => _actionService.FindAll().Select(a => new ContentActionSpec(a.Id, a.Name, a.ValueType)).ToArray();
 
     /// <summary>
     /// Validate a profile definition at save. Only malformed JSON blocks the save - a

--- a/app/editor/src/features/admin/automation/AutomationProfileForm.tsx
+++ b/app/editor/src/features/admin/automation/AutomationProfileForm.tsx
@@ -68,6 +68,7 @@ import {
   buildProfileForExport,
   buildProfileForSave,
   createDefaultSchedule,
+  findMissingContentActionValues,
   findOptionByValue,
   formatRunTime,
   formatScheduleWeekDays,
@@ -497,6 +498,19 @@ const AutomationProfileForm: React.FC = () => {
 
   const handleSubmit = async (values: IAutomationProfileModel) => {
     try {
+      // A content action that records a value is meaningless stamped without one, and the
+      // engine skips such a stamp at run time - so it is caught here, not discovered in a run.
+      const missingValues = findMissingContentActionValues(
+        parseDefinition(values.definition),
+        actionDescriptors,
+        actions,
+      );
+      if (missingValues.length > 0) {
+        toast.error(
+          `Set the value each content action stores before saving: ${missingValues.join('; ')}.`,
+        );
+        return;
+      }
       const profileToSave = buildProfileForSave(values);
 
       const originalId = values.id;
@@ -882,6 +896,7 @@ const AutomationProfileForm: React.FC = () => {
                         reportOptions={reportOptions}
                         notificationOptions={notificationOptions}
                         actionOptions={actionOptions}
+                        contentActions={actions}
                         onValidate={async (definition) =>
                           api.validateProfile({ ...values, definition })
                         }

--- a/app/editor/src/features/admin/automation/designer/ActionEditor.tsx
+++ b/app/editor/src/features/admin/automation/designer/ActionEditor.tsx
@@ -1,8 +1,18 @@
 import React from 'react';
-import { Checkbox, Col, type IOptionItem, Row, Select, Show, Text } from 'tno-core';
+import {
+  Checkbox,
+  Col,
+  type IActionModel,
+  type IOptionItem,
+  Row,
+  Select,
+  Show,
+  Text,
+  ValueType,
+} from 'tno-core';
 
 import { contentFieldOptionItems } from '../constants';
-import { createOption, findOptionByValue, toNumberOrUndefined } from '../utils';
+import { createOption, findOptionByValue, hasValueSource, toNumberOrUndefined } from '../utils';
 import { ComboBox } from './ComboBox';
 import { ConditionBuilder } from './ConditionBuilder';
 import { contentTokenFieldOptions, copyFieldOptions, fitSelectWidth } from './constants';
@@ -14,6 +24,7 @@ import {
   type IAutomationActionDescriptor,
   type IAutomationAnalysis,
   type IAutomationFieldSpec,
+  type IAutomationValueSource,
 } from './interfaces';
 import { ScopedNameField } from './ScopedNameField';
 import { kindHelp, ValueSourceEditor } from './ValueSourceEditor';
@@ -39,6 +50,24 @@ const getGate = (action: IAutomationAction, dedupeRefs: string[]): string => {
     return 'condition';
   }
   return 'always';
+};
+
+/** A boolean stamp's stored value; unset means 'true' - the flag is applied. */
+const isStampChecked = (value?: IAutomationValueSource | null): boolean => {
+  const literal = value?.literal;
+  if (literal === undefined || literal === null) return true;
+  return `${literal}`.trim().toLowerCase() !== 'false';
+};
+
+/**
+ * The value a newly picked content action starts with: a yes/no flag is stamped on, and an
+ * action that records a value starts from its own configured default.
+ */
+const initialStampValue = (picked?: IActionModel): IAutomationValueSource => {
+  if (!picked || picked.valueType === ValueType.Boolean) return { literal: true };
+  const fallback = picked.defaultValue?.trim() ?? '';
+  const numeric = fallback !== '' && !Number.isNaN(Number(fallback)) ? Number(fallback) : fallback;
+  return { literal: numeric };
 };
 
 const truncateToText = (truncate?: Record<string, number> | null): string =>
@@ -74,6 +103,8 @@ export interface IActionEditorProps {
   reportOptions: IOptionItem[];
   notificationOptions: IOptionItem[];
   actionOptions: IOptionItem[];
+  /** The content actions themselves; the stamped value's control follows their value type. */
+  contentActions: IActionModel[];
   promptNames: string[];
   onChange: (action: IAutomationAction) => void;
 }
@@ -96,6 +127,7 @@ export const ActionEditor: React.FC<IActionEditorProps> = ({
   reportOptions,
   notificationOptions,
   actionOptions,
+  contentActions,
   promptNames,
   onChange,
 }) => {
@@ -215,11 +247,63 @@ export const ActionEditor: React.FC<IActionEditorProps> = ({
             width="20rem"
             options={actionOptions}
             value={findOptionByValue(actionOptions, action.contentAction) ?? ''}
-            onChange={(newValue) =>
-              set({ contentAction: toNumberOrUndefined(newValue as IOptionItem) })
-            }
+            onChange={(newValue) => {
+              const contentAction = toNumberOrUndefined(newValue as IOptionItem);
+              // What the stamp stores depends on which flag it is, so a different flag starts
+              // from that flag's own default rather than keeping the previous one's value.
+              if (contentAction === action.contentAction) {
+                set({ contentAction });
+                return;
+              }
+              set({
+                contentAction,
+                value: contentAction
+                  ? initialStampValue(contentActions.find((a) => a.id === contentAction))
+                  : null,
+              });
+            }}
           />
         );
+      case 'contentActionValue': {
+        // The control is the picked flag's: nothing to configure until one is picked.
+        if (!action.contentAction) return null;
+        const picked = contentActions.find((a) => a.id === action.contentAction);
+        if (!picked || picked.valueType === ValueType.Boolean)
+          return (
+            <div key={key} className="frm-in">
+              <label>Value</label>
+              <div className="checkbox-inline">
+                <Checkbox
+                  name={key}
+                  label="Stamp as checked"
+                  checked={isStampChecked(action.value)}
+                  onChange={(e) => set({ value: { literal: e.target.checked } })}
+                />
+              </div>
+              <p className="automation-field-help">
+                {"Unchecked stores 'false', which shows the flag as cleared on the item."}
+              </p>
+            </div>
+          );
+        const missing = !hasValueSource(action.value);
+        return (
+          <div key={key} className="automation-field-wide frm-in">
+            <label className="required">{picked.valueLabel?.trim() || 'Value'}</label>
+            <ValueSourceEditor
+              name={key}
+              value={action.value}
+              fromSuggestions={valueRefs}
+              onChange={(value) => set({ value })}
+            />
+            <p className={`automation-field-help${missing ? ' automation-field-error' : ''}`}>
+              {`'${picked.name}' records a ${picked.valueType.toLowerCase()} value` +
+                (missing
+                  ? ' - it needs one to stamp, and the profile will not save without it.'
+                  : '.')}
+            </p>
+          </div>
+        );
+      }
       case 'contentField':
         return (
           <Select

--- a/app/editor/src/features/admin/automation/designer/AutomationDesigner.tsx
+++ b/app/editor/src/features/admin/automation/designer/AutomationDesigner.tsx
@@ -11,7 +11,17 @@ import {
   FaTrash,
 } from 'react-icons/fa';
 import { toast } from 'react-toastify';
-import { Button, ButtonVariant, Col, type IOptionItem, Modal, Row, Show, TextArea } from 'tno-core';
+import {
+  Button,
+  ButtonVariant,
+  Col,
+  type IActionModel,
+  type IOptionItem,
+  Modal,
+  Row,
+  Show,
+  TextArea,
+} from 'tno-core';
 
 import { SectionInfoButton } from '../SectionInfoButton';
 import { StrictModeDroppable } from '../StrictModeDroppable';
@@ -46,6 +56,8 @@ export interface IAutomationDesignerProps {
   reportOptions: IOptionItem[];
   notificationOptions: IOptionItem[];
   actionOptions: IOptionItem[];
+  /** The content actions themselves; a stamp's value control follows their value type. */
+  contentActions: IActionModel[];
   /** Validate the current definition against the catalog (server-side). */
   onValidate?: (definition: string) => Promise<IAutomationValidationError[]>;
 }
@@ -87,6 +99,7 @@ export const AutomationDesigner: React.FC<IAutomationDesignerProps> = ({
   reportOptions,
   notificationOptions,
   actionOptions,
+  contentActions,
   onValidate,
 }) => {
   const definition = React.useMemo(() => parseDefinition(value), [value]);
@@ -1041,6 +1054,7 @@ export const AutomationDesigner: React.FC<IAutomationDesignerProps> = ({
                 reportOptions={reportOptions}
                 notificationOptions={notificationOptions}
                 actionOptions={actionOptions}
+                contentActions={contentActions}
                 promptNames={promptNames}
                 onChange={(draft) =>
                   setActionModal((state) => (state ? { ...state, draft } : state))

--- a/app/editor/src/features/admin/automation/styled/AutomationProfileForm.tsx
+++ b/app/editor/src/features/admin/automation/styled/AutomationProfileForm.tsx
@@ -1419,6 +1419,14 @@ export const AutomationModalStyles = createGlobalStyle`
     font-size: 0.8rem;
     color: #667085;
   }
+  .automation-field-help.automation-field-error {
+    color: #912018;
+  }
+  /* Hand-rolled labels mark a required field the way tno-core's own fields do. */
+  .automation-action-fields label.required::after {
+    content: ' *';
+    color: #912018;
+  }
   .automation-badge {
     display: inline-block;
     padding: 0.05rem 0.5rem;

--- a/app/editor/src/features/admin/automation/utils/contentActionValues.ts
+++ b/app/editor/src/features/admin/automation/utils/contentActionValues.ts
@@ -1,0 +1,72 @@
+import { type IActionModel, ValueType } from 'tno-core';
+
+import {
+  type IAutomationAction,
+  type IAutomationActionDescriptor,
+  type IAutomationDefinition,
+  type IAutomationValueSource,
+} from '../designer/interfaces';
+
+/** The catalog field kind whose control follows the picked content action's own value type. */
+export const CONTENT_ACTION_VALUE_KIND = 'contentActionValue';
+
+/**
+ * Whether a value source actually supplies something. An empty literal, a blank reference, or a
+ * blank template is the editor's 'not filled in yet' shape, not a value. Mirrors the server-side
+ * validator so the editor and the API agree on what counts as missing.
+ */
+export const hasValueSource = (value?: IAutomationValueSource | null): boolean => {
+  if (!value) return false;
+  if (value.from?.trim()) return true;
+  if (value.template?.trim()) return true;
+  if (value.literal === undefined || value.literal === null) return false;
+  return `${value.literal}`.trim() !== '';
+};
+
+/** The content action an action stamps, when it stamps one. */
+export const findContentAction = (
+  action: IAutomationAction,
+  contentActions: IActionModel[],
+): IActionModel | undefined =>
+  action.contentAction ? contentActions.find((a) => a.id === action.contentAction) : undefined;
+
+/**
+ * Whether the action stamps a content action that records a value of its own (Commentary's
+ * timeout, for example) rather than a plain yes/no flag — those need a value to stamp.
+ */
+export const requiresContentActionValue = (
+  action: IAutomationAction,
+  descriptor: IAutomationActionDescriptor | undefined,
+  contentActions: IActionModel[],
+): boolean => {
+  if (!descriptor?.fields.some((field) => field.kind === CONTENT_ACTION_VALUE_KIND)) return false;
+  const picked = findContentAction(action, contentActions);
+  return !!picked && picked.valueType !== ValueType.Boolean;
+};
+
+/**
+ * Every stamp missing the value its content action stores, labelled 'step › action (flag)' for
+ * the save-time message.
+ */
+export const findMissingContentActionValues = (
+  definition: IAutomationDefinition,
+  descriptors: IAutomationActionDescriptor[],
+  contentActions: IActionModel[],
+): string[] =>
+  definition.steps.flatMap((step) =>
+    step.actions
+      .filter((action) => {
+        const descriptor = descriptors.find((d) => d.type === action.type);
+        return (
+          requiresContentActionValue(action, descriptor, contentActions) &&
+          !hasValueSource(action.value)
+        );
+      })
+      .map((action) => {
+        const descriptor = descriptors.find((d) => d.type === action.type);
+        const label = action.name || descriptor?.label || action.type;
+        return `${step.name || 'step'} › ${label} (${
+          findContentAction(action, contentActions)?.name
+        })`;
+      }),
+  );

--- a/app/editor/src/features/admin/automation/utils/index.ts
+++ b/app/editor/src/features/admin/automation/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './buildProfileForExport';
 export * from './buildProfileForSave';
+export * from './contentActionValues';
 export * from './createDefaultSchedule';
 export * from './createOption';
 export * from './findOptionByValue';

--- a/app/editor/src/test-vitest/components/automation/ActionEditorGates.test.tsx
+++ b/app/editor/src/test-vitest/components/automation/ActionEditorGates.test.tsx
@@ -30,6 +30,7 @@ describe('ActionEditor dedupe gates', () => {
           reportOptions={[]}
           notificationOptions={[]}
           actionOptions={[]}
+          contentActions={[]}
           promptNames={[]}
           onChange={() => {}}
         />

--- a/libs/net/models/Areas/Admin/Automation/ActionCatalog.cs
+++ b/libs/net/models/Areas/Admin/Automation/ActionCatalog.cs
@@ -30,7 +30,9 @@ public record ActionDescriptor(
 /// FieldSpec record, one configuration field of an action type.
 /// Kind drives the editor control: 'filter', 'collection', 'string', 'int', 'bool', 'condition',
 /// 'valueSource', 'valueMap', 'fields', 'truncateMap', 'contentField', 'report', 'notification',
-/// 'contentAction', 'item', 'draft', or 'enum:a|b|c'.
+/// 'contentAction', 'contentActionValue', 'item', 'draft', or 'enum:a|b|c'.
+/// 'contentActionValue' is a value source whose control follows the picked content action's own
+/// value type: a true/false toggle for a boolean action, the full value source for the rest.
 /// </summary>
 /// <param name="Name">The ActionDefinition property (camelCase, as serialized).</param>
 /// <param name="Kind">The field kind.</param>
@@ -173,9 +175,10 @@ public static class ActionCatalog
         new ActionDescriptor("content.action", "Apply Content Action", "content", true, true, false, _process, new[]
         {
             new FieldSpec("contentAction", "contentAction", true),
+            new FieldSpec("value", "contentActionValue", false, "What the action stores. A yes/no action stores true or false; an action that records a value (Commentary's timeout in days, for example) needs that value."),
             new FieldSpec("target", "draft", false, "A draft created by an earlier Create Content action in this step; leave empty for the original item."),
         },
-            Description: "Stamps a content action (editorial flag) on the item. 'contentAction' picks the flag; 'target' stamps a draft (a new content item produced by an earlier Create Content action in this step) instead. The item must already exist in the database."),
+            Description: "Stamps a content action (editorial flag) on the item. 'contentAction' picks the flag and 'value' supplies what it stores: a yes/no action stores true or false, while an action that records a value (Commentary's timeout in days, for example) takes it from an analysis result, a literal, or a template - such an action stamps nothing when no value resolves. 'target' stamps a draft (a new content item produced by an earlier Create Content action in this step) instead. The item must already exist in the database."),
         new ActionDescriptor("content.publish", "Publish Content", "content", true, false, false, _process, new[]
         {
             new FieldSpec("target", "draft", false, "A draft created by an earlier Create Content action in this step; leave empty for the original item."),
@@ -230,8 +233,9 @@ public static class ActionCatalog
             new FieldSpec("minScore", "int", false, "Keep every item scoring at or above this value, however many that is. Leave empty to select a fixed count with 'take' instead."),
             new FieldSpec("into", "collection", false, "Collection the selected items are written to."),
             new FieldSpec("contentAction", "contentAction", false, "Content action stamped on each selected item."),
+            new FieldSpec("value", "contentActionValue", false, "What the stamped content action stores. A yes/no action stores true or false; an action that records a value (Commentary's timeout in days, for example) needs that value."),
         },
-            Description: "Selects items from the scores a Score Content action recorded under 'objective'. No LLM is involved - it ranks the recorded scores highest first and breaks ties on the lowest content id, so the same scores always select the same items. Choose how many to keep: 'take' keeps a fixed count (the top 10); 'minScore' keeps every item scoring at or above a threshold, so a day with more good stories yields more selections; setting both keeps the qualifying items up to the 'take' cap. 'into' writes the selected items to a collection; 'contentAction' stamps an editorial flag on each. The run outcome and decision log name the selected items and report how many items carried each score."),
+            Description: "Selects items from the scores a Score Content action recorded under 'objective'. No LLM is involved - it ranks the recorded scores highest first and breaks ties on the lowest content id, so the same scores always select the same items. Choose how many to keep: 'take' keeps a fixed count (the top 10); 'minScore' keeps every item scoring at or above a threshold, so a day with more good stories yields more selections; setting both keeps the qualifying items up to the 'take' cap. 'into' writes the selected items to a collection; 'contentAction' stamps an editorial flag on each and 'value' supplies what that flag stores (true/false for a yes/no action, otherwise the value it records - a literal is the usual choice here, since the selection runs after the per-item analyses). The run outcome and decision log name the selected items and report how many items carried each score."),
         new ActionDescriptor("report.run", "Run Report", "distribute", false, true, false, _once, new[]
         {
             new FieldSpec("report", "report", true),

--- a/libs/net/models/Areas/Admin/Automation/AutomationDefinitionValidator.cs
+++ b/libs/net/models/Areas/Admin/Automation/AutomationDefinitionValidator.cs
@@ -10,6 +10,16 @@ namespace TNO.API.Areas.Admin.Models.Automation;
 public record ValidationError(string Path, string Message, string Severity = "error");
 
 /// <summary>
+/// ContentActionSpec record, the part of a content action a definition can be validated against.
+/// The catalog knows a field holds a content action id; only the database knows what that action
+/// stores, so the caller supplies these when it can reach the lookups.
+/// </summary>
+/// <param name="Id">The action id a definition references.</param>
+/// <param name="Name">Display name, for the finding's message.</param>
+/// <param name="ValueType">What the action stores.</param>
+public record ContentActionSpec(int Id, string Name, TNO.Entities.ValueType ValueType);
+
+/// <summary>
 /// AutomationDefinitionValidator class, validates a definition document against the action
 /// catalog and its own internal references, so configuration errors surface at save rather than
 /// in a run.
@@ -21,10 +31,13 @@ public static class AutomationDefinitionValidator
     /// warnings block.
     /// </summary>
     /// <param name="definition"></param>
+    /// <param name="contentActions">The content actions the definition may reference; when supplied,
+    /// an action that stores a value is checked for one. Omitted, those checks are skipped.</param>
     /// <returns></returns>
-    public static List<ValidationError> Validate(AutomationDefinition definition)
+    public static List<ValidationError> Validate(AutomationDefinition definition, IEnumerable<ContentActionSpec>? contentActions = null)
     {
         var errors = new List<ValidationError>();
+        var contentActionsById = contentActions?.GroupBy(a => a.Id).ToDictionary(g => g.Key, g => g.First());
 
         if (definition.Steps.Count == 0)
             errors.Add(new("steps", "The definition has no steps."));
@@ -173,6 +186,16 @@ public static class AutomationDefinitionValidator
                     if (!HasField(action, field.Name))
                         errors.Add(new($"{path}.{field.Name}", $"Action '{action.Type}' requires '{field.Name}'."));
                 }
+
+                // A content action that stores a value needs one; without it the stamp is
+                // meaningless (a Commentary timeout of 'true' is not a number of days).
+                if (contentActionsById != null
+                    && descriptor.Fields.Any(f => f.Kind == "contentActionValue")
+                    && action.ContentAction.HasValue
+                    && contentActionsById.TryGetValue(action.ContentAction.Value, out var contentAction)
+                    && contentAction.ValueType != TNO.Entities.ValueType.Boolean
+                    && !HasValueSource(action.Value))
+                    errors.Add(new($"{path}.value", $"Content action '{contentAction.Name}' stores a {contentAction.ValueType.ToString().ToLower()} value; give the action a value to stamp."));
 
                 // Collection references.
                 foreach (var (name, value) in CollectionRefs(action))
@@ -351,6 +374,28 @@ public static class AutomationDefinitionValidator
             errors.Add(new(path, "A condition requires a leaf (field/op), a combinator (all/any/not), or an analysis gate (from)."));
         else if (shapes > 1)
             errors.Add(new(path, "A condition must be exactly one shape: a leaf, a combinator, or an analysis gate."));
+    }
+
+    /// <summary>
+    /// Whether a value source actually supplies something. An empty literal, a blank reference,
+    /// or a blank template is the editor's 'not filled in yet' shape, not a value.
+    /// </summary>
+    private static bool HasValueSource(ValueSource? value)
+    {
+        if (value == null) return false;
+        if (!string.IsNullOrWhiteSpace(value.From)) return true;
+        if (!string.IsNullOrWhiteSpace(value.Template)) return true;
+        if (value.Literal.HasValue)
+        {
+            var literal = value.Literal.Value;
+            return literal.ValueKind switch
+            {
+                System.Text.Json.JsonValueKind.String => !string.IsNullOrWhiteSpace(literal.GetString()),
+                System.Text.Json.JsonValueKind.Null or System.Text.Json.JsonValueKind.Undefined => false,
+                _ => true,
+            };
+        }
+        return false;
     }
 
     private static bool HasField(ActionDefinition action, string name) => name switch

--- a/libs/net/tests/dal/Automation/AutomationDefinitionValidatorTest.cs
+++ b/libs/net/tests/dal/Automation/AutomationDefinitionValidatorTest.cs
@@ -296,6 +296,39 @@ public class AutomationDefinitionValidatorTest
         Assert.DoesNotContain(errors, e => e.Severity == "warning" && e.Message.Contains("[GO]"));
     }
 
+    /// <summary>
+    /// A content action that records a value ('Commentary' keeps a timeout) is meaningless stamped
+    /// without one - but only the database knows which actions those are, so the finding depends
+    /// on the caller supplying the lookups.
+    /// </summary>
+    [Fact]
+    public void ContentActionStoringAValue_WithoutAValue_IsAnError()
+    {
+        var contentActions = new[]
+        {
+            new ContentActionSpec(4, "Top Story", TNO.Entities.ValueType.Boolean),
+            new ContentActionSpec(7, "Commentary", TNO.Entities.ValueType.String),
+        };
+        var definition = ValidDefinition();
+        definition.Steps[1].Actions.Add(new ActionDefinition { Type = "content.action", ContentAction = 7 });
+        Assert.Contains(AutomationDefinitionValidator.Validate(definition, contentActions),
+            e => e.Severity == "error" && e.Message.Contains("Commentary"));
+
+        // Without the lookups the value type is unknowable, so the check does not run at all.
+        Assert.DoesNotContain(AutomationDefinitionValidator.Validate(definition),
+            e => e.Message.Contains("Commentary"));
+
+        // A yes/no action needs no value, and a value satisfies the one that does.
+        definition.Steps[1].Actions[^1].Value = new ValueSource { Literal = System.Text.Json.JsonDocument.Parse("3").RootElement };
+        definition.Steps[1].Actions.Add(new ActionDefinition { Type = "content.action", ContentAction = 4 });
+        Assert.Empty(AutomationDefinitionValidator.Validate(definition, contentActions).Where(e => e.Severity == "error"));
+
+        // An empty literal is the editor's 'not filled in yet' shape, not a value.
+        definition.Steps[1].Actions[^2].Value = new ValueSource { Literal = System.Text.Json.JsonDocument.Parse("\"\"").RootElement };
+        Assert.Contains(AutomationDefinitionValidator.Validate(definition, contentActions),
+            e => e.Severity == "error" && e.Message.Contains("Commentary"));
+    }
+
     [Fact]
     public void DefinitionRoundTrip_PreservesShape()
     {

--- a/services/net/automation/Engine/AutomationEngine.cs
+++ b/services/net/automation/Engine/AutomationEngine.cs
@@ -1044,13 +1044,22 @@ public class AutomationEngine
                             $"Content action '{ContentActionName(action.ContentAction.Value, env.Lookups)}' is disabled; nothing was applied to {target.Key}.");
                         break;
                     }
+                    // An action that records a value ('Commentary' keeps a timeout in days) is
+                    // meaningless stamped with 'true', so a missing value skips the stamp loudly
+                    // rather than writing a value the editor cannot read back.
+                    var stampValue = ResolveContentActionValue(action.ContentAction.Value, value, env.Lookups);
+                    if (stampValue == null)
+                    {
+                        env.Log.LogDecision(step.Name, actionName, action.Type, contentId, Outcomes.Skipped,
+                            $"Content action '{ContentActionName(action.ContentAction.Value, env.Lookups)}' stores a value and none was configured; nothing was applied to {target.Key}.");
+                        break;
+                    }
                     lock (target.Deltas)
                     {
-                        if (!target.Deltas.ContentActionIds.Contains(action.ContentAction.Value))
-                            target.Deltas.ContentActionIds.Add(action.ContentAction.Value);
+                        target.Deltas.ContentActions[action.ContentAction.Value] = stampValue;
                     }
-                    RecordChange("add-action", target, ContentActionName(action.ContentAction.Value, env.Lookups), action.ContentAction.Value.ToString());
-                    LogExecuted($"Applied content action '{ContentActionName(action.ContentAction.Value, env.Lookups)}' to {target.Key}.");
+                    RecordChange("add-action", target, ContentActionName(action.ContentAction.Value, env.Lookups), stampValue);
+                    LogExecuted($"Applied content action '{ContentActionName(action.ContentAction.Value, env.Lookups)}' = '{stampValue}' to {target.Key}.");
                     break;
                 }
             case "content.publish":
@@ -1283,18 +1292,26 @@ public class AutomationEngine
                     if (action.ContentAction.HasValue && !stampAction)
                         env.Log.LogDecision(step.Name, actionName, action.Type, null, Outcomes.Skipped,
                             $"Content action '{contentActionName}' is disabled; the selected items were not stamped with it.");
+                    // Every selected item is stamped with the same value: the selection runs after
+                    // the per-item analyses, so a literal is what normally resolves here.
+                    var selectionStampValue = stampAction ? ResolveContentActionValue(action.ContentAction!.Value, value, env.Lookups) : null;
+                    if (stampAction && selectionStampValue == null)
+                    {
+                        stampAction = false;
+                        env.Log.LogDecision(step.Name, actionName, action.Type, null, Outcomes.Skipped,
+                            $"Content action '{contentActionName}' stores a value and none was configured; the selected items were not stamped with it.");
+                    }
                     var rank = 0;
                     foreach (var (entry, entryScore) in selected)
                     {
                         rank++;
-                        if (action.ContentAction.HasValue)
+                        if (stampAction)
                         {
                             lock (entry.Deltas)
                             {
-                                if (!entry.Deltas.ContentActionIds.Contains(action.ContentAction.Value))
-                                    entry.Deltas.ContentActionIds.Add(action.ContentAction.Value);
+                                entry.Deltas.ContentActions[action.ContentAction!.Value] = selectionStampValue!;
                             }
-                            RecordChange("add-action", entry, contentActionName, action.ContentAction.Value.ToString());
+                            RecordChange("add-action", entry, contentActionName, selectionStampValue);
                         }
                         if (!string.IsNullOrWhiteSpace(action.Into))
                         {
@@ -1414,6 +1431,21 @@ public class AutomationEngine
     /// </summary>
     private static string ContentActionName(int id, LookupModel? lookups)
         => lookups?.Actions.FirstOrDefault(a => a.Id == id)?.Name ?? $"action {id}";
+
+    /// <summary>
+    /// The value a content action stamp stores. A yes/no action stores 'true' unless the action's
+    /// configured value resolves to a boolean; an action that records a value (a Commentary
+    /// timeout, say) stores whatever resolved, falling back to the action's own default value.
+    /// Null means there is nothing worth stamping - the caller skips the stamp and says why.
+    /// </summary>
+    private static string? ResolveContentActionValue(int id, string? resolved, LookupModel? lookups)
+    {
+        var definition = lookups?.Actions.FirstOrDefault(a => a.Id == id);
+        if (definition == null || definition.ValueType == Entities.ValueType.Boolean)
+            return bool.TryParse(resolved?.Trim(), out var flag) ? (flag ? "true" : "false") : "true";
+        if (!string.IsNullOrWhiteSpace(resolved)) return resolved!.Trim();
+        return !string.IsNullOrWhiteSpace(definition.DefaultValue) ? definition.DefaultValue : null;
+    }
 
     /// <summary>
     /// Whether a content action may still be applied. A profile keeps the id it was authored with,
@@ -1702,7 +1734,7 @@ public class AutomationEngine
                 if (entry.Deltas.Tags.Count > 0) parts.Add($"{entry.Deltas.Tags.Count} tag(s)");
                 if (entry.Deltas.Sentiment.HasValue) parts.Add("sentiment");
                 if (entry.Deltas.ContributorId.HasValue) parts.Add("contributor");
-                if (entry.Deltas.ContentActionIds.Count > 0) parts.Add($"{entry.Deltas.ContentActionIds.Count} content action(s)");
+                if (entry.Deltas.ContentActions.Count > 0) parts.Add($"{entry.Deltas.ContentActions.Count} content action(s)");
                 if (entry.Deltas.Status != null) parts.Add(entry.Deltas.Status);
                 pending = parts.Count > 0 ? string.Join("; ", parts) : "changes";
             }
@@ -1852,15 +1884,19 @@ public class AutomationEngine
                 tonePools.Add(new ContentTonePoolModel { Id = _options.DefaultTonePoolId, ContentId = content.Id, Value = entry.Deltas.Sentiment.Value });
                 content.TonePools = tonePools;
             }
-            foreach (var actionId in entry.Deltas.ContentActionIds.Distinct())
+            foreach (var (actionId, actionValue) in entry.Deltas.ContentActions)
             {
                 // Defence in depth: the request sites already refuse a disabled action, so a
                 // delta reaching here disabled means it was disabled mid-run. Never write it.
                 var definition = env.Lookups?.Actions.FirstOrDefault(a => a.Id == actionId && a.IsEnabled);
                 if (definition == null) continue;
-                var value = definition.ValueType == Entities.ValueType.Boolean
-                    ? "true"
-                    : (!string.IsNullOrWhiteSpace(definition.DefaultValue) ? definition.DefaultValue : "true");
+                // The stamping action resolved the value; the fallbacks only cover a delta that
+                // somehow arrived without one.
+                var value = !string.IsNullOrWhiteSpace(actionValue)
+                    ? actionValue
+                    : (definition.ValueType == Entities.ValueType.Boolean
+                        ? "true"
+                        : (!string.IsNullOrWhiteSpace(definition.DefaultValue) ? definition.DefaultValue : "true"));
                 var actions = content.Actions.ToList();
                 var existing = actions.FirstOrDefault(a => a.Id == actionId);
                 if (existing != null) existing.Value = value;
@@ -1882,7 +1918,7 @@ public class AutomationEngine
         deltas.Sentiment = null;
         deltas.ContributorId = null;
         deltas.ContributorName = null;
-        deltas.ContentActionIds.Clear();
+        deltas.ContentActions.Clear();
         deltas.Status = null;
     }
 
@@ -2028,8 +2064,8 @@ public class AutomationEngine
                 written.Add($"sentiment ({entry.Deltas.Sentiment.Value})");
             if (entry.Deltas.ContributorId.HasValue)
                 written.Add($"contributor ({entry.Deltas.ContributorName ?? entry.Deltas.ContributorId.Value.ToString()})");
-            if (entry.Deltas.ContentActionIds.Count > 0)
-                written.Add($"actions ({string.Join(", ", entry.Deltas.ContentActionIds.Distinct().Select(id => ContentActionName(id, lookups)))})");
+            if (entry.Deltas.ContentActions.Count > 0)
+                written.Add($"actions ({string.Join(", ", entry.Deltas.ContentActions.Keys.Select(id => ContentActionName(id, lookups)))})");
             if (entry.Deltas.Status != null)
                 written.Add($"status ({entry.Deltas.Status})");
         }

--- a/services/net/automation/Engine/RunContext.cs
+++ b/services/net/automation/Engine/RunContext.cs
@@ -117,10 +117,12 @@ public class Deltas
     public int? Sentiment { get; set; }
     public int? ContributorId { get; set; }
     public string? ContributorName { get; set; }
-    public List<int> ContentActionIds { get; } = new();
+    /// <summary>get - Content actions to stamp: action id -> the value it stores ('true' for a
+    /// yes/no action). A second stamp of the same action replaces the earlier value.</summary>
+    public Dictionary<int, string> ContentActions { get; } = new();
     /// <summary>'publish' or 'unpublish'; null when no status change is pending.</summary>
     public string? Status { get; set; }
-    public bool Dirty => Fields.Count > 0 || Tags.Count > 0 || Sentiment.HasValue || ContributorId.HasValue || ContentActionIds.Count > 0 || Status != null;
+    public bool Dirty => Fields.Count > 0 || Tags.Count > 0 || Sentiment.HasValue || ContributorId.HasValue || ContentActions.Count > 0 || Status != null;
 }
 
 /// <summary>


### PR DESCRIPTION
A content action stamp always wrote 'true' (or the action's default value), which is meaningless for an action that records a value of its own — a Commentary timeout is a number of days, not a flag.

- Add a 'value' field to the content.action and content.select actions, on a new 'contentActionValue' catalog kind whose editor control follows the picked action's value type: a true/false toggle for a boolean action, the full value source (analysis result, literal, or template) for the rest.
- Deltas carry action id -> value instead of a bare id list, so a later stamp of the same action replaces the earlier value.
- The engine skips the stamp and logs why when a value-storing action has no value to write, rather than writing one the editor cannot read back.
- The validator flags the same case at save; the API supplies the action value types from the database, since the catalog only knows a field holds an id.