### PR TITLE
Fix automation service validation+email

### DIFF
--- a/api/net/Areas/Admin/Controllers/AutomationController.cs
+++ b/api/net/Areas/Admin/Controllers/AutomationController.cs
@@ -1689,16 +1689,21 @@ public class AutomationController : ControllerBase
         => _actionService.FindAll().Select(a => new ContentActionSpec(a.Id, a.Name, a.ValueType)).ToArray();
 
     /// <summary>
-    /// Validate a profile definition at save. Only malformed JSON blocks the save - a
-    /// work-in-progress definition with validation errors persists as a draft (the findings
-    /// panel and the run-time guard in the automation service cover invalid definitions).
+    /// Validate a profile definition at save. A definition that cannot run is not stored:
+    /// malformed JSON and any 'error' severity finding both block the save, so a saved profile
+    /// is always one the automation service will accept. Warnings do not block - they surface
+    /// in the designer's findings panel.
     /// </summary>
     private IActionResult? ValidateDefinition(AutomationProfileModel model)
     {
         if (model.SchemaVersion < 2 || string.IsNullOrWhiteSpace(model.Definition)) return null;
         try
         {
-            AutomationDefinition.Parse(model.Definition!);
+            var definition = AutomationDefinition.Parse(model.Definition!);
+            var errors = AutomationDefinitionValidator.Validate(definition, GetContentActionSpecs())
+                .Where(e => e.Severity == "error")
+                .ToArray();
+            if (errors.Length > 0) return BadRequest(new { errors });
             return null;
         }
         catch (System.Text.Json.JsonException ex)

--- a/app/editor/src/features/admin/automation/AutomationProfileForm.tsx
+++ b/app/editor/src/features/admin/automation/AutomationProfileForm.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable simple-import-sort/imports */
+import { type AxiosError } from 'axios';
 import { FormikForm } from 'components/formik';
 import moment from 'moment';
 import React from 'react';
@@ -63,6 +64,7 @@ import {
   collectFilterIds,
   collectLlmIds,
   remapDefinition,
+  type IAutomationValidationError,
 } from './designer';
 import {
   buildProfileForExport,
@@ -119,6 +121,8 @@ const AutomationProfileForm: React.FC = () => {
   const { toggle: toggleRunDetailModal, isShowing: isRunDetailModalShowing } = useModal();
   // The run pending deletion; also drives the confirmation modal's visibility.
   const [runDeleteState, setRunDeleteState] = React.useState<IAutomationRunModel | null>(null);
+  // The errors that blocked the last save attempt; also drives that modal's visibility.
+  const [saveErrors, setSaveErrors] = React.useState<IAutomationValidationError[] | null>(null);
   // The action catalog (fetched once); the designer renders action forms from it.
   const [actionDescriptors, setActionDescriptors] = React.useState<IAutomationActionDescriptor[]>(
     [],
@@ -513,6 +517,17 @@ const AutomationProfileForm: React.FC = () => {
       }
       const profileToSave = buildProfileForSave(values);
 
+      // A definition with errors is one the automation service refuses to run, so it is not
+      // stored. Surfacing the errors here is the difference between fixing them now and
+      // discovering them when the scheduled run fails. Warnings do not block the save - they
+      // stay in the designer's findings panel.
+      const findings = await api.validateProfile(profileToSave);
+      const blocking = findings.filter((finding) => finding.severity === 'error');
+      if (blocking.length > 0) {
+        setSaveErrors(blocking);
+        return;
+      }
+
       const originalId = values.id;
       const result = !values.id
         ? await api.addProfile(profileToSave)
@@ -520,8 +535,15 @@ const AutomationProfileForm: React.FC = () => {
       setProfile(normalizeProfile(result));
       toast.success(`${result.name} has successfully been saved.`);
       if (!originalId) navigate(`/admin/automations/${result.id}`);
-    } catch {
-      toast.error('Unable to save automation profile.');
+    } catch (error) {
+      // The API applies the same rule, so a save can still be rejected (a stale page, another
+      // client). Show its findings in the same modal rather than a generic failure toast.
+      const data = (error as AxiosError)?.response?.data as
+        | { errors?: IAutomationValidationError[] }
+        | undefined;
+      const rejected = Array.isArray(data?.errors) ? data!.errors! : [];
+      if (rejected.length > 0) setSaveErrors(rejected);
+      else toast.error('Unable to save automation profile.');
     }
   };
 
@@ -1221,6 +1243,37 @@ const AutomationProfileForm: React.FC = () => {
                     closeRunDelete();
                   }
                 }}
+              />
+              <Modal
+                headerText="This automation cannot be saved"
+                isShowing={!!saveErrors}
+                hide={() => setSaveErrors(null)}
+                type="custom"
+                component={
+                  <div className="rule-modal-content save-errors-content">
+                    <p>
+                      {`The definition has ${saveErrors?.length ?? 0} error${
+                        (saveErrors?.length ?? 0) === 1 ? '' : 's'
+                      }. The automation service refuses to run a definition with errors, so it has not been saved. Correct the following and save again.`}
+                    </p>
+                    <Col className="automation-findings" gap="0.25rem">
+                      {(saveErrors ?? []).map((finding, index) => (
+                        <Row key={index} gap="0.5rem" alignItems="baseline">
+                          <span className="automation-badge automation-badge-danger">error</span>
+                          <code>{finding.path}</code>
+                          <span>{finding.message}</span>
+                        </Row>
+                      ))}
+                    </Col>
+                  </div>
+                }
+                customButtons={
+                  <Row justifyContent="flex-end" width="100%">
+                    <Button variant={ButtonVariant.secondary} onClick={() => setSaveErrors(null)}>
+                      Close
+                    </Button>
+                  </Row>
+                }
               />
             </div>
           );

