### PR TITLE
Email out failure to run

### DIFF
--- a/api/net/Areas/Admin/Controllers/AutomationController.cs
+++ b/api/net/Areas/Admin/Controllers/AutomationController.cs
@@ -1422,6 +1422,7 @@ public class AutomationController : ControllerBase
     /// <param name="search"></param>
     /// <param name="page"></param>
     /// <param name="qty"></param>
+    /// <param name="direction"></param>
     /// <returns></returns>
     [HttpGet("runs/{runId}/logs")]
     [Produces(MediaTypeNames.Application.Json)]

--- a/libs/net/elastic/Extensions/RegexSettings.cs
+++ b/libs/net/elastic/Extensions/RegexSettings.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 
 namespace TNO.Elastic;
 
@@ -32,5 +32,13 @@ public static partial class RegexSettings
 
     [GeneratedRegex(@"\b\w+:/(\\/|[^/])*/")]
     public static partial Regex RemoveFieldedSearchRegex();
+
+    /// <summary>
+    /// An html tag or comment. Keyword marking is applied to the text between these and never
+    /// inside one - a mark written into an attribute value corrupts it, and an inline base64
+    /// image 'src' is a long enough run of letters that a short keyword lands in one regularly.
+    /// </summary>
+    [GeneratedRegex(@"(<!--.*?-->|</?[a-zA-Z][^>]*>)", RegexOptions.Singleline)]
+    public static partial Regex HtmlTagRegex();
     #endregion
 }

--- a/libs/net/elastic/Extensions/StringExtensions.cs
+++ b/libs/net/elastic/Extensions/StringExtensions.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Text.RegularExpressions;
 
 namespace TNO.Elastic;
@@ -17,6 +17,7 @@ public static class StringExtensions
     static readonly Regex RemoveSimpleKeywords = RegexSettings.RemoveSimpleKeywordsRegex();
     static readonly Regex RemoveAdvancedKeywords = RegexSettings.RemoveAdvancedKeywordsRegex();
     static readonly Regex RemoveFieldedSearch = RegexSettings.RemoveFieldedSearchRegex();
+    static readonly Regex HtmlTag = RegexSettings.HtmlTagRegex();
     #endregion
 
     #region Methods
@@ -172,24 +173,44 @@ public static class StringExtensions
     {
         const string highlightStyle = "background-color:#fff59e;color:inherit;";
         var values = String.Join("|", keywords.Where(v => !String.IsNullOrWhiteSpace(v)));
-        return Regex.Replace(text, $@"\b({values})", match =>
+        if (String.IsNullOrEmpty(text) || String.IsNullOrEmpty(values)) return text;
+
+        string MarkText(string value)
         {
-            var values = new List<string>();
-            for (var i = 0; i < match.Groups.Count; i++)
+            if (String.IsNullOrEmpty(value)) return value;
+            return Regex.Replace(value, $@"\b({values})", match =>
             {
-                values.Add(match.Groups[i].Value);
-            }
-            // Not clear why each match results in multiple groups even when only a single value is found.
-            values = values.Distinct().Where(v => !String.IsNullOrWhiteSpace(v)).ToList();
-            var result = String.Join("", values);
-            if (values.Count != 0)
-            {
-                if (!String.IsNullOrWhiteSpace(tagName) && !markRawTag && tagName.Equals("mark", StringComparison.OrdinalIgnoreCase))
-                    return $"<span style=\"{highlightStyle}\">{result}</span>";
-                return $"<{tagName}>{result}</{tagName}>";
-            }
-            return result;
-        }, RegexOptions.IgnoreCase);
+                var values = new List<string>();
+                for (var i = 0; i < match.Groups.Count; i++)
+                {
+                    values.Add(match.Groups[i].Value);
+                }
+                // Not clear why each match results in multiple groups even when only a single value is found.
+                values = values.Distinct().Where(v => !String.IsNullOrWhiteSpace(v)).ToList();
+                var result = String.Join("", values);
+                if (values.Count != 0)
+                {
+                    if (!String.IsNullOrWhiteSpace(tagName) && !markRawTag && tagName.Equals("mark", StringComparison.OrdinalIgnoreCase))
+                        return $"<span style=\"{highlightStyle}\">{result}</span>";
+                    return $"<{tagName}>{result}</{tagName}>";
+                }
+                return result;
+            }, RegexOptions.IgnoreCase);
+        }
+
+        // Only the readable text between tags is marked. A keyword that lands inside a tag would
+        // be rewritten into the markup itself - splitting an 'href', or an inline base64 image
+        // 'src', into an unusable value.
+        var marked = new StringBuilder(text.Length);
+        var index = 0;
+        foreach (Match tag in HtmlTag.Matches(text))
+        {
+            marked.Append(MarkText(text[index..tag.Index]));
+            marked.Append(tag.Value);
+            index = tag.Index + tag.Length;
+        }
+        marked.Append(MarkText(text[index..]));
+        return marked.ToString();
     }
     #endregion
 }