--- a/app/editor/src/features/admin/automation/styled/AutomationProfileForm.tsx
+++ b/app/editor/src/features/admin/automation/styled/AutomationProfileForm.tsx
@@ -2034,6 +2034,47 @@ export const AutomationModalStyles = createGlobalStyle`
     color: #667085;
   }
 
+  /* The save-blocked modal: an explanatory line above the list of errors that stopped the save.
+     A long definition can produce many, so the list is the part that scrolls. */
+  .save-errors-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    min-height: 0;
+  }
+
+  .save-errors-content > p {
+    margin: 0;
+  }
+
+  .save-errors-content .automation-findings {
+    max-height: 45vh;
+    overflow-y: auto;
+    border: 1px solid #fda29b;
+    border-radius: 0.35rem;
+    padding: 0.5rem;
+    background: #fffbfa;
+  }
+
+  /* A long message wraps instead of pushing the modal wider. */
+  .save-errors-content .automation-findings code {
+    font-size: 0.8rem;
+    word-break: break-word;
+  }
+
+  .save-errors-content .automation-badge {
+    display: inline-block;
+    padding: 0.05rem 0.5rem;
+    border-radius: 0.75rem;
+    font-size: 0.75rem;
+    white-space: nowrap;
+  }
+
+  .save-errors-content .automation-badge-danger {
+    background: #fee4e2;
+    color: #912018;
+  }
+
   .run-detail-content .automation-explain-panel {
     border-top: 1px solid #e4e7ec;
     padding-top: 0.5rem;

--- a/libs/net/ches/ChesService.cs
+++ b/libs/net/ches/ChesService.cs
@@ -274,9 +274,18 @@ namespace TNO.Ches
             }
             if (!String.IsNullOrWhiteSpace(this.Options.OverrideTo) || !this.Options.EmailAuthorized)
             {
-                email.To = !String.IsNullOrWhiteSpace(this.Options.OverrideTo)
+                var address = !String.IsNullOrWhiteSpace(this.Options.OverrideTo)
                     ? this.Options.OverrideTo.Split(";").NotNullOrWhiteSpace().Select(e => e.Trim())
-                    : new[] { _user.GetEmail() }.Where(e => !String.IsNullOrWhiteSpace(e)).Select(e => e!);
+                    : new[] { _user.GetEmail() }.NotNullOrWhiteSpace();
+                // In a headless service there is no current user, so an unset OverrideTo leaves no
+                // recipient at all - CHES rejects an empty 'to' with 422. Skip the send with a clear
+                // warning instead of posting an invalid payload.
+                if (!address.Any())
+                {
+                    _logger.LogWarning("Email not sent: CHES is not authorized to email real recipients (Ches:EmailAuthorized=false) and no Ches:OverrideTo address is configured. Subject: {subject}", email.Subject);
+                    return new EmailResponseModel();
+                }
+                email.To = address;
                 email.Cc = email.Cc.Any() ? new[] { _user.GetEmail() }.NotNullOrWhiteSpace() : [];
                 email.Bcc = [];
             }

--- a/libs/net/services/Managers/ServiceManager`.cs
+++ b/libs/net/services/Managers/ServiceManager`.cs
@@ -122,7 +122,9 @@ public abstract class ServiceManager<TOption> : IServiceManager
                 }
                 else
                 {
-                    this.Logger.LogDebug("No email addresses configured to receive errors");
+                    // Warning, not debug: SendEmailOnFailure is on, so the operator expects an
+                    // email - an empty address list means the alert was silently dropped.
+                    this.Logger.LogWarning("No email addresses configured to receive {emailToType} emails; '{subject}' was not sent.", emailToType, subject);
                 }
             }
             catch (ChesException ex)

--- a/openshift/kustomize/services/automation/base/config-map.yaml
+++ b/openshift/kustomize/services/automation/base/config-map.yaml
@@ -38,4 +38,7 @@ data:
   AZURE_AI_TENANT_ID: ""
   AZURE_AI_CLIENT_ID: ""
   CHES_EMAIL_ENABLED: "true"
-  CHES_EMAIL_AUTHORIZED: "false"
+  # Must be true for the service to email real recipients. With it false and no
+  # Ches:OverrideTo, a headless service has no recipient at all and the failure
+  # email is silently dropped.
+  CHES_EMAIL_AUTHORIZED: "true"


### PR DESCRIPTION
- Automation service configuration will run the validation process before saving to ensure obvious configuration errors are caught.
- Failures should email out to support staff now