--- a/libs/net/template/ReportEngine.cs
+++ b/libs/net/template/ReportEngine.cs
@@ -1,9 +1,10 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.IO.Compression;
 using System.Net;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 using System.Xml;
 using CsvHelper.Configuration;
 using Microsoft.Extensions.Logging;
@@ -22,8 +23,24 @@ namespace TNO.TemplateEngine;
 /// <summary>
 /// ReportEngine class, provides a centralize collection of methods to generate reports and charts.
 /// </summary>
-public class ReportEngine : IReportEngine
+public partial class ReportEngine : IReportEngine
 {
+    #region Variables
+    /// <summary>
+    /// An &lt;img&gt; tag whose 'src' is an inline base64 data URI. The payload is worth hundreds of
+    /// kilobytes of prompt and carries nothing the model can read, so the whole tag is dropped.
+    /// </summary>
+    [GeneratedRegex("<img\\b[^>]*?\\bsrc\\s*=\\s*(?:\"\\s*data:[^\"]*?;base64,[^\"]*\"|'\\s*data:[^']*?;base64,[^']*')[^>]*>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex Base64ImageTagRegex();
+
+    /// <summary>
+    /// Any inline base64 payload the tag pattern does not cover - an unquoted 'src', a CSS
+    /// url(), a markdown image. Only the payload is dropped, so the surrounding markup still
+    /// tells the model an image was there.
+    /// </summary>
+    [GeneratedRegex("data:[\\w.+-]+/[\\w.+-]+;base64,[A-Za-z0-9+/=]+", RegexOptions.IgnoreCase)]
+    private static partial Regex Base64DataUriRegex();
+    #endregion
 
     #region Properties
     /// <summary>
@@ -731,6 +748,22 @@ public class ReportEngine : IReportEngine
     }
 
     /// <summary>
+    /// Strip inline base64 images out of 'html'.
+    /// An article body can carry an image as a data URI, which is megabytes of characters the
+    /// model cannot see and which crowds out the text it is being asked to summarize - and can
+    /// push the request past the deployment's context limit on its own.
+    /// </summary>
+    /// <param name="html"></param>
+    /// <returns>The html without any inline base64 image data.</returns>
+    public static string? RemoveBase64Images(string? html)
+    {
+        if (String.IsNullOrEmpty(html)) return html;
+
+        var result = Base64ImageTagRegex().Replace(html, "");
+        return Base64DataUriRegex().Replace(result, "");
+    }
+
+    /// <summary>
     /// Generate a dictionary contain the report minimized content items within each section.
     /// This is used by the AI summary.
     /// Each content item includes its 'id' and a ready-made 'url' so the prompt can link to the
@@ -749,7 +782,7 @@ public class ReportEngine : IReportEngine
                 id = c.Id,
                 url = viewContentUrl != null ? $"{viewContentUrl}{c.Id}" : null,
                 headline = c.Headline,
-                text = !String.IsNullOrWhiteSpace(c.Body) ? c.Body : c.Summary,
+                text = RemoveBase64Images(!String.IsNullOrWhiteSpace(c.Body) ? c.Body : c.Summary),
                 byline = c.Byline,
                 columnist = c.Contributor?.Name,
                 source = c.Source?.Name ?? c.OtherSource,

--- a/libs/net/tests/dal/Automation/AutomationDefinitionValidatorTest.cs
+++ b/libs/net/tests/dal/Automation/AutomationDefinitionValidatorTest.cs
@@ -42,7 +42,7 @@ public class AutomationDefinitionValidatorTest
     public void ValidDefinition_HasNoErrors()
     {
         var errors = AutomationDefinitionValidator.Validate(ValidDefinition());
-        Assert.Empty(errors.Where(e => e.Severity == "error"));
+        Assert.DoesNotContain(errors, e => e.Severity == "error");
     }
 
     /// <summary>A select-top action must say how much to keep: a count, a score threshold, or both.</summary>
@@ -64,7 +64,7 @@ public class AutomationDefinitionValidatorTest
         definition.Steps[1].Actions.Add(new ActionDefinition { Type = "score", Objective = "top-story", Value = new ValueSource { From = "triage.sentiment" } });
         definition.Steps[2].Actions.Add(new ActionDefinition { Type = "select-top", Objective = "top-story", MinScore = 7 });
         var errors = AutomationDefinitionValidator.Validate(definition);
-        Assert.Empty(errors.Where(e => e.Severity == "error"));
+        Assert.DoesNotContain(errors, e => e.Severity == "error");
     }
 
     /// <summary>An analysis target must name a draft the step actually creates.</summary>
@@ -86,7 +86,7 @@ public class AutomationDefinitionValidatorTest
         definition.Steps[1].Actions.Insert(0, new ActionDefinition { Type = "content.create", As = "$item.copy", CopyFrom = "$item" });
         definition.Steps[1].Analyses[0].Target = "$item.copy";
         var errors = AutomationDefinitionValidator.Validate(definition);
-        Assert.Empty(errors.Where(e => e.Severity == "error"));
+        Assert.DoesNotContain(errors, e => e.Severity == "error");
     }
 
     /// <summary>A '{target}' token with no target renders as nothing, which reads like the model
@@ -249,7 +249,7 @@ public class AutomationDefinitionValidatorTest
         definition.Steps[2].Source = new SourceDefinition { From = "collection", Collection = "$run.inbox" };
         definition.Steps[2].Actions.Add(new ActionDefinition { Type = "content.publish" });
         var errors = AutomationDefinitionValidator.Validate(definition);
-        Assert.Empty(errors.Where(e => e.Severity == "error"));
+        Assert.DoesNotContain(errors, e => e.Severity == "error");
     }
 
     [Fact]
@@ -321,7 +321,7 @@ public class AutomationDefinitionValidatorTest
         // A yes/no action needs no value, and a value satisfies the one that does.
         definition.Steps[1].Actions[^1].Value = new ValueSource { Literal = System.Text.Json.JsonDocument.Parse("3").RootElement };
         definition.Steps[1].Actions.Add(new ActionDefinition { Type = "content.action", ContentAction = 4 });
-        Assert.Empty(AutomationDefinitionValidator.Validate(definition, contentActions).Where(e => e.Severity == "error"));
+        Assert.DoesNotContain(AutomationDefinitionValidator.Validate(definition, contentActions), e => e.Severity == "error");
 
         // An empty literal is the editor's 'not filled in yet' shape, not a value.
         definition.Steps[1].Actions[^2].Value = new ValueSource { Literal = System.Text.Json.JsonDocument.Parse("\"\"").RootElement };
@@ -337,7 +337,7 @@ public class AutomationDefinitionValidatorTest
         Assert.Equal(definition.Steps.Count, reparsed.Steps.Count);
         Assert.Equal("triage", reparsed.Steps[1].Analyses[0].Name);
         Assert.Equal(100, reparsed.Steps[1].Actions[0].When!.Value!.Value.GetInt32());
-        Assert.Empty(AutomationDefinitionValidator.Validate(reparsed).Where(e => e.Severity == "error"));
+        Assert.DoesNotContain(AutomationDefinitionValidator.Validate(reparsed), static e => e.Severity == "error");
     }
     #endregion
 }

--- a/services/net/automation/AutomationManager.cs
+++ b/services/net/automation/AutomationManager.cs
@@ -1,11 +1,8 @@
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Confluent.Kafka;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using TNO.AI;
-using TNO.AI.Models;
 using TNO.Ches;
 using TNO.Ches.Configuration;
 using TNO.Elastic;
@@ -13,14 +10,8 @@ using TNO.Kafka;
 using TNO.Kafka.Models;
 using TNO.Services.Automation.Config;
 using TNO.Services.Managers;
-using AdminAutomationProfileModel = TNO.API.Areas.Admin.Models.Automation.AutomationProfileModel;
 using AdminAutomationRunModel = TNO.API.Areas.Admin.Models.Automation.AutomationRunModel;
 using AdminAutomationRunStatus = TNO.API.Areas.Admin.Models.Automation.AutomationRunStatus;
-using ContentActionModel = TNO.API.Areas.Services.Models.Content.ContentActionModel;
-using ContentModel = TNO.API.Areas.Services.Models.Content.ContentModel;
-using ContentTagModel = TNO.API.Areas.Services.Models.Content.ContentTagModel;
-using ContentTonePoolModel = TNO.API.Areas.Services.Models.Content.ContentTonePoolModel;
-using LLMModel = TNO.API.Areas.Services.Models.LLM.LLMModel;
 
 namespace TNO.Services.Automation;
 

--- a/services/net/automation/AutomationManager.cs
+++ b/services/net/automation/AutomationManager.cs
@@ -1,17 +1,9 @@
-using Confluent.Kafka;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
-using AdminAutomationProfileModel = TNO.API.Areas.Admin.Models.Automation.AutomationProfileModel;
-using AdminAutomationRunModel = TNO.API.Areas.Admin.Models.Automation.AutomationRunModel;
-using AdminAutomationRunStatus = TNO.API.Areas.Admin.Models.Automation.AutomationRunStatus;
-using ContentModel = TNO.API.Areas.Services.Models.Content.ContentModel;
-using ContentActionModel = TNO.API.Areas.Services.Models.Content.ContentActionModel;
-using ContentTagModel = TNO.API.Areas.Services.Models.Content.ContentTagModel;
-using ContentTonePoolModel = TNO.API.Areas.Services.Models.Content.ContentTonePoolModel;
-using LLMModel = TNO.API.Areas.Services.Models.LLM.LLMModel;
+using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using TNO.AI;
 using TNO.AI.Models;
 using TNO.Ches;
@@ -21,6 +13,14 @@ using TNO.Kafka;
 using TNO.Kafka.Models;
 using TNO.Services.Automation.Config;
 using TNO.Services.Managers;
+using AdminAutomationProfileModel = TNO.API.Areas.Admin.Models.Automation.AutomationProfileModel;
+using AdminAutomationRunModel = TNO.API.Areas.Admin.Models.Automation.AutomationRunModel;
+using AdminAutomationRunStatus = TNO.API.Areas.Admin.Models.Automation.AutomationRunStatus;
+using ContentActionModel = TNO.API.Areas.Services.Models.Content.ContentActionModel;
+using ContentModel = TNO.API.Areas.Services.Models.Content.ContentModel;
+using ContentTagModel = TNO.API.Areas.Services.Models.Content.ContentTagModel;
+using ContentTonePoolModel = TNO.API.Areas.Services.Models.Content.ContentTonePoolModel;
+using LLMModel = TNO.API.Areas.Services.Models.LLM.LLMModel;
 
 namespace TNO.Services.Automation;
 
@@ -393,6 +393,7 @@ public class AutomationManager : ServiceManager<AutomationOptions>
             run.Status = AdminAutomationRunStatus.Failed;
             run.CompletedOn = DateTime.UtcNow;
             run.Note = $"Run failed: {ex.Message}";
+            await this.SendErrorEmailAsync($"Automation run {run.Id} failed", ex);
         }
 
         // Persist status/note/completion first, then the (potentially very large) summary through


### PR DESCRIPTION
If a schedule fails due to a misconfiguration it currently only logs the error.  Now it will email out support staff.

Also resolve two related issues that occur with base64 images:
- We don't need to send base64 images to AI prompts.
- Reports that highlight keywords was breaking base64 images.